### PR TITLE
Do not stop time tracking before manual confirmation

### DIFF
--- a/src/app/features/pomodoro/store/pomodoro.effects.ts
+++ b/src/app/features/pomodoro/store/pomodoro.effects.ts
@@ -163,13 +163,13 @@ export class PomodoroEffects {
     { dispatch: false },
   );
 
-  pauseTimeTrackingForPause$: Observable<unknown> = createEffect(() =>
+  pauseTimeTrackingForBreak$: Observable<unknown> = createEffect(() =>
     this._pomodoroService.isEnabled$.pipe(
       switchMap((isEnabledI) =>
         !isEnabledI
           ? EMPTY
           : this._actions$.pipe(
-              ofType(pausePomodoro, pausePomodoroBreak),
+              ofType(startPomodoroBreak),
               withLatestFrom(this.currentTaskId$),
               filter(([, currentTaskId]) => !!currentTaskId),
               mapTo(unsetCurrentTask()),


### PR DESCRIPTION
# Description

If manual pomodoro break confirmation is required, do not stop time tracking before the user actually starts the break.

I did not made this as a optional feature as
1) I do not see the point.
2) I barely know how to code in Typescript and those two lines took me one hour.

## Issues Resolved

Closes #2504 and addresses #2587.

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
