### PR TITLE
feat: add repeat subtasks for repeating tasks #427

### DIFF
--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.spec.ts
@@ -24,6 +24,7 @@ const DUMMY_REPEATABLE_TASK: TaskRepeatCfg = {
   sunday: false,
   tagIds: [],
   order: 0,
+  subTaskIds: ['SUB_TASK__DEFAULT'],
 };
 
 const HOUR = 60 * 60 * 1000;
@@ -53,6 +54,23 @@ describe('selectTaskRepeatCfgsDueOnDay', () => {
       );
       const resultIds = result.map((item) => item.id);
       expect(resultIds).toEqual(['R1']);
+    });
+
+    it('should return cfg for a far future task WITH sub tasks', () => {
+      const result = selectTaskRepeatCfgsDueOnDay.projector(
+        [
+          dummyRepeatable('R1', {
+            repeatCycle: 'DAILY',
+            startDate: '2022-01-10',
+            subTaskIds: ['ST-1', 'ST-2'],
+          }),
+        ],
+        {
+          dayDate: new Date('2025-11-11'),
+        },
+      );
+      const resultSubTaskIds = result.map((item) => item.subTaskIds);
+      expect(resultSubTaskIds).toEqual([['ST-1', 'ST-2']]);
     });
 
     [

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.model.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.model.ts
@@ -51,6 +51,7 @@ export interface TaskRepeatCfgCopy {
   // advanced
   notes: string | undefined;
   // ... possible sub tasks & attachments
+  subTaskIds: string[];
 }
 
 export type TaskRepeatCfg = Readonly<TaskRepeatCfgCopy>;
@@ -87,4 +88,5 @@ export const DEFAULT_TASK_REPEAT_CFG: Omit<TaskRepeatCfgCopy, 'id'> = {
   order: 0,
 
   notes: undefined,
+  subTaskIds: [],
 };


### PR DESCRIPTION
# Description

The repeating tasks are updated so they include their sub-tasks.
Example Use Case: The user wants to add a task for a daily "Morning Routine" including several sub-tasks (steps of the routine), without having to re-add the sub-tasks every day.

## Issues Resolved

#427 

## Check List
- [ ] New functionality impemented.
- [ ] New functionality includes testing.
