### PR TITLE
Fix #3447 Gitlab time submission

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
@@ -212,13 +212,13 @@ export class GitlabApiService {
     time_estimate: null | number;
     total_time_spent: null | number;
   }*/
-    const iid = this._getIidFromIssue(issueId);
+
     return this._sendRawRequest$(
       {
         url: `${this._apiLink(
           cfg,
           cfg.project || undefined,
-        )}/issues/${iid}/add_spent_time`,
+        )}/issues/${issueId}/add_spent_time`,
         method: 'POST',
         data: {
           duration,

--- a/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
@@ -212,12 +212,13 @@ export class GitlabApiService {
     time_estimate: null | number;
     total_time_spent: null | number;
   }*/
+    const iid = this._getIidFromIssue(issueId);
     return this._sendRawRequest$(
       {
         url: `${this._apiLink(
           cfg,
           cfg.project || undefined,
-        )}/issues/${issueId}/add_spent_time`,
+        )}/issues/${iid}/add_spent_time`,
         method: 'POST',
         data: {
           duration,
@@ -242,7 +243,7 @@ export class GitlabApiService {
         url: `${this._apiLink(
           cfg,
           cfg.project || undefined,
-        )}/issues/${issueId}/time_stats`,
+        )}/issues/${this._getIidFromIssue(issueId)}/time_stats`,
       },
       cfg,
     ).pipe(map((res) => (res as any).body));

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -215,7 +215,7 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
       issuePoints: issue.weight,
       issueWasUpdated: false,
       issueLastUpdated: new Date(issue.updated_at).getTime(),
-      issueId: issue.id as string,
+      issueId: issue.number.toString(),
     };
   }
 


### PR DESCRIPTION
# Description

The tasks used the internal ID when retrieving Gitlab issues. With this change, it uses the issue number, so that time submission works again. Tested locally with an on-premise Gitlab instance.

## Issues Resolved

#3447 

## Check List

- [ ] New functionality includes testing. N/A
- [ ] New functionality has been documented in the README if applicable. N/A
