### PR TITLE
fix: delete a keyboard shortcut

### DIFF
--- a/src/app/features/config/keyboard-input/keyboard-input.component.ts
+++ b/src/app/features/config/keyboard-input/keyboard-input.component.ts
@@ -27,7 +27,10 @@ export class KeyboardInputComponent extends FieldType {
 
     // focus out on escape
     if (keyCode === 27 || ev.key === 'Escape') {
-      // element.blur();
+      this.formControl.setValue(null);
+      if (ev.target instanceof HTMLElement) {
+        ev.target.blur();
+      }
     } else if (keyCode === 13 || ev.key === 'Enter') {
       // element.blur();
     } else if (keyCode === 16 || keyCode === 17 || keyCode === 18) {


### PR DESCRIPTION
# Description
Use the escape key to remove bound keyboard shortcuts. I also thought that removing the focus would benefit UX.
I have tested the following:
* Removing a shortcut and the shortcut is not applied anymore.
* Setting a new shortcut afterwards again.
## Issues Resolved

closes issue #497

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
