### PR TITLE
Fix handling of WebDAV headers

### DIFF
--- a/src/app/imex/sync/web-dav/web-dav-api.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-api.service.ts
@@ -48,8 +48,10 @@ export class WebDavApiService {
       password: cfg.password,
     });
 
-    const r = await client.putFileContents('/' + cfg.syncFilePath, JSON.stringify(data));
-    console.log(r);
+    const r = await client.putFileContents('/' + cfg.syncFilePath, JSON.stringify(data), {
+      contentLength: false,
+      //, overwrite: isForceOverwrite
+    });
     return r;
   }
 

--- a/src/app/imex/sync/web-dav/web-dav-api.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-api.service.ts
@@ -82,7 +82,7 @@ export class WebDavApiService {
     });
     const r = await client.customRequest(path, { method: 'HEAD' });
     console.log(r);
-    return r;
+    return r.headers;
   }
 
   async download({

--- a/src/app/imex/sync/web-dav/web-dav-api.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-api.service.ts
@@ -52,6 +52,7 @@ export class WebDavApiService {
       contentLength: false,
       //, overwrite: isForceOverwrite
     });
+    const r = await this.getMetaData('/' + cfg.syncFilePath);
     return r;
   }
 

--- a/src/app/imex/sync/web-dav/web-dav-api.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-api.service.ts
@@ -48,7 +48,7 @@ export class WebDavApiService {
       password: cfg.password,
     });
 
-    const r = await client.putFileContents('/' + cfg.syncFilePath, JSON.stringify(data), {
+    await client.putFileContents('/' + cfg.syncFilePath, JSON.stringify(data), {
       contentLength: false,
       //, overwrite: isForceOverwrite
     });

--- a/src/app/imex/sync/web-dav/web-dav-api.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-api.service.ts
@@ -72,7 +72,7 @@ export class WebDavApiService {
       username: cfg.userName,
       password: cfg.password,
     });
-    const r = await client.stat(path);
+    const r = await client.customRequest(path, { method: 'HEAD' });
     console.log(r);
     return r;
   }

--- a/src/app/imex/sync/web-dav/web-dav-api.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-api.service.ts
@@ -7,7 +7,6 @@ import { WebDavConfig } from '../../../features/config/global-config.model';
 // @ts-ignore
 import { createClient } from 'webdav/web';
 import { AppDataComplete } from '../sync.model';
-import { AxiosResponse } from 'axios';
 
 @Injectable({ providedIn: 'root' })
 export class WebDavApiService {
@@ -40,7 +39,15 @@ export class WebDavApiService {
     localRev?: string | null;
     data: AppDataComplete;
     isForceOverwrite?: boolean;
-  }): Promise<AxiosResponse> {
+  }): Promise<{
+    basename: string;
+    etag: string;
+    filename: string;
+    lastmod: string;
+    mime: string;
+    size: number;
+    type: string;
+  }> {
     await this._isReady$.toPromise();
     const cfg = await this._cfg$.pipe(first()).toPromise();
     const client = createClient(cfg.baseUrl, {

--- a/src/app/imex/sync/web-dav/web-dav-sync.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-sync.service.ts
@@ -88,14 +88,14 @@ export class WebDavSyncService implements SyncProviderServiceInterface {
   ): Promise<string | Error> {
     this._globalProgressBarService.countUp(T.GPB.WEB_DAV_UPLOAD);
     try {
-      const r = await this._webDavApiService.upload({
+      const headers = await this._webDavApiService.upload({
         data,
         localRev,
         isForceOverwrite,
       });
-      console.log(r);
+      console.log(headers);
       this._globalProgressBarService.countDown();
-      return r.headers.etag;
+      return headers.etag;
     } catch (e) {
       console.error(e);
       this._globalProgressBarService.countDown();


### PR DESCRIPTION
# Description

This fixes issues with the handling of WebDAV headers:
- Don't attempt to set Content-Length manually (as browsers forbid this and set it automatically; Axios does the right thing, apparently)
- Correct handling of ETAG header, which is not always present in PUT or PROPFIND requests.

## Issues Resolved

 #1199 and #1197

## Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
