### PR TITLE
fix(search): can't read property 'icon' of undefined #1325

### DIFF
--- a/src/app/features/search-bar/search-bar.model.ts
+++ b/src/app/features/search-bar/search-bar.model.ts
@@ -13,7 +13,7 @@ export interface SearchItem {
   parentId: string | null;
   timeSpentOnDay: TimeSpentOnDay;
   created: number;
-  tagIds: string[];
+  tagId: string;
 
   // for the icons
   issueType: IssueProviderKey | null;


### PR DESCRIPTION
# Description

In fact, there is a chance for a task not to have neither a tag nor a project. Example: a subtask without a project.
By design subtasks don't inherit their parent's tags.

This will now search for the parent and use its tags instead.

It will also use a fallback help-icon if still no context can be found. This way the search function won't break.

## Issues Resolved

#1325 
