### PR TITLE
Add done date to Additional Info panel if exist

### DIFF
--- a/src/app/features/tasks/task-additional-info/task-additional-info.component.html
+++ b/src/app/features/tasks/task-additional-info/task-additional-info.component.html
@@ -279,7 +279,10 @@
     </ng-container>
   </task-additional-info-item>
 
-  <div class="created">Created on {{task?.created|date:'short'}}</div>
+  <div class="date-info">
+    <div>Created on {{task?.created|date:'short'}}</div>
+    <div>Completed on {{task?.doneOn|date:'short'}}</div>
+  </div>
 </div>
 
 <div

--- a/src/app/features/tasks/task-additional-info/task-additional-info.component.html
+++ b/src/app/features/tasks/task-additional-info/task-additional-info.component.html
@@ -281,7 +281,7 @@
 
   <div class="date-info">
     <div>Created on {{task?.created|date:'short'}}</div>
-    <div>Completed on {{task?.doneOn|date:'short'}}</div>
+    <div *ngIf="task.doneOn">Completed on {{task?.doneOn|date:'short'}}</div>
   </div>
 </div>
 

--- a/src/app/features/tasks/task-additional-info/task-additional-info.component.scss
+++ b/src/app/features/tasks/task-additional-info/task-additional-info.component.scss
@@ -76,7 +76,8 @@ progress-bar {
   }
 }
 
-.created {
+.created,
+.date-info {
   padding: $s;
   opacity: 0.5;
   text-align: center;


### PR DESCRIPTION
# Description

This PR adds the completed date of a task to the Additional Info panel. If the completed date doesn't exist, nothing is added.

I will add tests later if applicable.

## Issues Resolved

resolves #2155 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
