### PR TITLE
Lazy Load WebDAV and fix NO_REMOTE_DATA error

### DIFF
--- a/src/app/imex/sync/web-dav/web-dav-sync.service.ts
+++ b/src/app/imex/sync/web-dav/web-dav-sync.service.ts
@@ -46,11 +46,13 @@ export class WebDavSyncService implements SyncProviderServiceInterface {
         clientUpdate: d.getTime(),
         rev: this._getRevFromMeta(meta),
       };
-    } catch (e: unknown) {
-      const isAxiosError = !!(e && (e as any).response && (e as any).response.status);
-      if (isAxiosError && (e as any).response.status === 404) {
+    } catch (e: any) {
+      const isAxiosError = !!(e?.response && e.response.status);
+
+      if ((isAxiosError && e.response.status === 404) || e.status === 404) {
         return 'NO_REMOTE_DATA';
       }
+
       console.error(e);
       return e as Error;
     }


### PR DESCRIPTION
# Description

While checking the bundle size (4.2ish MB) I wanted to try out a simple improvement and decided to lazy load webdav as an example, with that 100kb are now lazy-loaded only when webdav is actually used, sure it might not be a lot in comparison to the 4.2mb but each byte counts 😬 

Also while changing it to lazy-load I saw it was missing some types, now thats added as well.

While testing it I came across the 404 Error, so I had to fix that haha

## Issues Resolved

-  fixes #1883 

## Check List

- [x] Tested it locally
- [ ] New functionality includes testing. 
- [ ] New functionality has been documented in the README if applicable.
