### PR TITLE
fix: focus after marking last subtask done (#2795)

### DIFF
--- a/e2e/src/work-view.e2e.ts
+++ b/e2e/src/work-view.e2e.ts
@@ -114,4 +114,18 @@ module.exports = {
 
         .assert.containsText(TASK + ':nth-child(1)', '1 test task hihi')
         .end(),
+
+  'should focus previous subtask when marking last subtask done': (browser: NBrowser) =>
+    browser
+      .loadAppAndClickAwayWelcomeDialog(WORK_VIEW_URL)
+      .addTask('task1')
+      .addTask('task2')
+      .setValue('task:last-child', 'a')
+      .keys(['task3', browser.Keys.ENTER])
+      .setValue('[listid="SUB"] task:nth-child(1)', 'a')
+      .keys(['task4', browser.Keys.ENTER])
+      .moveToElement('[listid="SUB"] task:nth-child(2)', 10, 30)
+      .click('.task-done-btn')
+      .assert.containsText(':focus', 'task3')
+      .end(),
 };

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -448,7 +448,11 @@ export class TaskComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     const taskEls = Array.from(document.querySelectorAll('task'));
-    const currentIndex = taskEls.findIndex((el) => document.activeElement === el);
+    const activeEl =
+      document.activeElement?.tagName.toLowerCase() === 'task'
+        ? document.activeElement
+        : document.activeElement?.closest('task');
+    const currentIndex = taskEls.findIndex((el) => el === activeEl);
     const prevEl = taskEls[currentIndex - 1] as HTMLElement;
 
     if (prevEl) {
@@ -470,7 +474,11 @@ export class TaskComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     const taskEls = Array.from(document.querySelectorAll('task'));
-    const currentIndex = taskEls.findIndex((el) => document.activeElement === el);
+    const activeEl =
+      document.activeElement?.tagName.toLowerCase() === 'task'
+        ? document.activeElement
+        : document.activeElement?.closest('task');
+    const currentIndex = taskEls.findIndex((el) => el === activeEl);
     const nextEl = taskEls[currentIndex + 1] as HTMLElement;
 
     if (nextEl) {


### PR DESCRIPTION
# Description

Hello there.

These changes should help resolve how the application focuses the first task of a task list if the last subtask of another task is marked as done via the tick button. The resulting behaviour should put it in line with how the focus travels when resolving the subtask using a keyboard shortcut instead. 

I've also added an E2E test to cover this particular scenario. I'm not all too familiar with how this works with Nightwatch, but I gave it my best shot.

As an aside, there's another usability niggle (opinionated) I've noticed, but I don't have any good ideas for how to improve it.

If one marks a task with subtasks as done, then the focus doesn't move to the next sibling task in the same list. Underneath the hood, the application tries to shift the focus to the first subtask. However, because of how that entire task will end up in the completed pile, the focus disappears altogether, creating some disorientation.

I think the above is exacerbated by how the default behaviour of keyboard scrolling down a task list will automatically move into subtask items from parent task items. As long as this latter behaviour is required, I can't see an easy intervention.

In any case, happy to amend whatever.

![demo1](https://github.com/johannesjo/super-productivity/assets/43751307/8ab5a2c4-67f8-4493-8112-596091be1e3f)

## Issues Resolved

#2795

## Check List

- [ ] New functionality includes testing. (N/A)
- [ ] New functionality has been documented in the README if applicable. (N/A)
