### PR TITLE
fix error when opening a new instance when one already exists

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -41,8 +41,10 @@ let shouldQuitBecauseAppIsAnotherInstance = app.makeSingleInstance(() => {
     mainWin.focus();
   }
 });
+
 if (shouldQuitBecauseAppIsAnotherInstance) {
   quitApp();
+  return;
 }
 
 // APP EVENT LISTENERS


### PR DESCRIPTION
Fixes "Cannot find module '../dialog'" by returning after checking if an
instance already exists instead of allowing the code to continue and try
to make new instance.