### PR TITLE
feat: Add current keyboard shortcuts to app menu's #3063

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -44,7 +44,7 @@
   <nav class="action-nav">
     <button
       (click)="layoutService.showAddTaskBar()"
-      [matTooltip]="T.MH.ADD_NEW_TASK|translate"
+      matTooltip="{{T.MH.ADD_NEW_TASK|translate}} {{_kb.addNewTask?'['+_kb.addNewTask+']':''}}"
       class="hide-xs tour-addBtn"
       mat-icon-button
     >
@@ -53,7 +53,7 @@
 
     <button
       (click)="layoutService.showSearchBar()"
-      [matTooltip]="T.MH.SHOW_SEARCH_BAR|translate"
+      matTooltip="{{T.MH.SHOW_SEARCH_BAR|translate}} {{_kb.showSearchBar?'['+_kb.showSearchBar+']':''}}"
       mat-icon-button
     >
       <mat-icon>search</mat-icon>
@@ -61,7 +61,7 @@
 
     <button
       *ngIf="(syncProviderService.isEnabled$|async)"
-      [matTooltip]="T.MH.TRIGGER_SYNC|translate"
+      matTooltip="T.MH.TRIGGER_SYNC|translate"
       (click)="sync()"
       mat-icon-button
     >
@@ -72,7 +72,7 @@
       (click)="bookmarkService.toggleBookmarks()"
       *ngIf="(workContextService.isActiveWorkContextProject$|async)"
       [class.isOpen]="bookmarkService.isShowBookmarks$|async"
-      [matTooltip]="T.MH.TOGGLE_SHOW_BOOKMARKS|translate"
+      matTooltip="{{T.MH.TOGGLE_SHOW_BOOKMARKS|translate}}{{_kb.toggleBookmarks?'['+_kb.toggleBookmarks+']':''}}"
       class="bookmark-btn"
       mat-icon-button
     >
@@ -91,7 +91,7 @@
     <button
       *ngIf="!(globalConfigService.misc$|async)?.isAlwaysUseFocusMode"
       mat-icon-button
-      [matTooltip]="'Enter focus mode'"
+      matTooltip="Enter focus mode {{_kb.goToFocusMode?'['+_kb.goToFocusMode+']':''}}"
       (click)="enableFocusMode()"
     >
       <mat-icon>center_focus_strong</mat-icon>
@@ -119,7 +119,7 @@
       <button
         (click)="taskService.toggleStartTask()"
         [color]="(taskService.currentTaskId$|async)? 'accent': 'primary'"
-        [matTooltip]="T.MH.TOGGLE_TRACK_TIME|translate"
+        matTooltip="{{T.MH.TOGGLE_TRACK_TIME|translate}}"
         [matTooltipPosition]="(pomodoroService.isEnabled$|async)? 'left': 'below'"
         class="play-btn tour-playBtn mat-elevation-z3"
         mat-mini-fab
@@ -224,7 +224,7 @@
       [class.isRouteWithRightPanel]="(isRouteWithSplitAddtionalInfoPanel$|async)"
       (click)="layoutService.toggleNotes()"
       mat-icon-button
-      [matTooltip]="T.MH.TOGGLE_SHOW_NOTES|translate"
+      matTooltip="{{T.MH.TOGGLE_SHOW_NOTES|translate}} {{_kb.openProjectNotes?'['+_kb.openProjectNotes+']':''}}"
     >
       <mat-icon class="note-ico">comment</mat-icon>
     </button>

--- a/src/app/core-ui/main-header/main-header.component.ts
+++ b/src/app/core-ui/main-header/main-header.component.ts
@@ -28,6 +28,7 @@ import { SnackService } from '../../core/snack/snack.service';
 import { NavigationEnd, Router } from '@angular/router';
 import { FocusModeService } from '../../features/focus-mode/focus-mode.service';
 import { GlobalConfigService } from '../../features/config/global-config.service';
+import { KeyboardConfig } from 'src/app/features/config/keyboard-config.model';
 
 @Component({
   selector: 'main-header',
@@ -93,6 +94,7 @@ export class MainHeaderComponent implements OnInit, OnDestroy {
     private readonly _snackService: SnackService,
     private readonly _router: Router,
     private readonly _focusModeService: FocusModeService,
+    private readonly _configService: GlobalConfigService,
   ) {}
 
   ngOnDestroy(): void {
@@ -134,5 +136,9 @@ export class MainHeaderComponent implements OnInit, OnDestroy {
 
   enableFocusMode(): void {
     this._focusModeService.showFocusOverlay();
+  }
+
+  private get _kb(): KeyboardConfig | undefined {
+    return this._configService.cfg?.keyboard;
   }
 }

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -209,7 +209,7 @@
           <button
             (click)="startTask()"
             *ngIf="!task.isDone && !isCurrent && !task.subTasks?.length"
-            [title]="T.F.TASK.CMP.TRACK_TIME|translate"
+            title="{{T.F.TASK.CMP.TRACK_TIME|translate}} {{_kb.togglePlay?'['+_kb.togglePlay+']':''}}"
             class="ico-btn start-task-btn"
             color=""
             mat-icon-button
@@ -223,7 +223,7 @@
           <button
             (click)="pauseTask()"
             *ngIf="!task.isDone && isCurrent && !task.subTasks?.length"
-            [title]="T.F.TASK.CMP.TRACK_TIME_STOP|translate"
+            title="{{T.F.TASK.CMP.TRACK_TIME_STOP|translate}} {{_kb.togglePlay?'['+_kb.togglePlay+']':''}}"
             class="ico-btn"
             color="accent"
             mat-icon-button
@@ -234,7 +234,7 @@
           <button
             (click)="addToMyDay()"
             *ngIf="isShowAddToToday"
-            [title]="T.F.TASK.CMP.ADD_TO_MY_DAY|translate"
+            title="{{T.F.TASK.CMP.ADD_TO_MY_DAY|translate}} {{_kb.moveToTodaysTasks?'['+_kb.moveToTodaysTasks+']':''}}"
             class="ico-btn"
             color=""
             mat-icon-button
@@ -256,7 +256,7 @@
           <button
             *ngIf="!task.isDone"
             (click)="toggleTaskDone()"
-            [title]="T.F.TASK.CMP.TOGGLE_DONE|translate"
+            title="{{T.F.TASK.CMP.TOGGLE_DONE|translate}} {{_kb.taskToggleDone?'['+_kb.taskToggleDone+']':''}}"
             class="ico-btn task-done-btn"
             color=""
             mat-icon-button
@@ -267,7 +267,7 @@
           <button
             (click)="toggleShowAdditionalInfoOpen()"
             *ngIf="!task.notes && (!task.issueId||task.issueType==='CALENDAR') && !isSelected"
-            [title]="T.F.TASK.CMP.TOGGLE_ADDITIONAL|translate"
+            title="{{T.F.TASK.CMP.TOGGLE_ADDITIONAL|translate}} {{_kb.taskToggleAdditionalInfoOpen?'['+_kb.taskToggleAdditionalInfoOpen+']':''}}"
             class="ico-btn show-additional-info-btn"
             color=""
             mat-icon-button
@@ -310,7 +310,7 @@
           <button
             (click)="toggleShowAdditionalInfoOpen()"
             *ngIf="task.notes|| (task.issueId&&task.issueType!=='CALENDAR') || isSelected"
-            [title]="T.F.TASK.CMP.TOGGLE_ADDITIONAL|translate"
+            title="{{T.F.TASK.CMP.TOGGLE_ADDITIONAL|translate}}  {{_kb.taskToggleAdditionalInfoOpen?'['+_kb.taskToggleAdditionalInfoOpen+']':''}}"
             [class.closeBtn]="!task.issueWasUpdated && isSelected"
             class="ico-btn show-additional-info-btn"
             color=""
@@ -337,19 +337,33 @@
               *ngIf="IS_TOUCH_PRIMARY && !task.isDone && !isCurrent && !task.subTasks?.length"
               mat-menu-item
             >
-              <mat-icon
-                class="play-icon"
-                svgIcon="play"
-              ></mat-icon>
-              {{T.F.TASK.CMP.TRACK_TIME|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon
+                    class="play-icon"
+                    svgIcon="play"
+                  ></mat-icon>
+                  {{T.F.TASK.CMP.TRACK_TIME|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.togglePlay?'&emsp;['+_kb.togglePlay+']':''}}
+                </span>
+              </div>
             </button>
             <button
               (click)="pauseTask()"
               *ngIf="IS_TOUCH_PRIMARY && !task.isDone && isCurrent && !task.subTasks?.length"
               mat-menu-item
             >
-              <mat-icon>pause</mat-icon>
-              {{T.F.TASK.CMP.TRACK_TIME_STOP|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon>pause</mat-icon>
+                  {{T.F.TASK.CMP.TRACK_TIME_STOP|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.togglePlay?'&emsp;['+_kb.togglePlay+']':''}}
+                </span>
+              </div>
             </button>
 
             <button
@@ -367,8 +381,15 @@
               class="hide-xs"
               mat-menu-item
             >
-              <mat-icon>timer</mat-icon>
-              {{T.F.TASK.CMP.OPEN_TIME|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon>timer</mat-icon>
+                  {{T.F.TASK.CMP.OPEN_TIME|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.taskOpenEstimationDialog?'&emsp;['+_kb.taskOpenEstimationDialog+']':''}}
+                </span>
+              </div>
             </button>
 
             <button
@@ -376,12 +397,26 @@
               mat-menu-item
             >
               <ng-container *ngIf="!task.reminderId">
-                <mat-icon>alarm_add</mat-icon>
-                {{T.F.TASK.CMP.SCHEDULE|translate}}
+                <div class="control-text">
+                  <span>
+                    <mat-icon>alarm_add</mat-icon>
+                    {{T.F.TASK.CMP.SCHEDULE|translate}}
+                  </span>
+                  <span class="keybindprev">
+                    {{_kb.taskSchedule?'&emsp;['+_kb.taskSchedule+']':''}}
+                  </span>
+                </div>
               </ng-container>
               <ng-container *ngIf="task.reminderId">
-                <mat-icon>alarm</mat-icon>
-                {{T.F.TASK.CMP.EDIT_REMINDER|translate}}
+                <div class="control-text">
+                  <span>
+                    <mat-icon>alarm</mat-icon>
+                    {{T.F.TASK.CMP.EDIT_REMINDER|translate}}
+                  </span>
+                  <span class="keybindprev">
+                    {{_kb.taskSchedule?'&emsp;['+_kb.taskSchedule+']':''}}
+                  </span>
+                </div>
               </ng-container>
             </button>
 
@@ -390,8 +425,15 @@
               *ngIf="!task.parentId&&!task.isDone"
               mat-menu-item
             >
-              <mat-icon>playlist_add</mat-icon>
-              {{T.F.TASK.CMP.ADD_SUB_TASK|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon>playlist_add</mat-icon>
+                  {{T.F.TASK.CMP.ADD_SUB_TASK|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.taskAddSubTask?'&emsp;['+_kb.taskAddSubTask+']':''}}
+                </span>
+              </div>
             </button>
 
             <button
@@ -406,7 +448,7 @@
             <!--TODO maybe handle dynamically -->
             <a
               *ngIf="task.issueId && task.issueType !=='CALENDAR'"
-              [href]="issueUrl$|async"
+              href="issueUrl$|async"
               mat-menu-item
               style="color: inherit"
               target="_blank"
@@ -429,17 +471,40 @@
               *ngIf="!task.parentId && !isBacklog && task.projectId && (isShowMoveFromAndToBacklogBtns$|async)"
               mat-menu-item
             >
-              <mat-icon>arrow_downward</mat-icon>
-              {{T.F.TASK.CMP.MOVE_TO_BACKLOG|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon>arrow_downward</mat-icon>
+                  {{T.F.TASK.CMP.MOVE_TO_BACKLOG|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.moveToBacklog?'&emsp;['+_kb.moveToBacklog+']':''}}
+                </span>
+              </div>
             </button>
+
+            <!-- <mat-menu-item> -->
+            <!--   <mat-icon class="play-icon" svgIcon="play"></mat-icon> -->
+            <!--   <span>Whatever</span> -->
+            <!--   <div style="display: flex; justify-content: space-between;"> -->
+            <!--     <span style="text-align: left;">Left-aligned text</span> -->
+            <!--     <span style="text-align: right;">Right-aligned text</span> -->
+            <!--   </div> -->
+            <!-- </mat-menu-item> -->
 
             <button
               (click)="moveToToday();"
               *ngIf="!task.parentId && isBacklog && task.projectId && (isShowMoveFromAndToBacklogBtns$|async)"
               mat-menu-item
             >
-              <mat-icon>arrow_upward</mat-icon>
-              {{T.F.TASK.CMP.MOVE_TO_TODAY|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon>arrow_upward</mat-icon>
+                  {{T.F.TASK.CMP.MOVE_TO_TODAY|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.moveToTodaysTasks?'&emsp;['+_kb.moveToTodaysTasks+']':''}}
+                </span>
+              </div>
             </button>
 
             <button
@@ -447,8 +512,15 @@
               *ngIf="!task.parentId"
               mat-menu-item
             >
-              <mat-icon>style</mat-icon>
-              {{T.F.TASK.CMP.EDIT_TAGS|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon>style</mat-icon>
+                  {{T.F.TASK.CMP.EDIT_TAGS|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.taskEditTags?'&emsp;['+_kb.taskEditTags+']':''}}
+                </span>
+              </div>
             </button>
 
             <button
@@ -456,9 +528,16 @@
               [matMenuTriggerFor]="projectMenu"
               mat-menu-item
             >
-              <mat-icon>forward</mat-icon>
-              {{(task.projectId ? T.F.TASK.CMP.MOVE_TO_OTHER_PROJECT :
-              T.F.TASK.CMP.ADD_TO_PROJECT)|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon>forward</mat-icon>
+                  {{(task.projectId ? T.F.TASK.CMP.MOVE_TO_OTHER_PROJECT :
+                  T.F.TASK.CMP.ADD_TO_PROJECT)|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.taskMoveToProject?'&emsp;['+_kb.taskMoveToProject+']':''}}
+                </span>
+              </div>
             </button>
 
             <button
@@ -475,9 +554,16 @@
               class="color-warn"
               mat-menu-item
             >
-              <mat-icon class="color-warn-i">delete_forever</mat-icon>
-              {{(task.repeatCfgId ? T.F.TASK.CMP.DELETE_REPEAT_INSTANCE :
-              T.F.TASK.CMP.DELETE)|translate}}
+              <div class="control-text">
+                <span>
+                  <mat-icon class="color-warn-i">delete_forever</mat-icon>
+                  {{(task.repeatCfgId ? T.F.TASK.CMP.DELETE_REPEAT_INSTANCE :
+                  T.F.TASK.CMP.DELETE)|translate}}
+                </span>
+                <span class="keybindprev">
+                  {{_kb.taskDelete?'&emsp;['+_kb.taskDelete+']':''}}
+                </span>
+              </div>
             </button>
           </ng-template>
         </mat-menu>

--- a/src/app/features/tasks/task/task.component.scss
+++ b/src/app/features/tasks/task/task.component.scss
@@ -309,6 +309,17 @@
   }
 }
 
+.control-text {
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+}
+
+.keybindprev {
+  opacity: 0.6;
+  text-align: right;
+}
+
 .hover-controls {
   transform-origin: right center;
   position: absolute;

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -57,6 +57,7 @@ import { Update } from '@ngrx/entity';
 import { SnackService } from '../../../core/snack/snack.service';
 import { isToday } from '../../../util/is-today.util';
 import { IS_TOUCH_PRIMARY } from '../../../util/is-mouse-primary';
+import { KeyboardConfig } from '../../config/keyboard-config.model';
 
 @Component({
   selector: 'task',
@@ -814,6 +815,10 @@ export class TaskComponent implements OnInit, OnDestroy, AfterViewInit {
     this._renderer.removeClass(this.blockLeftElRef.nativeElement, 'isActive');
     this._renderer.removeClass(this.blockRightElRef.nativeElement, 'isActive');
     this._renderer.setStyle(this.innerWrapperElRef.nativeElement, 'transform', ``);
+  }
+
+  private get _kb(): KeyboardConfig | undefined {
+    return this._configService.cfg?.keyboard;
   }
 
   private _handleKeyboardShortcuts(ev: KeyboardEvent): void {


### PR DESCRIPTION
I have implemented the feature would like to get initial feedback. 

# Description
Added keybind previews to the main task context menu and multiple tooltips in the main task window. 
The keybindings in the context menu are aligned to the right and have a lower transparency. 
Currently all keybindings are surrounded by ```[]```.

![ContextMenu](https://github.com/johannesjo/super-productivity/assets/123008073/7e65e1f9-b7ed-4fe5-8edd-5c3fa45fef4a)

Nothing will be visible when the key is unbound.

![Lightmode](https://github.com/johannesjo/super-productivity/assets/123008073/62d73429-78f5-4510-b659-55af5eb64c53)
![Keycombo in tooltip](https://github.com/johannesjo/super-productivity/assets/123008073/98e53189-fc0a-4b4e-b6e1-a0714cf1426f)


Right now the design has some issues, like the arrow being on the right. So I would welcome any ideas for improving the design.

![moveToProject](https://github.com/johannesjo/super-productivity/assets/123008073/a96e7866-fac6-41ff-8028-dd1d28e342b4)


## Issues Resolved
#3063

## Check List for ideas and improvements
- [ ] add to more tooltips and context windows (would be happy for every finding)
- [ ] add a config option to hide the keybindings completely
- [ ] maybe show all keys as uppercase: so ```[K]``` and ```[Shift+K]``` instead of ```[k]``` and ```[Shift+K]```.