### PR TITLE
hide app from dock when `isMinimizeToTray` is enabled

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -242,6 +242,7 @@ const appCloseHandler = (app: App): void => {
       getSettings(mainWin, (appCfg: GlobalConfigState) => {
         if (appCfg && appCfg.misc.isMinimizeToTray && !(app as any).isQuiting) {
           mainWin.hide();
+          app.dock.hide();
           return;
         }
 
@@ -273,6 +274,9 @@ const appMinimizeHandler = (app: App): void => {
         if (appCfg.misc.isMinimizeToTray) {
           event.preventDefault();
           mainWin.hide();
+          app.dock.hide();
+        } else {
+          app.dock.show();
         }
       });
     });


### PR DESCRIPTION
# Description

Hide the app from the dock when the _Minimize to Tray_ option in _Settings > Misc_ is enabled.

## Issues Resolved

closes https://github.com/johannesjo/super-productivity/issues/3393

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
