### PR TITLE
fix: add cmdline switch to force tray icons for dark mode #741

### DIFF
--- a/electron/indicator.ts
+++ b/electron/indicator.ts
@@ -7,6 +7,7 @@ import { getWin } from './main-window';
 let tray;
 let isIndicatorRunning = false;
 let DIR: string;
+let shouldUseDarkColors : boolean;
 
 const isGnomeShellExtensionRunning = false;
 
@@ -15,18 +16,21 @@ export const initIndicator = ({
   quitApp,
   app,
   ICONS_FOLDER,
+  forceDarkTray
 }: {
   showApp: () => void;
   quitApp: () => void;
   app: App;
   ICONS_FOLDER: string;
+  forceDarkTray: boolean;
 }) => {
   DIR = ICONS_FOLDER + 'indicator/';
+  shouldUseDarkColors = forceDarkTray || nativeTheme.shouldUseDarkColors;
 
   initAppListeners(app);
   initListeners();
 
-  const suf = nativeTheme.shouldUseDarkColors
+  const suf = shouldUseDarkColors
     ? '-d.png'
     : '-l.png';
   tray = new Tray(DIR + `stopped${suf}`);
@@ -52,7 +56,7 @@ function initAppListeners(app) {
 
 function initListeners() {
   ipcMain.on(IPC.SET_PROGRESS_BAR, (ev, {progress}) => {
-    const suf = nativeTheme.shouldUseDarkColors
+    const suf = shouldUseDarkColors
       ? '-d'
       : '-l';
     if (typeof progress === 'number' && progress > 0 && isFinite(progress)) {
@@ -82,7 +86,7 @@ function initListeners() {
           tray.setTitle(msg);
         } else {
           tray.setTitle('');
-          const suf = nativeTheme.shouldUseDarkColors
+          const suf = shouldUseDarkColors
             ? '-d.png'
             : '-l.png';
           setTrayIcon(tray, DIR + `stopped${suf}`);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,7 @@ const IS_DEV = process.env.NODE_ENV === 'DEV';
 let isShowDevTools: boolean = IS_DEV;
 let customUrl: string;
 let isDisableTray = false;
+let forceDarkTray = false;
 
 if (IS_DEV) {
   console.log('Starting in DEV Mode!!!');
@@ -40,6 +41,11 @@ process.argv.forEach((val) => {
   if (val && val.includes('--disable-tray')) {
     isDisableTray = true;
     console.log('Disable tray icon');
+  }
+
+  if (val && val.includes('--force-dark-tray')) {
+    forceDarkTray = true;
+    console.log('Force dark mode for tray icon');
   }
 
   if (val && val.includes('--user-data-dir=')) {
@@ -258,6 +264,7 @@ function createIndicator() {
     showApp,
     quitApp,
     ICONS_FOLDER,
+    forceDarkTray
   });
 }
 


### PR DESCRIPTION
# Description

This PR adds new cmdline arg (`--force-dark-tray`). Not sure how it should be tested. I've tested it on my PC (Fedora 33, Gnome 3) by adding new CLI arg to the npm start script. Let me know if it needs any additional tests.

## Issues Resolved

Fix https://github.com/johannesjo/super-productivity/issues/741

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
