### PR TITLE
refactor(Task): remove isHostFocus mixin

### DIFF
--- a/src/app/features/tasks/task/task.component.mixins.scss
+++ b/src/app/features/tasks/task/task.component.mixins.scss
@@ -56,19 +56,6 @@ $task-c-drag-drop-bg-dark: $dark12;
 $task-c-selected-bg-light: $light-theme-selected-task-bg-color;
 $task-c-selected-bg-dark: $dark4;
 
-
-@mixin isHostFocus($direct-parent-only-sel: false) {
-  @if $direct-parent-only-sel {
-    :host-context(.isNoTouchOnly):focus > #{$direct-parent-only-sel} > & {
-      @content;
-    }
-  } @else {
-    :host-context(.isNoTouchOnly):focus & {
-      @content;
-    }
-  }
-}
-
 @mixin isDone($direct-parent-only-sel: false) {
   @if $direct-parent-only-sel {
     .inner-wrapper.isDone > #{$direct-parent-only-sel} > & {
@@ -86,7 +73,6 @@ $task-c-selected-bg-dark: $dark4;
     @content;
   }
 }
-
 
 @mixin standardTaskOpacityChange {
   opacity: $task-icon-default-opacity;
@@ -130,7 +116,6 @@ $task-c-selected-bg-dark: $dark4;
     // text-transform: uppercase;
   }
 
-
   &:after {
     transition: $transition-leave;
     position: absolute;
@@ -147,7 +132,6 @@ $task-c-selected-bg-dark: $dark4;
 
     @include inlineEditElevation();
   }
-
 
   &:focus {
     z-index: $z-task-title-focus;

--- a/src/app/features/tasks/task/task.component.scss
+++ b/src/app/features/tasks/task/task.component.scss
@@ -116,18 +116,11 @@
     }
   }
 
-  @include isHostFocus('.inner-wrapper') {
+  :host:focus > .inner-wrapper > & {
     border-radius: $task-border-radius;
-    // because of the border, this looks better
-    //top: 2px;
-    //bottom: 2px;
-
-    @include mq(xs) {
-      // NOTE: somehow ng build messes up, if we don't include it like that
-      border-color: $task-c-focus;
-      border-width: 1px;
-      border-style: solid !important;
-    }
+    border-color: $task-c-focus;
+    border-width: 1px;
+    border-style: solid !important;
   }
 
   :host.isCurrent.isCurrent.isCurrent.isCurrent.isCurrent & {

--- a/src/app/features/tasks/task/task.component.scss
+++ b/src/app/features/tasks/task/task.component.scss
@@ -118,9 +118,12 @@
 
   :host:focus > .inner-wrapper > & {
     border-radius: $task-border-radius;
-    border-color: $task-c-focus;
-    border-width: 1px;
-    border-style: solid !important;
+    // we don't want focus borders for touch only devices
+    @include noTouchOnly() {
+       border-color: $task-c-focus;
+       border-width: 1px;
+       border-style: solid !important;
+    }
   }
 
   :host.isCurrent.isCurrent.isCurrent.isCurrent.isCurrent & {


### PR DESCRIPTION
# Description

This removes the unused isHostFocus mixin and refactors a part that used to mess up during
`yarn buildAllElectron:prod && yarn electron-builder`

For me now this builds just fine. 
