### PR TITLE
fix(markdown renderer): quotes & lists display issue

### DIFF
--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -273,13 +273,18 @@ export class UiModule {
 
     this._markdownService.renderer.paragraph = (text) => {
       const split = text.split('\n');
-      return split.reduce((acc, p) => {
+      return split.reduce((acc, p, i) => {
         const result = /h(\d)\./.exec(p);
         if (result !== null) {
           const h = `h${result[1]}`;
           return acc + `<${h}>${p.replace(result[0], '')}</${h}>`;
         }
-        return acc + `<p>${p}</p>`;
+
+        if (split.length === 1) {
+          return `<p>` + p + `</p>`;
+        }
+
+        return acc ? (split.length - 1 === i ? acc + p + `</p>` : acc + p) : `<p>` + p;
       }, '');
     };
   }

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -140,6 +140,12 @@ body {
   }
 }
 
+blockquote {
+  border-left: 4px solid rgba(var(--palette-accent-500), 1);
+  margin: 20px 0;
+  padding: 1px 20px;
+}
+
 a[href] {
   color: $c-accent;
 }


### PR DESCRIPTION
# Description

Addresses the rendered markdown issues where: 

>     * the quote isn't very lisible (despite the left offset); it could contain a vertical bar
> 
>     * the second list (with checkboxes) is oddly displayed

---

First issue -> Added a vertical bar on the left side of quote with blockquote tag styling on [src/styles/page.scss](https://github.com/johannesjo/super-productivity/blob/a0ce0e549ea56593cc1ced115bf220772f6e203f/src/styles/page.scss) as this will also be applied to components that has a **markdown** directive

Second issue -> Due to every element that had been appended by paragraph tag on markdown render

``` HTML
<li style="list-style: none;">
    <p>
        <input checked="" disabled="" type="checkbox"> 
    </p>
    <p>
        <a target="_blank" href="https://www.e-marketing.fr/Thematique/academie-1078/fiche-outils-10154/Les-sensations-325644.htm">
            https://www.e-marketing.fr/Thematique/academie-1078/fiche-outils-10154/Les-sensations-325644.htm
        </a>
    </p>
</li>
```

Refactored this line to support paragraph tag appending on multiple elements

https://github.com/johannesjo/super-productivity/blob/a0ce0e549ea56593cc1ced115bf220772f6e203f/src/app/ui/ui.module.ts#L282

Result:

![image](https://i.imgur.com/SV38N3Z.png)

## Issues Resolved

- #2252

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
