### PR TITLE
fix: show simple counter title on hover #2660

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -203,6 +203,7 @@
           [class.isVisibleMobile]="isShowSimpleCounterBtnsMobile"
         >
           <simple-counter-button
+            [matTooltip]="simpleCounter.title"
             *ngFor="let simpleCounter of enabledSimpleCounters; trackBy: trackById"
             [simpleCounter]="simpleCounter"
           ></simple-counter-button>


### PR DESCRIPTION
Show the title of the simple counter when hovering over the icon.