### PR TITLE
i18n/de: fix typo in 'Pomdoro Timer'

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1129,7 +1129,7 @@
       "IS_PLAY_TICK": "Spielen Sie jede Sekunde einen Tick-Sound",
       "IS_STOP_TRACKING_ON_BREAK": "Stoppen Sie die Zeiterfassung für die Aufgabe in der Pause",
       "LONGER_BREAK_DURATION": "Dauer längerer Pausen",
-      "TITLE": "Pomodoro TImer"
+      "TITLE": "Pomodoro Timer"
     },
     "SOUND": {
       "DONE_SOUND": "Aufgabe erledigt Ton",


### PR DESCRIPTION
# Description

I noticed a upper/lower case issue in the German translation for 'Pomodoro TImer'.
Replaced by 'Pomodoro Timer'.

## Issues Resolved

no issue created.

## Check List

- [ n/a] New functionality includes testing.
- [ n/a] New functionality has been documented in the README if applicable.
