### PR TITLE
Compatibility with Chrome <= 69 (default WebView on Android <= 9.0)

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -19,9 +19,9 @@
  */
 
 /* IE9, IE10 and IE11 requires all of the following polyfills. **/
-/*import 'core-js/es/symbol';
-import 'core-js/es/object';
-import 'core-js/es/function';
+//import 'core-js/es/symbol';
+import 'core-js/es/object'; // Support for Chrome mobile <= 69, which is the default browser for Android <= 9, especially the following error: TypeError: Object.fromEntries is not a function
+/*import 'core-js/es/function';
 import 'core-js/es/parse-int';
 import 'core-js/es/parse-float';
 import 'core-js/es/number';


### PR DESCRIPTION
# Description

Add a polyfill in `src/polyfills.ts` for compatibility with Chrome <= 69 (default WebView on Android <= 9.0). This bug also happens with desktop versions of Chrome, not only mobile.

In practice, this PR adds compatibility for Android 9.0 and 8.1 out of the box (whereas before, only Android 10+ were compatible out of the box, without updating Chrome first). This PR does not change anything for Android 6.0+ with an updated Chrome browser, as updating Chrome always restore compatibility with `super-productivity` (tested on Android 7.0+ in AVD emulator, could not test Android 6.0 because of a lack of Play Store but it should be the same).

## Issues Resolved

Fixes #2451, fixes https://github.com/johannesjo/super-productivity-android/issues/34 .

## Check List

Tested on (AVD emulator, default Chrome browser):
- [x] Android 9.0
- [x] Android 8.1 - SUCCESS (Chrome v61.0.3163.98)
- [x] Android 8.0 - FAIL with default browser (Chrome v58, no error but silent infinite loading on quote of the day screen)
- [x] Android 7.1 - FAIL (same as Android 8.0)
- [x] Android 7.0 - FAIL (same as Android 8.0)
- [x] Android 6.0 (SDK API 23, minimum targeted SDK version by `super-productivity-android` app) - FAIL (same as Android 8.0)
- [x] Android 10
- [x] Android 11
- [x] Android 13

Note that updating Chrome allows `super-productivity` alone or combined with `super-productivity-android` to work on all older Android versions, the failure above are only with the default Chrome version as supplied with the older Android release.
