### PR TITLE
Feat/edit project

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -23,7 +23,7 @@
 
     <mat-menu #activeWorkContextMenu="matMenu">
       <work-context-menu [contextId]="activeWorkContext?.id"
-                         [project]="activeWorkContext"
+                         [project]="projectService.currentProject$|async"  
                          [contextType]="activeWorkContext?.type"></work-context-menu>
     </mat-menu>
   </ng-container>

--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -23,6 +23,7 @@
 
     <mat-menu #activeWorkContextMenu="matMenu">
       <work-context-menu [contextId]="activeWorkContext?.id"
+                         [project]="activeWorkContext"
                          [contextType]="activeWorkContext?.type"></work-context-menu>
     </mat-menu>
   </ng-container>

--- a/src/app/core-ui/side-nav/side-nav.component.html
+++ b/src/app/core-ui/side-nav/side-nav.component.html
@@ -78,6 +78,7 @@
       </button>
       <mat-menu #projectMenu="matMenu">
         <work-context-menu [contextId]="project.id"
+                           [project]="project"
                            [contextType]="WorkContextType.PROJECT"></work-context-menu>
       </mat-menu>
     </div>

--- a/src/app/core-ui/work-context-menu/work-context-menu.component.html
+++ b/src/app/core-ui/work-context-menu/work-context-menu.component.html
@@ -1,3 +1,10 @@
+<button *ngIf="isForProject"
+        (click)="edit(project)"
+        mat-menu-item>
+  <mat-icon>edit</mat-icon>
+  <span class="text">{{T.PP.EDIT_PROJECT|translate}}</span>
+</button>
+
 <button [routerLink]="[base,contextId,'worklog']"
         mat-menu-item>
   <mat-icon>date_range</mat-icon>

--- a/src/app/core-ui/work-context-menu/work-context-menu.component.ts
+++ b/src/app/core-ui/work-context-menu/work-context-menu.component.ts
@@ -3,6 +3,7 @@ import { WorkContextType } from '../../features/work-context/work-context.model'
 import { T } from 'src/app/t.const';
 import { TODAY_TAG } from '../../features/tag/tag.const';
 import { from, Observable, of, Subscription } from 'rxjs';
+import { DialogCreateProjectComponent } from '../../features/project/dialogs/create-project/dialog-create-project.component';
 import { DialogConfirmComponent } from '../../ui/dialog-confirm/dialog-confirm.component';
 import { MatDialog } from '@angular/material/dialog';
 import { TagService } from '../../features/tag/tag.service';
@@ -10,6 +11,7 @@ import { concatMap, filter, first, switchMap, take, tap } from 'rxjs/operators';
 import { Tag } from '../../features/tag/tag.model';
 import { WorkContextService } from '../../features/work-context/work-context.service';
 import { Router } from '@angular/router';
+import { Project } from '../../features/project/project.model';
 
 @Component({
   selector: 'work-context-menu',
@@ -18,6 +20,7 @@ import { Router } from '@angular/router';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WorkContextMenuComponent implements OnDestroy {
+  @Input() project!: Project;
   @Input() contextId?: string;
   T: typeof T = T;
   TODAY_TAG_ID: string = TODAY_TAG.id as string;
@@ -58,6 +61,13 @@ export class WorkContextMenuComponent implements OnDestroy {
         this._tagService.removeTag(this.contextId);
       }
     }));
+  }
+
+  edit(project: Project) {
+    this._matDialog.open(DialogCreateProjectComponent, {
+      restoreFocus: true,
+      data: Object.assign({}, project),
+    });
   }
 
   private _confirmTagDelete(): Observable<boolean> {


### PR DESCRIPTION
# Description

This adds an "edit project" entry to the three vertical dots menu in the sidenav projectlist and in the main header.
The "edit project" entry simply opens the create-project dialog whilst passing the selected project, just like from the project-overview page.
This allows editing name, color and jira etc. from everywhere without going to the project-overview page. 

## Issues Resolved

#785

