### PR TITLE
Wait to exit startup tip until user event

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <ng-container
-  *ngIf="(syncTriggerService.afterInitialSyncDoneAndDataLoadedInitially$|async) && !(imexMetaService.isDataImportInProgress$|async)"
+  *ngIf="(syncTriggerService.afterInitialSyncDoneAndDataLoadedInitially$|async) && !(imexMetaService.isDataImportInProgress$|async) && userActive"
 >
   <div
     *ngIf="(globalThemeService.backgroundImg$|async) as bgImage"
@@ -55,7 +55,7 @@
 </ng-container>
 
 <div
-  *ngIf="!(syncTriggerService.afterInitialSyncDoneAndDataLoadedInitially$|async) || (imexMetaService.isDataImportInProgress$|async)"
+  *ngIf="!(syncTriggerService.afterInitialSyncDoneAndDataLoadedInitially$|async) || (imexMetaService.isDataImportInProgress$|async) || !userActive"
   class="loading-full-page-wrapper"
 >
   <global-progress-bar></global-progress-bar>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -60,6 +60,7 @@ export class AppComponent implements OnDestroy {
   @ViewChild('sideNavElRef', { read: ViewContainerRef }) sideNavElRef?: ViewContainerRef;
 
   isRTL: boolean = false;
+  userActive: boolean = false;
 
   private _subs: Subscription = new Subscription();
   private _intervalTimer?: NodeJS.Timeout;
@@ -210,6 +211,16 @@ export class AppComponent implements OnDestroy {
         },
       },
     });
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  startUserActiveViaMouse() {
+    this.userActive = true
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  startUserActiveViaKey() {
+    this.userActive = true
   }
 
   getPage(outlet: RouterOutlet): string {


### PR DESCRIPTION
This keeps the tip on-screen until a mouse move or keypress

Fixes #1284

# Description

This allows the user to read the productivity tip and keep it there until they are ready to move forward with an input event, either mouse or key

## Issues Resolved

#1284

## Check List

- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable.
