### PR TITLE
Fix/android center icons #1975

### DIFF
--- a/src/app/features/tasks/task/task.component.scss
+++ b/src/app/features/tasks/task/task.component.scss
@@ -828,7 +828,7 @@ $this-play-size: 22px;
 
   mat-icon {
     transition: $transition-standard;
-    margin-top: -8px;
+    margin-top: -4px;
     opacity: $task-icon-default-opacity;
 
     &.isHideDoneTasks {

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -103,6 +103,13 @@ body .mat-form-field {
   text-transform: uppercase;
 }
 
+.mat-button-wrapper,
+.mat-button-wrapper > .mat-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 // otherwise it's hard to see when an off-screen element gets focused via tab
 .mat-flat-button.mat-primary:focus {
   &:after {


### PR DESCRIPTION
# Description

this merge will make minor changes to scss to center button icons on android

## Issues Resolved

this will resolve open issue [#1975](https://github.com/johannesjo/super-productivity/issues/1975#issue-1176152299)

## Check List

- [ X ] New functionality includes testing.

I tested on desktop and mobile(samsung a51) using firefox, chrome, and gnome web. I didn't test using an .apk build because I'm still noob so sorry about that.

## Pics from testing
here are some before and afters from the mobile tests

  <details>
      <summary>before</summary>
      <img
        src="https://user-images.githubusercontent.com/86887236/163917597-f5df8eb4-a9cb-4749-b9e8-dbac16b1aaa2.jpg"
        alt=""
        style="height: 650px;"
      /><img
        src="https://user-images.githubusercontent.com/86887236/163917794-9adba547-7412-48b1-a9fa-ed915451c174.jpg"
        alt=""
        style="height: 650px;"
      />
    </details>
    <details>
      <summary>after</summary>
      <img
        src="https://user-images.githubusercontent.com/86887236/163917695-6c493311-7a60-4d3e-a5fc-d0a0885df096.jpg"
        alt=""
        style="height: 650px;"
      /><img
        src="https://user-images.githubusercontent.com/86887236/163917896-9e438d6b-5b9e-4f59-b42c-66a12f689a12.jpg"
        alt=""
        style="height: 650px;"
      />
    </details>
