### PR TITLE
feat: webdav integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ ENV PORT=80
 # copy artifact build from the 'build environment'
 COPY --from=build /app/dist/browser /usr/share/nginx/html
 
+# copy nginx config
+COPY ./nginx/default.conf.template /etc/nginx/templates/default.conf.template
+
 # expose port: defaults to 80
 EXPOSE $PORT
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ cd sp
 
 **Setup user accounts**
 
-Edit `webdav.yaml` to configure username and password. Remember to allocate separate directories to different user (within `/data`) to avoid mixing up user data.
+Edit `webdav.yaml` to configure username and password. Remember to create and assign different directories to different users (within `/data`) to avoid mixing up user data.
 
 **Start the services**
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,40 @@ Packaging the app is done via [electron-builder](https://github.com/electron-use
 docker run -d -p 80:80 johannesjo/super-productivity:latest
 ```
 
+Now you can access the web app from your browser at `http://localhost`.
+
+This container only serves the web app, and the user data is stored in the browser. Therefore, it does not have any persistent storage.
+
+### Integrate with WebDAV backend server
+
+You can integrate the container with a WebDAV server container to provides WebDAV service with base url `http://localhost/webdav`.
+
+**Download pre-configured files**
+
+Download the pre-configured `docker-compose.yaml` and `webdav.yaml` from this repository to a local directory, say `sp/`.
+
+```bash
+# Alternatively, you can get them by cloning this repository
+git clone https://github.com/johannesjo/super-productivity.git
+mkdir -p sp
+cp super-productivity/docker-compose.yaml sp/
+cp super-productivity/webdav.yaml sp/
+cd sp
+```
+
+**Setup user accounts**
+
+Edit `webdav.yaml` to configure username and password. Remember to allocate separate directories to different user (within `/data`) to avoid mixing up user data.
+
+**Start the services**
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Additionally to accessing the web app from your browser at `http://localhost`, you can set up WebDAV synchronization with base url `http://localhost/webdav/`.
+
 ## Custom themes (desktop only)
 
 In addition to color coding your projects and tags and to the dark and light theme you can also load completely custom css to restyle everything. To load a custom theme you simply need put them into a new file named `styles.css` directly in the [user data folder](#user-data-folder).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+services:
+  sp:
+    image: johannesjo/super-productivity:latest
+    ports:
+      - 80:80
+    environment:
+      - WEBDAV_BACKEND=http://webdav # Optional
+
+  # Optional: WebDAV backend server
+  # (used with the WEBDAV_BACKEND environment variable)
+  webdav:
+    image: hacdias/webdav:latest
+    ports:
+      - 81:80
+    volumes:
+      - ./webdav.yaml:/config.yml:ro
+      - ./data:/data

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -14,7 +14,11 @@ server {
         return 302 /webdav/;
     }
     location /webdav/ {
-        proxy_pass $WEBDAV_BACKEND/;
+        set $upstream $WEBDAV_BACKEND;
+        # note: put the upstream host in a variable first so that nginx can
+        # starts successfully even if the upstream hsot is not found.
+
+        proxy_pass $upstream/;
         # note: the trailing slash here matters!
     }
 

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,26 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    # serve super-productivity as static files at the path /
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # forward requests starting with "/webdav/" to $WEBDAV_BACKEND
+    # note: the prefix "/webdav" is removed during forwarding
+    location = /webdav {
+        return 302 /webdav/;
+    }
+    location /webdav/ {
+        proxy_pass $WEBDAV_BACKEND/;
+        # note: the trailing slash here matters!
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/webdav.yaml
+++ b/webdav.yaml
@@ -1,0 +1,13 @@
+address: 0.0.0.0
+port: 80
+
+prefix: /
+permissions: CRUD
+
+users:
+  - username: alice
+    password: alicepassword
+    directory: /data/alice
+  - username: bob
+    password: bobpassword
+    directory: /data/bob


### PR DESCRIPTION
I saw @johannesjo mentioned in a [comment](https://github.com/johannesjo/super-productivity/issues/3513#issuecomment-2375125846) that he is interested in bundling a webdav server to the super-productivity docker container. So... I made a prototype of it.

# Description

This patch provides an optional way to integrate an external WebDAV server so that the super-productivity container can serve as a WebDAV server with base url http://localhost/webdav/ . It includes the following changes:

**Replace the default nginx config file**
Besides serving the web app, the new nginx config file also forwards all the requests with paths starting with "/webdav/" to a backend WebDAV server specified by the environment variable WEBDAV_BACKEND. Note that during forwarding, the path prefix "/webdav" will be removed.

**Use hacdias/webdav as default WebDAV backend server** The docker-compose.yaml provides an example setup to use the docker image [hacdias/webdav](https://github.com/hacdias/webdav) as the WebDAV backend server. An example for the configuration of the WebDAV server is also provided in webdav.yaml.

## Issues Resolved

#2309 #3513 

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.

## Remark

The docker-compose.yaml simply points to the docker image "johannesjo/super-productivity:latest" on Docker Hub, which does not contain this patch. You need to change it to the locally built image during testing. 
