### PR TITLE
[fix] Use volume setting for pomodoro tick sound.

### DIFF
--- a/src/app/features/pomodoro/pomodoro.service.ts
+++ b/src/app/features/pomodoro/pomodoro.service.ts
@@ -147,7 +147,7 @@ export class PomodoroService {
       filter(([val, cfg]) => cfg.isEnabled && cfg.isPlayTick),
       map(([val]) => val),
       distinctUntilChanged(),
-      withLatestFrom(this.soundConfig$)
+      withLatestFrom(this.soundConfig$),
     ).subscribe(([val, soundConfig]) => {
       this._playTickSound(soundConfig.volume);
     });


### PR DESCRIPTION
# Description

Use SoundConfiguration#volume to set the tick volume of pomodoro, getthe code idea from commented code in play-done-sound.

## Issues Resolved

Fixes #956 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
