### PR TITLE
Use truthy check as condition for gitlabBaseUrl url construction

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
@@ -214,7 +214,7 @@ export class GitlabApiService {
   private apiLink(projectConfig: GitlabCfg): string {
     let apiURL: string = '';
     let projectURL: string = projectConfig.project ? projectConfig.project : '';
-    if (projectConfig.gitlabBaseUrl != null) {
+    if (projectConfig.gitlabBaseUrl) {
       const fixedUrl = projectConfig.gitlabBaseUrl.match(/.*\/$/) ? projectConfig.gitlabBaseUrl : `${projectConfig.gitlabBaseUrl}/`;
       apiURL = fixedUrl + 'api/v4/projects/';
     } else {

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -27,7 +27,7 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
   issueLink$(issueId: number, projectId: string): Observable<string> {
     return this._getCfgOnce$(projectId).pipe(
       map((cfg) => {
-        if (cfg.gitlabBaseUrl != null) {
+        if (cfg.gitlabBaseUrl) {
           const fixedUrl = cfg.gitlabBaseUrl.match(/.*\/$/) ? cfg.gitlabBaseUrl : `${cfg.gitlabBaseUrl}/`;
           return `${fixedUrl}${cfg.project}issues/${issueId}`;
         } else {


### PR DESCRIPTION
# Description
Currently an empty string value for `gitlabBaseUrl` breaks polling and other gitlab api requests, this is due to a condition it should fail as a falsey value, this change corrects that.

## Issues Resolved
Fixes #926 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
