### PR TITLE
fix: Hide security keys in settings #1605

### DIFF
--- a/src/app/features/issue/providers/github/github.const.ts
+++ b/src/app/features/issue/providers/github/github.const.ts
@@ -44,6 +44,7 @@ export const GITHUB_CONFIG_FORM: LimitedFormlyFieldConfig<GithubCfg>[] = [
     templateOptions: {
       label: T.F.GITHUB.FORM.TOKEN,
       description: T.F.GITHUB.FORM.TOKEN_DESCRIPTION,
+      type: 'password',
     },
   },
   {

--- a/src/app/features/issue/providers/gitlab/gitlab.const.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab.const.ts
@@ -50,6 +50,7 @@ export const GITLAB_CONFIG_FORM: LimitedFormlyFieldConfig<GitlabCfg>[] = [
     hideExpression: (model: any) => !model.isEnabled,
     templateOptions: {
       label: T.F.GITLAB.FORM.TOKEN,
+      type: 'password',
     },
     validation: {
       show: true,

--- a/src/app/features/issue/providers/open-project/open-project.const.ts
+++ b/src/app/features/issue/providers/open-project/open-project.const.ts
@@ -44,6 +44,7 @@ export const OPEN_PROJECT_CONFIG_FORM: LimitedFormlyFieldConfig<OpenProjectCfg>[
     templateOptions: {
       label: T.F.OPEN_PROJECT.FORM.TOKEN,
       required: true,
+      type: 'password',
     },
   },
   {


### PR DESCRIPTION
# Description

When creating a project from github, gitlab or OpenProject the access Tokens were shown in clear text. I Changed the input field type to password fields.

## Issues Resolved

[#1605 hiding security keys in settings](https://github.com/johannesjo/super-productivity/issues/1605)

![HideTokens](https://user-images.githubusercontent.com/62438618/148298149-0fcfb72b-d7e5-473c-a644-a7d230a219ed.jpg)

## Check List

- [ ] New functionality includes testing.


- [ ] New functionality has been documented in the README if applicable.
