### PR TITLE
improvement: Trigger focus task when reorder button is clicked

### DIFF
--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -83,6 +83,7 @@
 
     <div class="title-and-left-btns-wrapper">
       <div
+        (click)="focusSelf()"
         [class.handle-par]="!task.parentId"
         [class.handle-sub]="task.parentId"
         class="drag-handle"


### PR DESCRIPTION
# Description

Now focus on task can be triggered when reorder button is clicked

## Issues Resolved

#2208 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
