### PR TITLE
feat: respect first day of week in reports

### DIFF
--- a/src/app/features/quick-history/quick-history.component.ts
+++ b/src/app/features/quick-history/quick-history.component.ts
@@ -11,6 +11,7 @@ import { DialogWorklogExportComponent } from '../worklog/dialog-worklog-export/d
 import { Task } from '../tasks/task.model';
 import { WorklogDataForDay } from '../worklog/worklog.model';
 import { T } from 'src/app/t.const';
+import { DateAdapter } from '@angular/material/core';
 
 @Component({
   selector: 'quick-history',
@@ -29,6 +30,7 @@ export class QuickHistoryComponent {
     public readonly simpleCounterService: SimpleCounterService,
     private readonly _matDialog: MatDialog,
     private readonly _taskService: TaskService,
+    private _dateAdapter: DateAdapter<unknown>,
   ) {
     this.worklogService.quickHistoryWeeks$.subscribe((v) =>
       console.log(`worklogService.quickHistoryWeeks$`, v),
@@ -42,7 +44,7 @@ export class QuickHistoryComponent {
   async exportData(): Promise<void> {
     const now = new Date();
     const year = now.getFullYear();
-    const weekNr = getWeekNumber(now);
+    const weekNr = getWeekNumber(now, this._dateAdapter.getFirstDayOfWeek());
 
     // get for whole week
     const { rangeStart, rangeEnd } = getDateRangeForWeek(year, weekNr);

--- a/src/app/features/worklog/util/map-archive-to-worklog-weeks.ts
+++ b/src/app/features/worklog/util/map-archive-to-worklog-weeks.ts
@@ -28,6 +28,7 @@ export const mapArchiveToWorklogWeeks = (
   taskState: EntityState<Task>,
   noRestoreIds: string[] = [],
   startEnd: { workStart: WorkStartEnd; workEnd: WorkStartEnd },
+  firstDayOfWeek: number = 1,
 ): WorklogYearsWithWeeks => {
   const entities = taskState.entities;
   const worklogYearsWithSimpleWeeks: WorklogYearsWithWeeks = {};
@@ -41,7 +42,7 @@ export const mapArchiveToWorklogWeeks = (
       const year = parseInt(split[0], 10);
       const month = parseInt(split[1], 10);
       const day = parseInt(split[2], 10);
-      const weekNr = getWeekNumber(new Date(+year, +month - 1, day));
+      const weekNr = getWeekNumber(new Date(+year, +month - 1, day), firstDayOfWeek);
       const weekNrIndex = month === 1 && weekNr >= 52 ? 0 : weekNr;
 
       if (!worklogYearsWithSimpleWeeks[year]) {

--- a/src/app/features/worklog/util/map-archive-to-worklog.ts
+++ b/src/app/features/worklog/util/map-archive-to-worklog.ts
@@ -35,6 +35,7 @@ export const mapArchiveToWorklog = (
   taskState: EntityState<Task>,
   noRestoreIds: string[] = [],
   startEnd: { workStart: WorkStartEnd; workEnd: WorkStartEnd },
+  firstDayOfWeek: number = 1,
 ): { worklog: Worklog; totalTimeSpent: number } => {
   const entities = taskState.entities;
   const worklog: Worklog = {};
@@ -130,7 +131,7 @@ export const mapArchiveToWorklog = (
       month.daysWorked = days.length;
       year.daysWorked += days.length;
 
-      const weeks = getWeeksInMonth(+monthIN - 1, +yearIN);
+      const weeks = getWeeksInMonth(+monthIN - 1, +yearIN, firstDayOfWeek);
 
       month.weeks = weeks
         .map((week) => {
@@ -139,7 +140,10 @@ export const mapArchiveToWorklog = (
             timeSpent: 0,
             daysWorked: 0,
             ent: {},
-            weekNr: getWeekNumber(new Date(+yearIN, +monthIN - 1, week.start)),
+            weekNr: getWeekNumber(
+              new Date(+yearIN, +monthIN - 1, week.start),
+              firstDayOfWeek,
+            ),
           };
 
           days.forEach((dayIN: string) => {

--- a/src/app/features/worklog/worklog-week/worklog-week.component.ts
+++ b/src/app/features/worklog/worklog-week/worklog-week.component.ts
@@ -11,6 +11,7 @@ import { Task } from '../../tasks/task.model';
 import { TaskService } from '../../tasks/task.service';
 import { T } from '../../../t.const';
 import { SimpleCounterService } from '../../simple-counter/simple-counter.service';
+import { DateAdapter } from '@angular/material/core';
 
 @Component({
   selector: 'worklog-week',
@@ -29,6 +30,7 @@ export class WorklogWeekComponent {
     public readonly simpleCounterService: SimpleCounterService,
     private readonly _matDialog: MatDialog,
     private readonly _taskService: TaskService,
+    private _dateAdapter: DateAdapter<unknown>,
   ) {}
 
   sortDays(a: any, b: any): number {
@@ -38,7 +40,7 @@ export class WorklogWeekComponent {
   async exportData(): Promise<void> {
     const now = new Date();
     const year = now.getFullYear();
-    const weekNr = getWeekNumber(now);
+    const weekNr = getWeekNumber(now, this._dateAdapter.getFirstDayOfWeek());
 
     // get for whole week
     const { rangeStart, rangeEnd } = getDateRangeForWeek(year, weekNr);

--- a/src/app/features/worklog/worklog.service.ts
+++ b/src/app/features/worklog/worklog.service.ts
@@ -31,6 +31,7 @@ import { DataInitService } from '../../core/data-init/data-init.service';
 import { WorklogTask } from '../tasks/task.model';
 import { mapArchiveToWorklogWeeks } from './util/map-archive-to-worklog-weeks';
 import * as moment from 'moment';
+import { DateAdapter } from '@angular/material/core';
 
 @Injectable({ providedIn: 'root' })
 export class WorklogService {
@@ -156,6 +157,7 @@ export class WorklogService {
     private readonly _dataInitService: DataInitService,
     private readonly _taskService: TaskService,
     private readonly _router: Router,
+    private _dateAdapter: DateAdapter<unknown>,
   ) {}
 
   refreshWorklog(): void {
@@ -234,6 +236,7 @@ export class WorklogService {
         completeStateForWorkContext,
         unarchivedIds,
         startEnd,
+        this._dateAdapter.getFirstDayOfWeek(),
       );
       return {
         worklog,
@@ -273,6 +276,7 @@ export class WorklogService {
         completeStateForWorkContext,
         unarchivedIds,
         startEnd,
+        this._dateAdapter.getFirstDayOfWeek(),
       );
     }
     return null;

--- a/src/app/util/get-week-number.spec.ts
+++ b/src/app/util/get-week-number.spec.ts
@@ -13,6 +13,16 @@ describe('getWeekNumber()', () => {
     expect(result).toBe(1);
   });
 
+  it('should return a valid value for 2020-01-08 based on first day of week', () => {
+    let d = new Date('2020-01-08');
+    let result = getWeekNumber(d);
+    expect(result).toBe(2);
+
+    d = new Date('2020-01-08');
+    result = getWeekNumber(d, 6);
+    expect(result).toBe(1);
+  });
+
   it('should return a valid value for last of the year', () => {
     const d = new Date('2020-12-31');
     const result = getWeekNumber(d);

--- a/src/app/util/get-week-number.ts
+++ b/src/app/util/get-week-number.ts
@@ -1,12 +1,15 @@
-export const getWeekNumber = (d: Date): number => {
+export const getWeekNumber = (d: Date, firstDayOfWeek: number = 1): number => {
   // Copy date so don't modify original
   d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
-  // Set to nearest Thursday: current date + 4 - current day number
-  // Make Sunday's day number 7
-  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  // Set to nearest middle of week based on first day of
+  // week (if first day of week is default it will be Thursday):
+  // current date + 4 - current day number
+  // Make end of week day number 7
+  const diff = (7 - (firstDayOfWeek - 1)) % 7;
+  d.setUTCDate(d.getUTCDate() + 4 - ((d.getUTCDay() + diff) % 7 || 7));
   // Get first day of year
   const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  // Calculate full weeks to nearest Thursday
+  // Calculate full weeks to nearest middle of week
   // prettier-ignore
   const weekNo = Math.ceil((((+d - +yearStart) / 86400000) + 1) / 7);
   // Return array of year and week number

--- a/src/app/util/get-weeks-in-month.spec.ts
+++ b/src/app/util/get-weeks-in-month.spec.ts
@@ -9,6 +9,15 @@ describe('getWeeksInMonth', () => {
     expect(result.length).toBe(5);
   });
 
+  it('should work for february 2019 based on saturday as first day of week', () => {
+    const result = getWeeksInMonth(1, 2019, 6);
+
+    expect(result[0]).toEqual({ start: 1, end: 1 });
+    expect(result[1]).toEqual({ start: 2, end: 8 });
+    expect(result[4]).toEqual({ start: 23, end: 28 });
+    expect(result.length).toBe(5);
+  });
+
   it('should work for march 2019', () => {
     const result = getWeeksInMonth(2, 2019);
     expect(result[0]).toEqual({ start: 1, end: 3 });

--- a/src/app/util/get-weeks-in-month.ts
+++ b/src/app/util/get-weeks-in-month.ts
@@ -1,20 +1,25 @@
 // starting on monday
 import { WeeksInMonth } from './get-week-in-month-model';
 
-export const getWeeksInMonth = (month: number, year: number): WeeksInMonth[] => {
+export const getWeeksInMonth = (
+  month: number,
+  year: number,
+  firstDayOfWeek: number = 1,
+): WeeksInMonth[] => {
   const weeks: { start: number; end: number }[] = [];
   const firstDate = new Date(year, month, 1);
   const lastDate = new Date(year, month + 1, 0);
 
   const numDays = lastDate.getDate();
 
+  const diff = (7 - (firstDayOfWeek - 1)) % 7;
   let end: number;
   let start: number = 1;
 
-  if (firstDate.getDay() === 0) {
+  if ((firstDate.getDay() + diff) % 7 === 0) {
     end = 1;
   } else {
-    end = 7 - firstDate.getDay() + 1;
+    end = 7 - ((firstDate.getDay() + diff) % 7) + 1;
   }
   while (start <= numDays) {
     weeks.push({ start, end });


### PR DESCRIPTION
we can set the first day of week to what we want, but the value is not respected in worklog and quick history.
