### PR TITLE
Fix: preferences shortcut not working

### DIFF
--- a/src/app/core-ui/shortcut/shortcut.service.ts
+++ b/src/app/core-ui/shortcut/shortcut.service.ts
@@ -102,7 +102,7 @@ export class ShortcutService {
       this._router.navigate(['/active/tasks']);
 
     } else if (checkKeyCombo(ev, keys.goToSettings)) {
-      this._router.navigate(['/settings']);
+      this._router.navigate(['/config']);
 
       // } else if (checkKeyCombo(ev, keys.goToDailyAgenda)) {
       //   this._router.navigate(['/daily-agenda']);


### PR DESCRIPTION
Hello @johannesjo 
So, on MacOS I'm accustomed to using `Cmd+,` as a shortcut for the preferences page. After manually setting the shortcut I noticed that it actually brought me to the project page.

I tracked down the problem to a wrong routing. As it can be seen here:
https://github.com/johannesjo/super-productivity/blob/master/src/app/app.routes.ts#L17

the actual route is `config`, not `settings`. Hoping not to have misinterpreted the intended behaviour this simple PR fix this.