### PR TITLE
fix(issues): Disable caldav issue search by default

### DIFF
--- a/src/app/features/issue/providers/caldav/caldav.const.ts
+++ b/src/app/features/issue/providers/caldav/caldav.const.ts
@@ -9,7 +9,7 @@ export const DEFAULT_CALDAV_CFG: CaldavCfg = {
   password: null,
   isAutoAddToBacklog: false,
   isAutoPoll: false,
-  isSearchIssuesFromCaldav: true,
+  isSearchIssuesFromCaldav: false,
   isTransitionIssuesEnabled: false,
   categoryFilter: null,
 };


### PR DESCRIPTION
# Description

This is necessary as there is a caldav config already for every new
project even if caldav was never set up for the project. This causes a
miconfiguration-warning on every issue-add.

