### PR TITLE
Feat: Update logic to disable deletion of default project.

### DIFF
--- a/src/app/pages/project-overview-page/project-overview-page.component.html
+++ b/src/app/pages/project-overview-page/project-overview-page.component.html
@@ -53,7 +53,7 @@
           <!--            <mat-icon>flight</mat-icon>-->
           <!--          </button>-->
           <button (click)="remove(project.id)"
-                  [disabled]="project.id === (workContextService.activeWorkContextId$|async)"
+                  [disabled]="project.id === defaultId"
                   [title]="T.PP.DELETE_PROJECT|translate"
                   color="warn"
                   mat-icon-button>

--- a/src/app/pages/project-overview-page/project-overview-page.component.ts
+++ b/src/app/pages/project-overview-page/project-overview-page.component.ts
@@ -15,6 +15,7 @@ import { THEME_COLOR_MAP } from '../../app.constants';
 import { WorkContextService } from '../../features/work-context/work-context.service';
 import { withLatestFrom } from 'rxjs/operators';
 import { ExportedProject } from '../../features/project/project-archive.model';
+import { DEFAULT_PROJECT_ID } from '../../features/project/project.const'
 
 @Component({
   selector: 'project-page',
@@ -26,6 +27,7 @@ import { ExportedProject } from '../../features/project/project-archive.model';
 export class ProjectOverviewPageComponent implements OnInit, OnDestroy {
   T: typeof T = T;
   private _subs: Subscription = new Subscription();
+  private defaultId: string = DEFAULT_PROJECT_ID;
 
   constructor(
     public readonly projectService: ProjectService,
@@ -127,6 +129,9 @@ export class ProjectOverviewPageComponent implements OnInit, OnDestroy {
   }
 
   remove(projectId: string) {
+    if (projectId === this.defaultId) {
+      return;
+    }
     this._matDialog.open(DialogConfirmComponent, {
       restoreFocus: true,
       data: {

--- a/src/app/pages/project-overview-page/project-overview-page.component.ts
+++ b/src/app/pages/project-overview-page/project-overview-page.component.ts
@@ -15,7 +15,7 @@ import { THEME_COLOR_MAP } from '../../app.constants';
 import { WorkContextService } from '../../features/work-context/work-context.service';
 import { withLatestFrom } from 'rxjs/operators';
 import { ExportedProject } from '../../features/project/project-archive.model';
-import { DEFAULT_PROJECT_ID } from '../../features/project/project.const'
+import { DEFAULT_PROJECT_ID } from '../../features/project/project.const';
 
 @Component({
   selector: 'project-page',


### PR DESCRIPTION
# Description

Allows users to delete current project in navigation menu. Disallows users from deleting default project.

There's a potential issue with this. If users have already deleted the default project then this will cause issues if users delete all their projects. Sometimes the app crashes when the default project no longer exists. The issue an be fixed with a cache reload but that should be avoided as it wipes all projects from users' storage.

I'm completely new to angular, so I did some reading and I'm wondering if there's a way to get the number of projects? A better way to do this is to disable the delete button if there's only one project remaining but I didn't see anything in the template class or the model class that does this. Is there a way to get this from the service?

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/581

## Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
