### PR TITLE
fix: parse scheduled times using local time zone (#3192)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "10.0.11",
       "license": "MIT",
       "dependencies": {
-        "@capacitor/android": "^6.1.2",
-        "@capacitor/cli": "^6.1.2",
-        "@capacitor/core": "^6.1.2",
         "electron-dl": "^3.5.2",
         "electron-localshortcut": "^3.2.1",
         "electron-log": "^5.1.2",
@@ -42,6 +39,9 @@
         "@angular/platform-server": "^18.1.4",
         "@angular/router": "^18.1.4",
         "@angular/service-worker": "^18.1.4",
+        "@capacitor/android": "^6.1.2",
+        "@capacitor/cli": "^6.1.2",
+        "@capacitor/core": "^6.1.2",
         "@electron/notarize": "^2.5.0",
         "@fontsource/roboto": "^4.5.8",
         "@nextcloud/cdav-library": "^1.1.0",
@@ -3265,6 +3265,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-6.1.2.tgz",
       "integrity": "sha512-Yh0gQDY1bgRrL25J6ecIlvvs2kF8iNSwIPXjyw6Yz9mnwYxBazF5KZbjpKtGPnJgicJhFkYGsqOkEtxrve0EoQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^6.1.0"
@@ -3274,6 +3275,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-6.1.2.tgz",
       "integrity": "sha512-HKCNGE0RP8U7aiEF2vg5wTivJROS8BVfu8a3yYJb1mRQvzv+czpmtHNsTWS/WukvwoxUjyjRmsNQSAACHfMTmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/cli-framework-output": "^2.2.5",
@@ -3307,6 +3309,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -3316,6 +3319,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
       "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^9.2.0"
@@ -3334,6 +3338,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.1.2.tgz",
       "integrity": "sha512-xFy1/4qLFLp5WCIzIhtwUuVNNoz36+V7/BzHmLqgVJcvotc4MMjswW/TshnPQaLLujEOaLkA4h8ZJ0uoK3ImGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -5605,6 +5610,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
       "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-terminal": "2.3.5",
@@ -5619,6 +5625,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.5.tgz",
       "integrity": "sha512-HD72a71IQVBmQckDwmA8RxNVMTbxnaLbgFOl+dO5tbvW9CkkSFCv41h6fUuNsSEVgngfkn0i98HDuZC8mk+lTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
@@ -5632,6 +5639,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
       "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.0",
@@ -5647,6 +5655,7 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
       "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5656,6 +5665,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -5671,6 +5681,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5683,6 +5694,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
       "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
@@ -5696,6 +5708,7 @@
       "version": "2.1.12",
       "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
       "integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-object": "2.1.6",
@@ -5713,6 +5726,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.5.tgz",
       "integrity": "sha512-hkm46uHvEC05X/8PHgdJi4l4zv9VQDELZTM+Kz69odtO9zZYfnt8DkfXHJqJ+PxmtiE5mk/ehJWLnn/XAczTUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
@@ -5726,6 +5740,7 @@
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-2.1.11.tgz",
       "integrity": "sha512-6zCDixNmZCbMCy5np8klSxOZF85kuDyzZSTTQKQP90ZtYNCcPYmuFSzaqDwApJT4r5L3MY3JrqK1gLkc6xiUPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-array": "2.1.5",
@@ -5745,6 +5760,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.6.tgz",
       "integrity": "sha512-eikrNkK89CfGPmexjTfSWl4EYqsPSBh0Ka7by4F0PLc1hJZYtJxUZV3X4r5ecA8ikjicUmcbU7zJmAjmqutG/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.0",
@@ -5760,6 +5776,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.5.tgz",
       "integrity": "sha512-XnYNSwfewUqxq+yjER1hxTKggftpNjFLJH0s37jcrNDwbzmbpFTQTVAp4ikNK4rd9DOebX/jbeZb8jfD86IYxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
@@ -5773,6 +5790,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.10.tgz",
       "integrity": "sha512-mZ7JEowcuGQK+SKsJXi0liYTcXd2bNMR3nE0CyTROpMECUpJeAvvaBaPGZf5ERQUPeWBVuwqAqjUmIdxhz5bxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-object": "2.1.5",
@@ -5790,6 +5808,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
       "integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/slice-ansi": "^4.0.0",
@@ -5810,6 +5829,7 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
       "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5819,6 +5839,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5834,6 +5855,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5846,12 +5868,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ionic/utils-subprocess/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -5867,6 +5891,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5879,6 +5904,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5896,6 +5922,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
       "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/slice-ansi": "^4.0.0",
@@ -5916,6 +5943,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5931,6 +5959,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5943,12 +5972,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ionic/utils-terminal/node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7751,6 +7782,7 @@
     },
     "node_modules/@types/node": {
       "version": "20.12.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7869,6 +7901,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sockjs": {
@@ -8315,6 +8348,7 @@
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
       "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -8636,6 +8670,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9111,6 +9146,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9136,6 +9172,7 @@
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
@@ -9290,6 +9327,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base-64": {
@@ -9299,6 +9337,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9350,6 +9389,7 @@
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
       "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
@@ -9584,6 +9624,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
       "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.x"
@@ -9673,6 +9714,7 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -10175,6 +10217,7 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -10361,7 +10404,9 @@
       "dev": true
     },
     "node_modules/chrono-node": {
-      "version": "2.7.6",
+      "version": "2.7.7",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.7.7.tgz",
+      "integrity": "sha512-p3S7gotuTPu5oqhRL2p1fLwQXGgdQaRTtWR3e8Di9P1Pa9mzkK5DWR5AWBieMUh2ZdOnPgrK+zCrbbtyuA+D/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11386,6 +11431,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -11398,6 +11444,7 @@
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12351,6 +12398,7 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13130,6 +13178,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
       "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "sax": "1.1.4"
@@ -13142,6 +13191,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
       "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/elkjs": {
@@ -13152,6 +13202,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-toolkit": {
@@ -13263,6 +13314,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14487,6 +14539,7 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -14768,6 +14821,7 @@
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -14778,6 +14832,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -14967,6 +15022,7 @@
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
       "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "minimatch": "^8.0.2",
@@ -15000,6 +15056,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -15008,6 +15065,7 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
       "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -15022,6 +15080,7 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
       "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15956,12 +16015,14 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
       "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -16163,6 +16224,7 @@
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -16184,6 +16246,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16505,6 +16568,7 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -16544,6 +16608,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -17381,6 +17446,7 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18903,6 +18969,7 @@
     },
     "node_modules/minipass": {
       "version": "3.1.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -18989,6 +19056,7 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -19332,6 +19400,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.1.tgz",
       "integrity": "sha512-XfG1FBZLM50J10xH9361whJRC9SHZ0Bub4iNRhhI61C8Jv0e1ud19muex6sNKB51ibQNUJNuYn25MuYET/rE6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-fs": "^3.1.7",
@@ -20263,6 +20332,7 @@
     },
     "node_modules/open": {
       "version": "8.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -20631,6 +20701,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20648,6 +20719,7 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -20662,6 +20734,7 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.2.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "14 || >=16.14"
@@ -20669,6 +20742,7 @@
     },
     "node_modules/path-scurry/node_modules/minipass": {
       "version": "7.0.4",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -20723,6 +20797,7 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -20860,6 +20935,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
@@ -21220,6 +21296,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -21233,6 +21310,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21626,6 +21704,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -22201,6 +22280,7 @@
     },
     "node_modules/sax": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/saxes": {
@@ -22305,6 +22385,7 @@
     },
     "node_modules/semver": {
       "version": "7.6.2",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -22582,6 +22663,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -22592,6 +22674,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -22642,6 +22725,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sigstore": {
@@ -22675,6 +22759,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
@@ -22979,6 +23064,7 @@
     },
     "node_modules/split2": {
       "version": "4.2.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -23180,6 +23266,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -23187,6 +23274,7 @@
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -23205,6 +23293,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -23277,6 +23366,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -23409,6 +23499,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -23438,6 +23529,7 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -23445,6 +23537,7 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -23658,6 +23751,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "3"
@@ -23785,6 +23879,7 @@
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -23886,7 +23981,8 @@
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true
     },
     "node_modules/tuf-js": {
       "version": "2.2.1",
@@ -24105,6 +24201,7 @@
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -24211,6 +24308,7 @@
     },
     "node_modules/untildify": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24287,6 +24385,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-decorators": {
@@ -25132,6 +25231,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -25194,6 +25294,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -25207,6 +25308,7 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -25217,6 +25319,7 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -25265,6 +25368,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -25278,6 +25382,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -25287,6 +25392,7 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
       "engines": {
         "node": ">=8.0"
       }
@@ -25306,6 +25412,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -25376,6 +25483,7 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -669,5 +669,13 @@ describe('shortSyntax', () => {
       expect(parsedTaskInfo?.newTagTitles.includes('html')).toBeTrue();
       expect(parsedTaskInfo?.newTagTitles.includes('css')).toBeTrue();
     });
+    it('should parse scheduled date using local time zone when unspecified', () => {
+      const t = {
+        ...TASK,
+        title: '@2024-10-12T13:37',
+      };
+      const plannedTimestamp = getPlannedDateTimestampFromShortSyntaxReturnValue(t);
+      expect(checkIfCorrectDateAndTime(plannedTimestamp, 'saturday', 13, 37)).toBeTrue();
+    });
   });
 });

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -253,7 +253,6 @@ const parseScheduledDate = (task: Partial<TaskCopy>, now: Date): Partial<Task> =
 
     if (parsedDateArr.length) {
       const parsedDateResult = parsedDateArr[0];
-      console.log({ parsedDateResult });
       const start = parsedDateResult.start;
       let plannedAt = start.date().getTime();
       // If user doesn't explicitly enter time, set the scheduled date


### PR DESCRIPTION
# Description

Hello there,

The latest version (`2.7.7`) of the `chrono-node` package contains a commit which should resolve scheduled time components being incorrectly offset when parsed:

- https://github.com/wanasit/chrono/commit/696d2479ce5295c9ad830ad6ac8cb2253130a8f9

I've introduced an extra test to cover this case for posterity. Note it'll fail if using `2.7.6` (as one would expect).

Also redacted what appears to be a superfluous `console.log` as I was investigating the issue to begin with.

## Issues Resolved

#3192

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.

Closes #3192