### PR TITLE
add keyboard shortcut to quit app

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -176,6 +176,7 @@ function createMenu(quitApp): void {
         {
           label: 'Quit',
           click: quitApp,
+          accelerator: 'CmdOrCtrl+Q',
         },
       ],
     },


### PR DESCRIPTION
# Description

Fixes #1586 

## Issues Resolved

On Mac, now users can see that there's a keyboard short bound to the Quit function. it works with Cmd+Q too.

![image](https://user-images.githubusercontent.com/35736525/138023313-715af02e-d3df-48cf-b41b-43f539372d79.png)

## Check List

- [x] New functionality includes testing -> I didn't find other tests for the other keyboard shortcuts in this function, so I didnt add any
- [x] New functionality has been documented in the README if applicable. -> no new functionality
