### PR TITLE
docs: Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ makepkg -si
 ### MacOS
 Install via [homebrew cask](https://github.com/caskroom/homebrew-cask):
 ```
-brew cask install superproductivity
+brew install --cask superproductivity
 ```
 <a href='//apps.apple.com/de/app/super-productivity/id1482572463?l=en&mt=12' target="_blank">
   <img src='./screens/app-store-badge.svg'


### PR DESCRIPTION
# Description

Fix error when installing using latest Homebrew in macOS. This is not a bug of this app, but README.md needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103143701-344f2780-475f-11eb-8d4c-e86e081f1b8c.png)

## Issues Resolved

n/a

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
