### PR TITLE
Hide projects that are marked as hidden from "Add To Project" context menu

### DIFF
--- a/src/app/features/project/store/project.selectors.ts
+++ b/src/app/features/project/store/project.selectors.ts
@@ -82,7 +82,7 @@ export const selectUnarchivedProjectsWithoutCurrent = createSelector(
     return ids
       .filter((id) => id !== props.currentId)
       .map((id) => exists(s.entities[id]) as Project)
-      .filter((p) => !p.isArchived && p.id);
+      .filter((p) => !p.isArchived && !p.isHiddenFromMenu && p.id);
   },
 );
 


### PR DESCRIPTION
# Description

This is a small change to hide projects from the "Add to project" context menu that are marked as `isHiddenFromMenu`

## Issues Resolve

- https://github.com/johannesjo/super-productivity/issues/2077

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
