### PR TITLE
fix: follow setting when quick scheduling next week (#3373)

### DIFF
--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -37,6 +37,7 @@ import { PlannerService } from '../planner.service';
 import { first } from 'rxjs/operators';
 import { fadeAnimation } from '../../../ui/animations/fade.ani';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
+import { DateAdapter } from '@angular/material/core';
 
 @Component({
   selector: 'dialog-schedule-task',
@@ -78,6 +79,7 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     private _taskService: TaskService,
     private _reminderService: ReminderService,
     private _plannerService: PlannerService,
+    private readonly _dateAdapter: DateAdapter<unknown>,
   ) {}
 
   async ngAfterViewInit(): Promise<void> {
@@ -327,9 +329,14 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
         this.selectedDate = tomorrow;
         break;
       case 2:
-        const nextMonday = tDate;
-        nextMonday.setDate(nextMonday.getDate() + ((1 + 7 - nextMonday.getDay()) % 7));
-        this.selectedDate = nextMonday;
+        const nextFirstDayOfWeek = tDate;
+        const dayOffset =
+          (this._dateAdapter.getFirstDayOfWeek() -
+            this._dateAdapter.getDayOfWeek(nextFirstDayOfWeek) +
+            7) %
+            7 || 7;
+        nextFirstDayOfWeek.setDate(nextFirstDayOfWeek.getDate() + dayOffset);
+        this.selectedDate = nextFirstDayOfWeek;
         break;
       case 3:
         const nextMonth = tDate;

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
@@ -63,6 +63,7 @@ import { PlannerActions } from '../../../planner/store/planner.actions';
 import { combineDateAndTime } from '../../../../util/combine-date-and-time';
 import { FocusModeService } from '../../../focus-mode/focus-mode.service';
 import { isToday } from '../../../../util/is-today.util';
+import { DateAdapter } from '@angular/material/core';
 
 @Component({
   selector: 'task-context-menu-inner',
@@ -159,6 +160,7 @@ export class TaskContextMenuInnerComponent implements AfterViewInit {
     private readonly _globalConfigService: GlobalConfigService,
     private readonly _store: Store,
     private readonly _focusModeService: FocusModeService,
+    private readonly _dateAdapter: DateAdapter<unknown>,
   ) {}
 
   ngAfterViewInit(): void {
@@ -495,9 +497,14 @@ export class TaskContextMenuInnerComponent implements AfterViewInit {
         this._schedule(tomorrow);
         break;
       case 2:
-        const nextMonday = tDate;
-        nextMonday.setDate(nextMonday.getDate() + ((1 + 7 - nextMonday.getDay()) % 7));
-        this._schedule(nextMonday);
+        const nextFirstDayOfWeek = tDate;
+        const dayOffset =
+          (this._dateAdapter.getFirstDayOfWeek() -
+            this._dateAdapter.getDayOfWeek(nextFirstDayOfWeek) +
+            7) %
+            7 || 7;
+        nextFirstDayOfWeek.setDate(nextFirstDayOfWeek.getDate() + dayOffset);
+        this._schedule(nextFirstDayOfWeek);
         break;
       case 3:
         const nextMonth = tDate;


### PR DESCRIPTION
# Description

Hello there,

I tried scouring history for context around why the quick action for scheduling a task forces it to always be the following Monday, but it's still not clear to me why. The following commit appears to be the original appearance:

https://github.com/johannesjo/super-productivity/commit/88220015d225249b4c84e7384b616c05177be73d

The proposed changes here should ensure that the `FIRST_DAY_OF_WEEK` setting is respected.

Though one might argue that rather than abide by the setting, the action should instead be today's date plus seven days.

Anyway, I'm happy to revise as necessary. I was going to pull out the rather similar logic for establishing the scheduled date into a utility function, but thought I'd solicit feedback first.

## Issues Resolved

#3373

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
