### PR TITLE
fix pagination requests in gitlab

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -71,7 +71,7 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
         this.isEnabled(gitlabCfg) && gitlabCfg.isSearchIssuesFromGitlab
           ? this._gitlabApiService.searchIssueInProject$(searchTerm, gitlabCfg).pipe(
               catchError((err) => {
-                console.log('Error searching issue', err);
+                console.error('Error searching issue', err);
                 return [];
               }),
             )

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -69,9 +69,12 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
     return this._getCfgOnce$(projectId).pipe(
       switchMap((gitlabCfg) =>
         this.isEnabled(gitlabCfg) && gitlabCfg.isSearchIssuesFromGitlab
-          ? this._gitlabApiService
-              .searchIssueInProject$(searchTerm, gitlabCfg)
-              .pipe(catchError(() => []))
+          ? this._gitlabApiService.searchIssueInProject$(searchTerm, gitlabCfg).pipe(
+              catchError((err) => {
+                console.log('Error searching issue', err);
+                return [];
+              }),
+            )
           : of([]),
       ),
     );


### PR DESCRIPTION
# Description
Fix a small problem with parsing the data. Every pagination call was parsed as an issue object when it shouldn't, because it could be a comment.

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/1970