### PR TITLE
docs: Correct Windows User Data Path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ For the desktop version automatic backups are stored per default in the `backup`
 
 Where user data is stored differs from os to os. The most common locations are:
 Mac OS: `~/Library/Application Support/superProductivity/`
-Windows: `C:\Users\<YOUR_USER_NAME>\AppData\Local\superProductivity/`
+Windows: `C:\Users\<YOUR_USER_NAME>\AppData\Roaming\superProductivity/` or `%APPDATA%\superProductivity`
 Linux: `~/.config/superProductivity/`
 
 The path should be shown when you go to the "Automatic Backups` section on the configuration page (minus the "backup" sub folder). You can also see it printed out when you start the app from the command line.


### PR DESCRIPTION
First time proposing a change. The user data path in Windows is located in `%APPDATA%`, not `%LOCALAPPDATA%` (the latter contains a generic update folder).
New path (Windows): `%appdata%\superProductivity`

# Description

States the correct location of the user directory on Windows.

## Issues Resolved

Search through the open issues show nothing.