### PR TITLE
Make the datetime picker more coherent by darkening the selected reminder date

### DIFF
--- a/src/styles/components/date-time-picker-schedule.scss
+++ b/src/styles/components/date-time-picker-schedule.scss
@@ -740,9 +740,15 @@ $owl-missing: $owl-light-selected-bg !default;
 
   &.isActive {
     border-color: $c-primary;
+    outline: none;
+    background: $owl-light-selected-bg;
+    opacity: 1;
+
+    @include darkTheme(true) {
+      background: $owl-dark-light-selected-bg;
+    }
   }
 
-  &:focus,
   &:hover {
     outline: none;
     background: $owl-light-selected-bg;


### PR DESCRIPTION
# Description

This small style change makes the datetime picker more coherent by darkening the selected reminder date instead of the first focused one.

## Issues Resolved

- #2247 

## Check List

- [x] New functionality includes testing. (Not really applicable, but the feature was tested)
