### PR TITLE
Revert "feat(TaskBar): Add indeterminate state for tasks with no time…

### DIFF
--- a/src/app/features/tasks/store/task-electron.effects.ts
+++ b/src/app/features/tasks/store/task-electron.effects.ts
@@ -65,12 +65,10 @@ export class TaskElectronEffects {
     map(([act]) => act.payload.task),
     tap((task: Task) => {
       const progress = task.timeSpent / task.timeEstimate;
-      const mode = task.timeEstimate === 0 ? 'indeterminate' : 'normal';
       (this._electronService.ipcRenderer as typeof ipcRenderer).send(
         IPC.SET_PROGRESS_BAR,
         {
           progress,
-          mode,
         },
       );
     }),


### PR DESCRIPTION
… estimate"

This reverts commit 0321055efe4d3d947afcec522781989839e26c64 and 35d7af17c8e48c4d992da64e3e8212526d9ec682 .

Will revert this patch for now, until I know how to deal with RxJS 😂 

Not sure how to pass the configuration at line 66, probably some help? 🌚
![image](https://user-images.githubusercontent.com/5886584/122390679-d92b1e80-cfa4-11eb-8e94-685d55496e31.png)

Here's what I've done
https://github.com/kwongtn/super-productivity/tree/toggleable-indeterminate


# Description

Reverts indeterminate state cause its annoying to many people 😅 

## Issues Resolved
TaskBar: Make "indeterminate state for tasks with no time estimate" configurable - https://github.com/johannesjo/super-productivity/issues/1299


## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
