### PR TITLE
Disable spellcheck in Add Task Bar Component

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.html
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.html
@@ -20,6 +20,7 @@
       (blur)="onBlur($event)"
       [formControl]="taskSuggestionsCtrl"
       [matAutocomplete]="autoEl"
+      spellcheck="false"
       [placeholder]="(doubleEnterCount > 0)
          ? (T.F.TASK.ADD_TASK_BAR.START|translate)
          : isAddToBottom


### PR DESCRIPTION
Closes #2874

Disables spellchecking in Add Task Bar Component, fixes issues with tags and non-english words being highlighted as wrong.