### PR TITLE
Fix #2002

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -112,7 +112,7 @@
       <button
         (click)="taskService.toggleStartTask()"
         [color]="(taskService.currentTaskId$|async)? 'accent': 'primary'"
-        [matTooltip]="T.MH.TOGGLE_TRACK_TIME|translate"
+        [matTooltip]="(pomodoroService.isEnabled$|async)? '': T.MH.TOGGLE_TRACK_TIME|translate"
         class="play-btn mat-elevation-z3"
         mat-mini-fab
       >


### PR DESCRIPTION
# Description

Fix for #2002 by removing the matTooltip on the toggleStartTask button
when pomodoro is enabled.

I don't think this is ideal though. In my opinion, we should keep the tooltips on the left side of the buttons and that's what I want to do but there isn't enough translation strings as a `skip session` and `stop session` strings are needed.

## Issues Resolved

This change fixes the issue described in #2002 

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
