### PR TITLE
fix: ordering of weekly entries in quick history #2817

### DIFF
--- a/src/app/features/quick-history/quick-history.component.ts
+++ b/src/app/features/quick-history/quick-history.component.ts
@@ -9,9 +9,10 @@ import { getWeekNumber } from '../../util/get-week-number';
 import { getDateRangeForWeek } from '../../util/get-date-range-for-week';
 import { DialogWorklogExportComponent } from '../worklog/dialog-worklog-export/dialog-worklog-export.component';
 import { Task } from '../tasks/task.model';
-import { WorklogDataForDay } from '../worklog/worklog.model';
+import { WorklogDataForDay, WorklogDay } from '../worklog/worklog.model';
 import { T } from 'src/app/t.const';
 import { DateAdapter } from '@angular/material/core';
+import { KeyValue } from '@angular/common';
 
 @Component({
   selector: 'quick-history',
@@ -37,8 +38,9 @@ export class QuickHistoryComponent {
     );
   }
 
-  sortDays(a: any, b: any): number {
-    return a.key - b.key;
+  sortDays(a: KeyValue<string, WorklogDay>, b: KeyValue<string, WorklogDay>): number {
+    // avoid comparison by key (day) because a week may span across two months
+    return a.value.dateStr.localeCompare(b.value.dateStr);
   }
 
   async exportData(): Promise<void> {


### PR DESCRIPTION
# Description

Hello there.

I believe the ordering problem comes about because Quick History appears to order by each entry's day (as a string literal). This is fine, until a week happens to span across two months.

I did a quick survey for any other components that might be affected but this should be it. While Worklog uses a similar comparator, it dodges the problem because it groups weeks by month for presentation.

Happy to amend as need be.

## Issues Resolved

#2817

## Check List

- [ ] New functionality includes testing. (N/A)
- [ ] New functionality has been documented in the README if applicable. (N/A)
