### PR TITLE
feat(TaskBar): Add indeterminate state for tasks with no time estimate

### DIFF
--- a/src/app/features/tasks/store/task-electron.effects.ts
+++ b/src/app/features/tasks/store/task-electron.effects.ts
@@ -65,7 +65,7 @@ export class TaskElectronEffects {
     map(([act]) => act.payload.task),
     tap((task: Task) => {
       const progress = task.timeSpent / task.timeEstimate;
-      const mode = task.timeEstimate == 0 ? 'indeterminate' : 'normal';
+      const mode = task.timeEstimate === 0 ? 'indeterminate' : 'normal';
       (this._electronService.ipcRenderer as typeof ipcRenderer).send(
         IPC.SET_PROGRESS_BAR,
         {

--- a/src/app/features/tasks/store/task-electron.effects.ts
+++ b/src/app/features/tasks/store/task-electron.effects.ts
@@ -65,10 +65,12 @@ export class TaskElectronEffects {
     map(([act]) => act.payload.task),
     tap((task: Task) => {
       const progress = task.timeSpent / task.timeEstimate;
+      const mode = task.timeEstimate == 0 ? 'indeterminate' : 'normal';
       (this._electronService.ipcRenderer as typeof ipcRenderer).send(
         IPC.SET_PROGRESS_BAR,
         {
           progress,
+          mode,
         },
       );
     }),


### PR DESCRIPTION
# Description

For task with no time estimate, the taskbar will show an indeterminate moving green indicator instead of "full" bar.

## Issues Resolved

None that I know of

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
