### PR TITLE
style(procrastination): Mirror Sync Icon

### DIFF
--- a/src/app/features/procrastination/procrastination.component.html
+++ b/src/app/features/procrastination/procrastination.component.html
@@ -12,8 +12,8 @@
 
         <div class="procrastination-graph">
           <div class="wrap">
-            <div class="text-item">{{T.F.PROCRASTINATION.INTRO.AVOIDING|translate}}</div>
             <div class="text-item">{{T.F.PROCRASTINATION.INTRO.FEAR|translate}}</div>
+            <div class="text-item">{{T.F.PROCRASTINATION.INTRO.AVOIDING|translate}}</div>
           </div>
           <mat-icon>sync</mat-icon>
           <div class="text-item">{{T.F.PROCRASTINATION.INTRO.STRESSED|translate}}</div>

--- a/src/app/features/procrastination/procrastination.component.scss
+++ b/src/app/features/procrastination/procrastination.component.scss
@@ -60,6 +60,6 @@
     transform: rotate(0deg);
   }
   to {
-    transform: rotate(360deg);
+    transform: rotate(-360deg);
   }
 }

--- a/src/app/features/procrastination/procrastination.component.scss
+++ b/src/app/features/procrastination/procrastination.component.scss
@@ -57,9 +57,9 @@
 
 @keyframes spin {
   from {
-    transform: rotate(0deg);
+    transform: rotate(0deg) scaleX(-1);
   }
   to {
-    transform: rotate(-360deg);
+    transform: rotate(360deg) scaleX(-1);
   }
 }


### PR DESCRIPTION
Change sync icon rotation from clockwise to counter-clockwise. This way,
the icon rotates in the same direction that the arrows are pointing.
