### PR TITLE
Produce Win32/ARM64 packages

### DIFF
--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -10,7 +10,6 @@ directories:
   output: './app-builds'
 
 win:
-  artifactName: ${productName}-${version}-${arch}.${ext}
   target:
     - target: nsis
       arch:
@@ -22,13 +21,17 @@ win:
         - x64
   publish:
     - github
-
+nsis:
+  artifactName: ${productName} Setup ${version}-${arch}.${ext}
+portable:
+  artifactName: ${productName}-${version}-${arch}.${ext}
 appx:
   applicationId: SuperProductivity
   displayName: Super Productivity
   publisherDisplayName: johannesjo
   publisher: CN=___-___
   identityName: ___johannesjo.SuperProductivity
+
 linux:
   category: Productivity
   target:

--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -10,11 +10,19 @@ directories:
   output: './app-builds'
 
 win:
+  artifactName: ${productName}-${version}-${arch}.${ext}
   target:
-    - nsis
-    - portable
+    - target: nsis
+      arch:
+        - arm64
+        - x64
+    - target: portable
+      arch:
+        - arm64
+        - x64
   publish:
     - github
+
 appx:
   applicationId: SuperProductivity
   displayName: Super Productivity


### PR DESCRIPTION
# Description
Add Win32/ARM64 topology to electron-builder and produces ARM64 builds for Windows.
![image](https://user-images.githubusercontent.com/8717471/215415025-e818f9fa-7407-4b1e-951a-0d6167dee367.png)

`artifactName` is added to produce installer/portable executable per arch, otherwise nsis and portable creates a universal one with size doubled, see https://github.com/electron-userland/electron-builder/pull/5718

This is how app-builds look now:
- superProductivity-7.12.1.exe: universal portable
- superProductivity-7.12.1-arm64.exe: ARM64 portable
- superProductivity-7.12.1-x64.exe: X64 portable
- superProductivity Setup 7.12.1.exe: universal installer
- superProductivity Setup 7.12.1-arm64.exe: ARM64 installer
- superProductivity Setup 7.12.1-x64.exe: x64 installer

```
npm run dist:only

> superProductivity@7.12.1 dist:only
> electron-builder

  • electron-builder  version=23.3.3 os=10.0.22621
  • loaded configuration  file=super-productivity\electron-builder.yaml
  • writing effective config  file=app-builds\builder-effective-config.yaml
  • packaging       platform=win32 arch=arm64 electron=22.0.1 appOutDir=app-builds\win-arm64-unpacked
  • packaging       platform=win32 arch=x64 electron=22.0.1 appOutDir=app-builds\win-unpacked
  • building        target=nsis file=app-builds\superProductivity Setup 7.12.1.exe archs=arm64, x64 oneClick=true perMachine=false
  • building        target=portable file=app-builds\superProductivity-7.12.1.exe archs=arm64, x64
  • building        target=portable file=app-builds\superProductivity-7.12.1-arm64.exe archs=arm64
  • building        target=portable file=app-builds\superProductivity-7.12.1-x64.exe archs=x64
  • building block map  blockMapFile=app-builds\superProductivity Setup 7.12.1.exe.blockmap
  • building        target=nsis file=app-builds\superProductivity Setup 7.12.1-arm64.exe archs=arm64 oneClick=true perMachine=false
  • building block map  blockMapFile=app-builds\superProductivity Setup 7.12.1-arm64.exe.blockmap
  • building        target=nsis file=app-builds\superProductivity Setup 7.12.1-x64.exe archs=x64 oneClick=true perMachine=false
  • building block map  blockMapFile=app-builds\superProductivity Setup 7.12.1-x64.exe.blockmap
```

## Issues Resolved
- Electron supports ARM64 but super productivity doesn't produce corresponding builds.

## Check List

- [ ] New functionality includes testing.
N/A, no test available.
- [ ] New functionality has been documented in the README if applicable.
N/A, minor change.