### PR TITLE
bug: Adding worklog to Jira is converting starts to Zulu time #757

### DIFF
--- a/src/app/features/issue/providers/jira/jira-view-components/dialog-jira-add-worklog/dialog-jira-add-worklog.component.ts
+++ b/src/app/features/issue/providers/jira/jira-view-components/dialog-jira-add-worklog/dialog-jira-add-worklog.component.ts
@@ -7,6 +7,7 @@ import { Task } from '../../../../../tasks/task.model';
 import { T } from '../../../../../../t.const';
 import { ProjectService } from '../../../../../project/project.service';
 import { first } from 'rxjs/operators';
+import * as moment from 'moment';
 
 @Component({
   selector: 'dialog-jira-add-worklog',
@@ -62,9 +63,8 @@ export class DialogJiraAddWorklogComponent {
   }
 
   private _convertTimestamp(timestamp: number): string {
-    const date = new Date(timestamp);
-    date.setSeconds(0, 0);
-    const isoStr = date.toISOString();
-    return isoStr.substring(0, isoStr.length - 1);
+    const date = moment(timestamp);
+    const isoStr = date.seconds(0).local().format();
+    return isoStr.substring(0, 19);
   }
 }


### PR DESCRIPTION
bug: Adding worklog to Jira is converting starts to Zulu time #757

# Description

_convertTimestamp() is replaced. Previous version used GMT time to convert it to string and removed last char ('Z' = Zulu time). The change uses moment to be able to show timestamp in local timezone. 

## Issues Resolved

#757


