### PR TITLE
feat: show autocomplete when using short syntax for tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@typescript-eslint/eslint-plugin": "7.13.1",
         "@typescript-eslint/parser": "7.13.1",
         "angular-material-css-vars": "^7.0.0",
+        "angular-mentions": "^1.5.0",
         "axios": "^1.6.0",
         "chai": "^5.1.1",
         "chart.js": "^4.4.3",
@@ -8164,6 +8165,19 @@
         "@angular/common": ">=18",
         "@angular/core": ">=18",
         "@angular/material": ">=18"
+      }
+    },
+    "node_modules/angular-mentions": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/angular-mentions/-/angular-mentions-1.5.0.tgz",
+      "integrity": "sha512-6l63v7AvrX9vFzj2h7jAPTnQ390IomCz3HiQP+b3PnDvaZiycd+tiVavi5RxAIX8WYjsamAR+tTPCkOkBkqZ+w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=7.2.0",
+        "@angular/core": ">=7.2.0"
       }
     },
     "node_modules/ansi-align": {
@@ -33223,6 +33237,15 @@
       "requires": {
         "@ctrl/tinycolor": "^4.0.0",
         "tslib": "^2.3.0"
+      }
+    },
+    "angular-mentions": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/angular-mentions/-/angular-mentions-1.5.0.tgz",
+      "integrity": "sha512-6l63v7AvrX9vFzj2h7jAPTnQ390IomCz3HiQP+b3PnDvaZiycd+tiVavi5RxAIX8WYjsamAR+tTPCkOkBkqZ+w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "ansi-align": {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "@typescript-eslint/eslint-plugin": "7.13.1",
     "@typescript-eslint/parser": "7.13.1",
     "angular-material-css-vars": "^7.0.0",
+    "angular-mentions": "^1.5.0",
     "axios": "^1.6.0",
     "chai": "^5.1.1",
     "chart.js": "^4.4.3",
@@ -228,6 +229,9 @@
       "@angular/common": "$@angular/common",
       "@angular/core": "$@angular/core",
       "@angular/animations": "$@angular/animations"
+    },
+    "angular-mentions": {
+      "@angular/common": "$@angular/common"
     }
   }
 }

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.html
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.html
@@ -20,6 +20,8 @@
       (blur)="onBlur($event)"
       [formControl]="taskSuggestionsCtrl"
       [matAutocomplete]="autoEl"
+      [mention]="tagSuggestions"
+      [mentionConfig]="{triggerChar: '#', labelKey: 'title'}"
       spellcheck="false"
       [placeholder]="(doubleEnterCount > 0)
          ? (T.F.TASK.ADD_TASK_BAR.START|translate)

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -40,7 +40,7 @@ $short-syntax-bar-height: 32px;
   position: relative;
   color: #000000;
   border-radius: $card-border-radius;
-  overflow: hidden;
+  // overflow: hidden;
 
   @include darkTheme {
     color: #eeeeee;

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -129,6 +129,9 @@ export class AddTaskBarComponent implements AfterViewInit, OnDestroy {
   inputVal: string = '';
   inputVal$: Observable<string> = this.taskSuggestionsCtrl.valueChanges;
 
+  tagSuggestions$: Observable<Tag[]> = this._tagService.tagsNoMyDay$;
+  tagSuggestions: Tag[] = [];
+
   isAddToBacklogAvailable$: Observable<boolean> = this.shortSyntaxTags$.pipe(
     switchMap((shortSyntaxTags) => {
       const shortSyntaxProjectId =
@@ -169,6 +172,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnDestroy {
     );
     this._subs.add(this.shortSyntaxTags$.subscribe((v) => (this.shortSyntaxTags = v)));
     this._subs.add(this.inputVal$.subscribe((v) => (this.inputVal = v)));
+    this._subs.add(this.tagSuggestions$.subscribe((v) => (this.tagSuggestions = v)));
   }
 
   ngAfterViewInit(): void {

--- a/src/app/features/tasks/tasks.module.ts
+++ b/src/app/features/tasks/tasks.module.ts
@@ -4,6 +4,7 @@ import { TaskComponent } from './task/task.component';
 import { TaskListComponent } from './task-list/task-list.component';
 import { UiModule } from '../../ui/ui.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MentionModule } from 'angular-mentions';
 import { AddTaskBarComponent } from './add-task-bar/add-task-bar.component';
 import { DialogTimeEstimateComponent } from './dialog-time-estimate/dialog-time-estimate.component';
 import { StoreModule } from '@ngrx/store';
@@ -40,6 +41,7 @@ import { ShortSyntaxEffects } from './store/short-syntax.effects';
   imports: [
     CommonModule,
     IssueModule,
+    MentionModule,
     UiModule,
     FormsModule,
     TaskAttachmentModule,


### PR DESCRIPTION
# Description

When user types the content of the new task and include the hash symbol (short syntax for tag), an autocomplete dropdown will open with a list of available tags. Users can click to select the tag and the tag title will be inserted into the input.

## Issues Resolved

resolves #3224 

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
