### PR TITLE
build: update node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ### build ###
 
 # base image
-FROM node:12 as build
+FROM node:16 as build
 
 # add app
 COPY . /app


### PR DESCRIPTION
# Description

Docker image builds have been broken since 3895c130b830ade27b649867a1c1867d3de7cc3f ([v7.11.6](https://github.com/johannesjo/super-productivity/actions/runs/2932989100)). Changing the version of node used in Dockerfile to 16 as in the other build workflows solves this problem.