### PR TITLE
Resolves #102: Save and restore window size and position

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -1,3 +1,4 @@
+import * as windowStateKeeper from 'electron-window-state';
 import {BrowserWindow, dialog, ipcMain, Menu, MenuItemConstructorOptions, MessageBoxReturnValue, shell} from 'electron';
 import {errorHandler} from './error-handler';
 import {join, normalize} from 'path';
@@ -40,9 +41,16 @@ export const createWindow = (params) => {
     Menu.setApplicationMenu(null);
   }
 
+  const mainWindowState = windowStateKeeper({
+    defaultWidth: 800,
+    defaultHeight: 800
+  });
+
   mainWin = new BrowserWindow({
-    width: 800,
-    height: 800,
+    x: mainWindowState.x,
+    y: mainWindowState.y,
+    width: mainWindowState.width,
+    height: mainWindowState.height,
     titleBarStyle: IS_MAC ? 'hidden' : 'default',
     show: false,
     webPreferences: {
@@ -52,6 +60,8 @@ export const createWindow = (params) => {
     },
     icon: ICONS_FOLDER + '/icon_256x256.png'
   });
+
+  mainWindowState.manage(mainWin);
 
   const url = (IS_DEV)
     ? 'http://localhost:4200'

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "electron-dl": "^1.13.0",
     "electron-localshortcut": "^3.1.0",
     "electron-log": "^3.0.1",
+    "electron-window-state": "^5.0.3",
     "googleapis": "^40.0.0",
     "jira-client-fork": "^4.2.1",
     "moment": "^2.24.0",


### PR DESCRIPTION
I'm not able to test the multi-monitor behavior of this at the moment but if it doesn't work as desired then it can either be fixed upstream in the [electron-window-state](https://github.com/mawie81/electron-window-state) package.