### PR TITLE
Pomodoro controls labels

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -112,7 +112,8 @@
       <button
         (click)="taskService.toggleStartTask()"
         [color]="(taskService.currentTaskId$|async)? 'accent': 'primary'"
-        [matTooltip]="(pomodoroService.isEnabled$|async)? '': T.MH.TOGGLE_TRACK_TIME|translate"
+        [matTooltip]="T.MH.TOGGLE_TRACK_TIME|translate"
+        [matTooltipPosition]="(pomodoroService.isEnabled$|async)? 'left': 'below'"
         class="play-btn mat-elevation-z3"
         mat-mini-fab
       >
@@ -156,6 +157,8 @@
         <div class="pomodoro-controls">
           <button
             (click)="pomodoroService.finishPomodoroSession()"
+            [matTooltip]="T.F.POMODORO.S.SESSION_SKIP|translate"
+            matTooltipPosition="left"
             class="pomodoro-btn"
             color=""
             mat-mini-fab
@@ -164,6 +167,8 @@
           </button>
           <button
             (click)="pomodoroService.stop()"
+            [matTooltip]="T.F.POMODORO.S.SESSION_END|translate"
+            matTooltipPosition="left"
             class="pomodoro-btn"
             color=""
             mat-mini-fab

--- a/src/app/core/banner/banner/banner.component.scss
+++ b/src/app/core/banner/banner/banner.component.scss
@@ -3,8 +3,6 @@
 $vertical-button-margin: $s;
 
 :host {
-  position: relative;
-  z-index: 22;
   display: block;
 }
 

--- a/src/app/t.const.ts
+++ b/src/app/t.const.ts
@@ -525,6 +525,8 @@ const T = {
       },
       S: {
         SESSION_X_START: 'F.POMODORO.S.SESSION_X_START',
+        SESSION_SKIP: 'F.POMODORO.S.SESSION_SKIP',
+        SESSION_END: 'F.POMODORO.S.SESSION_END',
       },
       SKIP_BREAK: 'F.POMODORO.SKIP_BREAK',
     },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -516,7 +516,9 @@
         "SESSION_X_START": "Pomodoro: Session {{nr}} started!"
       },
       "S": {
-        "SESSION_X_START": "Pomodoro: Session {{nr}} started!"
+        "SESSION_X_START": "Pomodoro: Session {{nr}} started!",
+        "SESSION_SKIP": "Skip Pomodoro session",
+        "SESSION_END": "End Pomodoro session"
       },
       "SKIP_BREAK": "Skip break"
     },

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -499,7 +499,9 @@
         "SESSION_X_START": "Pomodoro : La session {{nr}} a commencée !"
       },
       "S": {
-        "SESSION_X_START": "Pomodoro : La session {{nr}} a commencée !"
+        "SESSION_X_START": "Pomodoro : La session {{nr}} a commencée !",
+        "SESSION_SKIP": "Passer la session Pomodoro",
+        "SESSION_END": "Arrêter la session Pomodoro"
       },
       "SKIP_BREAK": "Passer la pause"
     },


### PR DESCRIPTION
# Description

Follow-up to #2013 by adding labels to Pomodoro main header buttons but also fixing their overlapping interaction with the header UI element.

This adds two new translation strings which I took care to add in English and French:

- `F.POMODORO.S.SESSION_SKIP`
- `F.POMODORO.S.SESSION_END`

## Issues Resolved

None

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
