### PR TITLE
fix(typo): correct typo in TaskActionTypes enum

### DIFF
--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -45,7 +45,7 @@ enum TaskActionTypes {
   'MoveToOtherProject' = '[Task] Move tasks to other project',
   'ToggleStart' = '[Task] Toggle start',
   'RoundTimeSpentForDay' = '[Task] RoundTimeSpentForDay',
-  'AddNewTagsFromShortSyntax' = '[Task] Add new tags form short syntax',
+  'AddNewTagsFromShortSyntax' = '[Task] Add new tags from short syntax',
 }
 
 export const setCurrentTask = createAction(


### PR DESCRIPTION
# Description

Change the enum value of AddNewTagsFromShortSyntax to correctly reflect element ('from' instead of 'form')

## Issues Resolved

No issue existing for this, discussed in #2866

## Check List

- [ ] New functionality includes testing. (n/a)
- [ ] New functionality has been documented in the README if applicable. (n/a)
