### PR TITLE
Fix minor issues with grouped exports

### DIFF
--- a/src/app/features/worklog/worklog-export/worklog-export.component.ts
+++ b/src/app/features/worklog/worklog-export/worklog-export.component.ts
@@ -16,7 +16,6 @@ import Clipboard from 'clipboard';
 import {SnackService} from '../../../core/snack/snack.service';
 import {WorklogService} from '../worklog.service';
 import {WorklogExportSettingsCopy, WorklogGrouping, WorklogTask} from '../worklog.model';
-import {spread} from 'q';
 
 const LINE_SEPARATOR = '\n';
 const EMPTY_VAL = ' - ';


### PR DESCRIPTION
When exporting grouped by work log:
- Don't show parent's time spent (to avoid incorrect sums)
- Show relative estimated time (based on share of the work log in the
  task's time spent)

Resolves remarks from #195 
Finally implements #162 