### PR TITLE
fix blank screen on startup

### DIFF
--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -215,7 +215,7 @@ gulp.task('testSingle', function (done) {
     action: 'run',
     autoWatch: false,
     singleRun: true
-  }, done()).start();
+  }, done).start();
 });
 
 gulp.task('lint', function () {


### PR DESCRIPTION
done should be passed to karma server, not called.

This fixes an error causing a blank screen on startup for native Linux builds (untested on windows).
This error does not occur when starting through `npm start` only the native builds.
Building now takes much longer, this is a good thing I think, as it appears the tests were not running before due to the done() function being called before being passed to the karma server.