### PR TITLE
Explictly skip the MD5sums

### DIFF
--- a/build/linux/PKGBUILD_template
+++ b/build/linux/PKGBUILD_template
@@ -13,6 +13,7 @@ depends=('gtk3' 'nss')
 provides=("${_pkgname}")
 conflicts=("${_pkgname}"
 		   "${_pkgname}-git")
+md5sums=('SKIP')
 source=("https://github.com/johannesjo/super-productivity/releases/download/v${pkgver}/superProductivity_${pkgver}_amd64.deb")
 
 package() {


### PR DESCRIPTION
# Description

This will fix an error/warning message because of the lack of MD5 Checksum for downloaded files during the package build (The .deb file)

