### PR TITLE
feat(pomodoro): Added pause status for windows taskbar

### DIFF
--- a/src/app/features/pomodoro/store/pomodoro.effects.ts
+++ b/src/app/features/pomodoro/store/pomodoro.effects.ts
@@ -259,12 +259,15 @@ export class PomodoroEffects {
         switchMap((isEnabledI) =>
           !isEnabledI ? EMPTY : this._pomodoroService.sessionProgress$,
         ),
+        withLatestFrom(this._pomodoroService.isManualPause$),
         // we display pomodoro progress for pomodoro
-        tap((progress) => {
+        tap(([progress, isPause]: [number, boolean]) => {
+          const progressBarMode: 'normal' | 'pause' = isPause ? 'pause' : 'normal';
           (this._electronService.ipcRenderer as typeof ipcRenderer).send(
             IPC.SET_PROGRESS_BAR,
             {
               progress,
+              progressBarMode,
             },
           );
         }),


### PR DESCRIPTION
# Description

If the task is manually paused, the progress bar in the windows taskbar will show yellow / orange instead of green.

## Issues Resolved

None known

## Check List
Need help on writing testing (if required)
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
