### PR TITLE
default dtend to dtstart if dtend is missing per RFC

### DIFF
--- a/src/app/features/timeline/ical/get-relevant-events-from-ical.ts
+++ b/src/app/features/timeline/ical/get-relevant-events-from-ical.ts
@@ -5,7 +5,6 @@ import { TimelineFromCalendarEvent } from '../timeline.model';
 // NOTE: this sucks and is slow, but writing a new ical parser would be very hard... :(
 
 const TWO_MONTHS = 60 * 60 * 1000 * 24 * 62;
-const DEFAULT_DURATION = 15 * 60 * 1000;
 
 export const getRelevantEventsFromIcal = (
   icalData: string,
@@ -72,9 +71,11 @@ const getForReoccurring = (
 
 const convertVEventToTimelineEvent = (vevent: any): TimelineFromCalendarEvent => {
   const start = vevent.getFirstPropertyValue('dtstart').toJSDate().getTime();
-  // NOTE: dtend might not always be defined for some reason @see #1814
+  // NOTE: if dtend is missing, it defaults to dtstart; @see #1814 and RFC 2455
+  //       detailed comment in #1418: 
+  //         https://github.com/johannesjo/super-productivity/issues/1814#issuecomment-1008132824
   const endVal = vevent.getFirstPropertyValue('dtend');
-  const end = endVal ? endVal.toJSDate().getTime() : start + DEFAULT_DURATION;
+  const end = endVal ? endVal.toJSDate().getTime() : start;
 
   return {
     title: vevent.getFirstPropertyValue('summary'),

--- a/src/app/features/timeline/ical/get-relevant-events-from-ical.ts
+++ b/src/app/features/timeline/ical/get-relevant-events-from-ical.ts
@@ -72,7 +72,7 @@ const getForReoccurring = (
 const convertVEventToTimelineEvent = (vevent: any): TimelineFromCalendarEvent => {
   const start = vevent.getFirstPropertyValue('dtstart').toJSDate().getTime();
   // NOTE: if dtend is missing, it defaults to dtstart; @see #1814 and RFC 2455
-  //       detailed comment in #1418: 
+  //       detailed comment in #1814:
   //         https://github.com/johannesjo/super-productivity/issues/1814#issuecomment-1008132824
   const endVal = vevent.getFirstPropertyValue('dtend');
   const end = endVal ? endVal.toJSDate().getTime() : start;


### PR DESCRIPTION
# Description

Defaults DTEND to DTSTART if DTEND is missing. This is compliant with RFC 2445. See https://github.com/johannesjo/super-productivity/issues/1814#issuecomment-1008132824 for a detailed explanation.

## Issues Resolved

#1814 

## Check List

- [ ] New functionality includes testing.
I do not code in javascript/typescript, so I do not have the kit available to test this.
- [x] New functionality has been documented in the README if applicable.
Not needed.
