### PR TITLE
fix: strip trailing jira host slash

### DIFF
--- a/src/app/features/issue/providers/jira/jira-api.service.ts
+++ b/src/app/features/issue/providers/jira/jira-api.service.ts
@@ -37,6 +37,7 @@ import { ipcRenderer, IpcRendererEvent } from 'electron';
 import { SS_JIRA_WONKY_COOKIE } from '../../../../core/persistence/ls-keys.const';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogPromptComponent } from '../../../../ui/dialog-prompt/dialog-prompt.component';
+import { stripTrailing } from '../../../../util/strip-trailing';
 
 const BLOCK_ACCESS_KEY = 'SUP_BLOCK_JIRA_ACCESS';
 const API_VERSION = 'latest';
@@ -351,7 +352,7 @@ export class JiraApiService {
         const queryStr = jiraReqCfg.query
           ? `?${stringify(jiraReqCfg.query, {arrayFormat: 'comma'})}`
           : '';
-        const base = `${cfg.host}/rest/api/${API_VERSION}`;
+        const base = `${stripTrailing(cfg.host || 'null', '/')}/rest/api/${API_VERSION}`;
         const url = `${base}/${jiraReqCfg.pathname}${queryStr}`.trim();
 
         return this._sendRequestToExecutor$(requestId, url, requestInit, jiraReqCfg.transform, cfg);

--- a/src/app/util/strip-trailing.ts
+++ b/src/app/util/strip-trailing.ts
@@ -1,0 +1,5 @@
+export const stripTrailing = (str: string, toBeStripped: string) => {
+  return str.endsWith(toBeStripped) && toBeStripped.length > 0 ?
+        str.slice(0, -1 * toBeStripped.length) :
+        str;
+};


### PR DESCRIPTION
# Description

Strips possible trailing slash in the host path of jira.

I tested the `stripTrailing` itself, but since I don't have an access to jira itself, I could not test this part.
I was not sure about the handling of `cfg.host` possibly being `null`, so I used `'null'` as a fallback (as would have happened before).

## Issues Resolved

fixes issue #622 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
