### PR TITLE
Fix time format in start time description for repeated task in french

### DIFF
--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -977,7 +977,7 @@
         "REMIND_AT_PLACEHOLDER": "Sélectionnez quand rappeler",
         "SATURDAY": "samedi",
         "START_TIME": "Heure de début programmée",
-        "START_TIME_DESCRIPTION": "Par exemple. 15h00. Laisser vide pour une tâche toute la journée",
+        "START_TIME_DESCRIPTION": "Par exemple. 15:00. Laisser vide pour une tâche toute la journée",
         "SUNDAY": "dimanche",
         "THURSDAY": "jeudi",
         "TITLE": "Titre de la tâche",


### PR DESCRIPTION
# Description

In french, the help provides a false indication regarding the format to use for the start time of a repeated task : the help indicates "15h00", but the fact is that the correct format is "15:00".
