### PR TITLE
Fix wrong translation

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1410,7 +1410,7 @@
     "E_DATETIME": "Der eingegebene Wert ist keine Datums- / Uhrzeitangabe!",
     "E_MAX": "Sollte nicht größer als {{val}} sein",
     "E_MAX_LENGTH": "Darf maximal {{val}} Zeichen lang sein",
-    "E_MIN": "Sollte kleiner als {{val}} sein",
+    "E_MIN": "Darf nicht kleiner als {{val}} sein",
     "E_MIN_LENGTH": "Sollte mindestens {{val}} Zeichen lang sein",
     "E_PATTERN": "Ungültige Eingabe",
     "E_REQUIRED": "Dieses Feld wird benötigt"


### PR DESCRIPTION
# Description

This is wrongly translated as "should be lower than", which results in funny error messages about "should be lower than 1" when you enter 0:
![grafik](https://github.com/johannesjo/super-productivity/assets/71322635/e8b43c59-2bbc-47aa-99c3-e8c0a58c0381)

Now translated it as "should not be lower than" similar to the max one, so than 1 in our example is still valid. "should be larger than or equal" would also be possible, but I deemed this to be unnecessary long and wordy.

## Issues Resolved
N/A