### PR TITLE
Fix shortcut in message about bookmark

### DIFF
--- a/src/app/core-ui/shortcut/shortcut.service.ts
+++ b/src/app/core-ui/shortcut/shortcut.service.ts
@@ -155,7 +155,7 @@ export class ShortcutService {
         this._snackService.open({
           msg: this._translateService.instant(
             T.GLOBAL_SNACK.SHORTCUT_WARN_OPEN_BOOKMARKS_FROM_TAG,
-            { keyCombo: keys.openProjectNotes },
+            { keyCombo: keys.toggleBookmarks },
           ),
         });
       }


### PR DESCRIPTION
If I press Shift+V, I currently get a message that says "Shift+N pressed, but open bookmarks shortcut is only available when in project context".

# Description

This should fix the message to display "Shift+V" instead. I haven't tested it though.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
