### PR TITLE
fix(issues): do not rely on caldav last-changed

### DIFF
--- a/src/app/features/issue/providers/caldav/caldav-client.service.ts
+++ b/src/app/features/issue/providers/caldav/caldav-client.service.ts
@@ -127,10 +127,26 @@ export class CaldavClientService {
       summary: todo.getFirstPropertyValue('summary') || '',
       due: todo.getFirstPropertyValue('due') || '',
       start: todo.getFirstPropertyValue('dtstart') || '',
-      last_modified: todo.getFirstPropertyValue('last-modified').toUnixTime(),
       labels: categories,
-      note: todo.getFirstPropertyValue('description') || ''
+      note: todo.getFirstPropertyValue('description') || '',
+      etag_hash: this._hashEtag(task.etag),
     };
+  }
+
+  private static _hashEtag(etag: string): number {
+    let hash = 0;
+    let i;
+    let chr;
+    if (etag.length === 0) {
+      return hash;
+    }
+    for (i = 0; i < this.length; i++) {
+      chr = etag.charCodeAt(i);
+      hash = ((hash << 5) - hash) + chr; //eslint-disable-line no-bitwise
+      // Convert to 32bit integer
+      hash |= 0; //eslint-disable-line no-bitwise
+    }
+    return hash;
   }
 
   async _get_client(cfg: CaldavCfg): Promise<ClientCache> {

--- a/src/app/features/issue/providers/caldav/caldav-issue/caldav-issue.model.ts
+++ b/src/app/features/issue/providers/caldav/caldav-issue/caldav-issue.model.ts
@@ -6,7 +6,7 @@ export type CaldavIssueReduced = Readonly<{
   due: string;
   start: string;
   labels: string[];
-  last_modified: number;
+  etag_hash: number;
 }>;
 
 export type CaldavIssue = CaldavIssueReduced & Readonly<{


### PR DESCRIPTION
# Description

It seems that last changed is not always available. As the issue model
expects a number for a change-identification attribute this simply
computes a hash over the etag value, which should change on every
content-change if the caldav service behaved correctly.

## Issues Resolved

Resolves #952
