### PR TITLE
feat: add repeat subtasks for repeating tasks #427

### DIFF
--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
@@ -22,10 +22,14 @@ import {
 import { selectTaskRepeatCfgFeatureState } from './task-repeat-cfg.reducer';
 import { PersistenceService } from '../../../core/persistence/persistence.service';
 import { Task, TaskArchive, TaskCopy } from '../../tasks/task.model';
-import { updateTask } from '../../tasks/store/task.actions';
+import { addSubTask, updateTask } from '../../tasks/store/task.actions';
 import { TaskService } from '../../tasks/task.service';
 import { TaskRepeatCfgService } from '../task-repeat-cfg.service';
-import { TaskRepeatCfg, TaskRepeatCfgState } from '../task-repeat-cfg.model';
+import {
+  DEFAULT_TASK_REPEAT_CFG,
+  TaskRepeatCfg,
+  TaskRepeatCfgState,
+} from '../task-repeat-cfg.model';
 import { forkJoin, from, merge, of } from 'rxjs';
 import { setActiveWorkContext } from '../../work-context/store/work-context.actions';
 import { SyncTriggerService } from '../../../imex/sync/sync-trigger.service';
@@ -38,6 +42,8 @@ import { Update } from '@ngrx/entity';
 import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
 import { isToday } from '../../../util/is-today.util';
 import { DateService } from 'src/app/core/date/date.service';
+import { getWorklogStr } from 'src/app/util/get-work-log-str';
+import { getTaskById } from '../../tasks/store/task.reducer.util';
 
 @Injectable()
 export class TaskRepeatCfgEffects {
@@ -57,6 +63,83 @@ export class TaskRepeatCfgEffects {
       ),
     { dispatch: false },
   );
+
+  /*   addTaskRepeatCfgForSubTasksOf: any = createEffect(
+    () =>
+      this._actions$.pipe(
+        ofType(
+          addTaskRepeatCfgToTask
+        ),
+        tap(async (aAction) => {
+          // TODO: is there an easier way to get to the parent task?
+          const allTasks = await this._taskService.allTasks$.pipe(first()).toPromise();
+          const parentTask = allTasks.find((aTask) => aTask.id === aAction.taskId);
+
+          if (parentTask !== undefined && parentTask.subTaskIds.length > 0) {
+            parentTask.subTaskIds.forEach(aSubTaskId => {
+              const task = allTasks.find((aTask) => aTask.id === aSubTaskId)!;
+
+              const repeatCfg = {
+                ...DEFAULT_TASK_REPEAT_CFG,
+                startDate: getWorklogStr(), // TODO: What is happening here? Is this correct?
+                title: task.title,
+                notes: task.notes,
+                tagIds: task.tagIds,
+                defaultEstimate: task.timeEstimate
+              };
+
+              this._taskRepeatCfgService.addTaskRepeatCfgToTask(
+                task.id,
+                task.projectId,
+                repeatCfg
+              );
+            });
+          }
+        })
+      ),
+      { dispatch: false } // Question: What exactly does this do?
+  ); */
+
+  /**
+   * When adding a sub task, this function checks if the parent is a repeatable task and therefore the sub-task also has to be.
+   */
+  /*   addTaskRepeatCfgForSubTask: any = createEffect(
+    () =>
+      this._actions$.pipe(
+        ofType(
+          addSubTask
+        ),
+        tap(async (aAction) => {
+          const task = aAction.task;
+
+          console.log("A TASKKK");
+
+          // TODO: is there an easier way to get to the parent task?
+          const allTasks = await this._taskService.allTasks$.pipe(first()).toPromise();
+          const parentTask = allTasks.find((aTask) => aTask.id === aAction.parentId);
+
+          console.log("PARENT TASK", parentTask);
+
+          if (parentTask !== undefined && parentTask.repeatCfgId !== null) {
+            const repeatCfg = {
+              ...DEFAULT_TASK_REPEAT_CFG,
+              startDate: getWorklogStr(), // TODO: What is happening here? Is this correct?
+              title: task.title,
+              notes: task.notes || undefined,
+              tagIds: task.tagIds,
+              defaultEstimate: task.timeEstimate
+            };
+  
+            this._taskRepeatCfgService.addTaskRepeatCfgToTask(
+              task.id,
+              task.projectId,
+              repeatCfg
+            );
+          }
+        })
+      ),
+      { dispatch: false } // Question: What exactly does this do?
+  ); */
 
   private triggerRepeatableTaskCreation$ = merge(
     this._syncTriggerService.afterInitialSyncDoneAndDataLoadedInitially$,

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.ts
@@ -45,6 +45,17 @@ export const selectTaskRepeatCfgById = createSelector(
   },
 );
 
+export const selectTaskRepeatCfgByParentId = createSelector(
+  selectAllTaskRepeatCfgs,
+  (taskRepeatCfgs: TaskRepeatCfg[], props: { id: string }): TaskRepeatCfg[] => {
+    const cfgs = taskRepeatCfgs.filter(
+      (aTaskRepeatCfg) => aTaskRepeatCfg.parentId === props.id,
+    );
+
+    return cfgs;
+  },
+);
+
 export const selectTaskRepeatCfgsWithStartTime = createSelector(
   selectAllTaskRepeatCfgs,
   (taskRepeatCfgs: TaskRepeatCfg[]): TaskRepeatCfg[] => {
@@ -55,7 +66,12 @@ export const selectTaskRepeatCfgsWithStartTime = createSelector(
 export const selectTaskRepeatCfgsSortedByTitleAndProject = createSelector(
   selectAllTaskRepeatCfgs,
   (taskRepeatCfgs: TaskRepeatCfg[]): TaskRepeatCfg[] => {
-    return taskRepeatCfgs.sort((a, b) => {
+    // we only want main tasks, no sub tasks
+    const mainTaskRepeatCfgs = taskRepeatCfgs.filter(
+      (aTaskRepeatCfg) => aTaskRepeatCfg.parentId === null,
+    );
+
+    return mainTaskRepeatCfgs.sort((a, b) => {
       if (a.projectId !== b.projectId) {
         if (a.projectId === null) {
           return -1;

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.model.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.model.ts
@@ -23,6 +23,7 @@ export type RepeatQuickSetting =
 
 export interface TaskRepeatCfgCopy {
   id: string;
+  parentId: string | null;
   projectId: string | null;
   lastTaskCreation: number;
   title: string | null;
@@ -66,6 +67,7 @@ export const DEFAULT_TASK_REPEAT_CFG: Omit<TaskRepeatCfgCopy, 'id'> = {
   defaultEstimate: undefined,
 
   // id: undefined,
+  parentId: null,
   projectId: null,
   // lastTaskCreation: Date.now() - 24 * 60 * 60 * 1000,
 

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.service.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.service.ts
@@ -241,8 +241,6 @@ export class TaskRepeatCfgService {
     taskRepeatSubTasks.forEach((aRepeatSubTask) => {
       const subTask = this._getSubTaskRepeatTemplate(aRepeatSubTask, task.id);
 
-      console.log('GETTING SB TASK', subTask);
-
       createNewActions.push(
         addSubTask({
           task: {

--- a/src/app/features/work-context/work-context.model.ts
+++ b/src/app/features/work-context/work-context.model.ts
@@ -53,6 +53,7 @@ export type WorkContextThemeCfg = Readonly<{
   backgroundImageLight: string | null;
 }>;
 
+// TODO: do you mean tag = day? If yes, shouldn't we change this to English?
 export enum WorkContextType {
   PROJECT = 'PROJECT',
   TAG = 'TAG',

--- a/src/app/features/work-context/work-context.model.ts
+++ b/src/app/features/work-context/work-context.model.ts
@@ -53,7 +53,6 @@ export type WorkContextThemeCfg = Readonly<{
   backgroundImageLight: string | null;
 }>;
 
-// TODO: do you mean tag = day? If yes, shouldn't we change this to English?
 export enum WorkContextType {
   PROJECT = 'PROJECT',
   TAG = 'TAG',


### PR DESCRIPTION
# Description

The repeating tasks are updated so they include their sub-tasks.
Example Use Case: The user wants to add a task for a daily "Morning Routine" including several sub-tasks (steps of the routine), without having to re-add the sub-tasks every day.

_There is no way to individually decide for certain sub tasks to be repeatable or not in this implementation. All sub tasks of a repeatable parent task are automatically repeatable, too._

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/427

## Check List

- [ ] When a task is repeatable and a sub task is added, the sub task automatically gets repeatable, too
- [ ] When a task with subtasks is made repeatable, all sub tasks are made repeatable, too
- [ ] BUGFIX: fixed taskCfg not updating when repeatable task gets updated (tested my changing name of repeatable task and changing to next day -> was the old name)
- [ ] only main repeatable tasks are shown in the "Scheduled" Tab, subs automatically get removed when the parent tasks repeatable gets removed
