### PR TITLE
Add product name key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./electron/main.js",
   "author": "johannesjo <contact@super-productivity.com> (http://super-productivity.com)",
   "license": "MIT",
+  "productName": "Super Productivity",
   "homepage": "http://super-productivity.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello @johannesjo 
This a minor Quality of Life improvement that you may want to investigate a little before merging (or not).

On Mac both the application title and the application bundle are spelled `superProductivity`, which is a little ugly and breaks the consistency.

As a solution I found that adding a `productName` key gets the job done. 

||Title Bar|App Bundle|
|---|---|---|
|Before|![Schermata 2020-07-12 alle 17 52 40](https://user-images.githubusercontent.com/6209647/87425049-51db6b00-c5dd-11ea-89fc-79714690aec1.png)|![Schermata 2020-07-12 alle 17 55 25](https://user-images.githubusercontent.com/6209647/87425054-52740180-c5dd-11ea-9df1-1bb97bfa1530.png)|
|After|![Schermata 2020-07-12 alle 17 22 09](https://user-images.githubusercontent.com/6209647/87425044-5011a780-c5dd-11ea-8a52-6bec03252435.png)|![Schermata 2020-07-12 alle 17 22 24](https://user-images.githubusercontent.com/6209647/87425048-5142d480-c5dd-11ea-8261-70bd20568ffe.png)|

For docs: 
https://stackoverflow.com/questions/41551110/unable-to-override-app-name-on-mac-os-electron-menu
https://www.electron.build/configuration/configuration#configuration