### PR TITLE
Fix feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -17,7 +17,8 @@ Please also make sure that there is no similar feature already opened up!
 A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
 -->
 
-## :grey_question: Possible Solution <!--
+## :grey_question: Possible Solution
+<!--
 A clear and concise description of what you want to happen.
 -->
 


### PR DESCRIPTION
- Comment was bleeding into heading, fix by adding a new line before the comment.

# Description

Fixes an issue where the HTML comment started on the same line as the heading. If people don't change that manually, the `<--` is being rendered as part of the heading.

## Issues Resolved

n/a

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
