### PR TITLE
Feat/emojis as project icons

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,7 @@
             "leadingUnderscore": "allowSingleOrDouble",
             "trailingUnderscore": "allow",
             "filter": {
-              "regex": "(should)|@tags",
+              "regex": "(should)|@tags|\\d+",
               "match": false
             }
           },

--- a/angular.json
+++ b/angular.json
@@ -36,7 +36,7 @@
               "src/manifest.json",
               "src/static"
             ],
-            "styles": ["src/styles.scss"],
+            "styles": ["src/styles.scss", "node_modules/@ctrl/ngx-emoji-mart/picker.css"],
             "scripts": [],
             "webWorkerTsConfig": "src/tsconfig.worker.json",
             "browser": "src/main.ts",
@@ -205,7 +205,7 @@
             "tsConfig": "src/tsconfig.spec.json",
             "preserveSymlinks": true,
             "karmaConfig": "src/karma.conf.js",
-            "styles": ["src/styles.scss"],
+            "styles": ["src/styles.scss", "node_modules/@ctrl/ngx-emoji-mart/picker.css"],
             "scripts": [],
             "assets": ["src/favicon.ico", "src/assets", "src/manifest.json"]
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "10.0.11",
       "license": "MIT",
       "dependencies": {
+        "@ctrl/ngx-emoji-mart": "^9.2.0",
         "electron-dl": "^3.5.2",
         "electron-localshortcut": "^3.2.1",
         "electron-log": "^5.1.2",
@@ -235,6 +236,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -511,6 +513,8 @@
     },
     "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -547,6 +551,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -623,6 +628,8 @@
     },
     "node_modules/@angular-devkit/core/node_modules/rxjs": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -652,6 +659,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1096,6 +1104,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1294,7 +1303,6 @@
       "version": "18.1.4",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.1.4.tgz",
       "integrity": "sha512-+N3oWYFubT3GdCkBfD/CmH4DGjr/fGFQZChWbph2ZuPpK7JYNgfyvXS4SjLtdL4WTjjBevBTgR70GyLH/5EbKA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3370,6 +3378,28 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@ctrl/ngx-emoji-mart": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/ngx-emoji-mart/-/ngx-emoji-mart-9.2.0.tgz",
+      "integrity": "sha512-q8B7DiXPfyTe+VOGO6Ix7eh5gKCuADxAsud2xXRTlECTfchoKGTmirSczyjaxIKE/xmB+/ZsnkpthZqUM7SAJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rxjs": "7.8.1",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0-0"
+      }
+    },
+    "node_modules/@ctrl/ngx-emoji-mart/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -22139,7 +22169,8 @@
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.9.0"
@@ -22150,7 +22181,8 @@
     },
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
     "node_modules/sade": {
@@ -23981,8 +24013,7 @@
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/tuf-js": {
       "version": "2.2.1",
@@ -24601,6 +24632,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -25575,7 +25607,6 @@
     },
     "node_modules/zone.js": {
       "version": "0.14.7",
-      "dev": true,
       "license": "MIT"
     },
     "tools/schematics": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     }
   ],
   "dependencies": {
+    "@ctrl/ngx-emoji-mart": "^9.2.0",
     "electron-dl": "^3.5.2",
     "electron-localshortcut": "^3.2.1",
     "electron-log": "^5.1.2",

--- a/src/app/core-ui/side-nav/side-nav-item/side-nav-item.component.html
+++ b/src/app/core-ui/side-nav/side-nav-item/side-nav-item.component.html
@@ -15,7 +15,17 @@
   mat-menu-item
 >
   <span class="badge">{{ workContext().taskIds.length }}</span>
-  <mat-icon class="drag-handle">{{ workContext().icon || defaultIcon() }}</mat-icon>
+  <ngx-emoji
+    *ngIf="workContext().icon?.startsWith('emoji:'); else icon_preview"
+    class="drag-handle side-nav-project-emoji"
+    [emoji]="{id: workContext().icon.split(':')[1]}"
+    [skin]="workContext().icon.split(':')[2]"
+    set="apple"
+    size="22"
+  ></ngx-emoji>
+  <ng-template #icon_preview>
+    <mat-icon class="drag-handle">{{ workContext().icon || defaultIcon() }}</mat-icon>
+  </ng-template>
   <span class="text">{{ workContext().title }}</span>
 </button>
 

--- a/src/app/core-ui/side-nav/side-nav-item/side-nav-item.component.scss
+++ b/src/app/core-ui/side-nav/side-nav-item/side-nav-item.component.scss
@@ -36,6 +36,15 @@
   &.isHidden {
     display: none !important;
   }
+
+  button.mat-mdc-menu-item {
+    ngx-emoji {
+      display: block;
+      width: 40px;
+      height: 40px;
+      top: 5px;
+    }
+  }
 }
 
 // color bar left styles

--- a/src/app/core-ui/side-nav/side-nav-item/side-nav-item.component.ts
+++ b/src/app/core-ui/side-nav/side-nav-item/side-nav-item.component.ts
@@ -17,6 +17,8 @@ import { Project } from '../../../features/project/project.model';
 import { WorkContextMenuComponent } from '../../work-context-menu/work-context-menu.component';
 import { ContextMenuComponent } from '../../../ui/context-menu/context-menu.component';
 import { CdkDragPlaceholder } from '@angular/cdk/drag-drop';
+import { EmojiComponent } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'side-nav-item',
@@ -28,6 +30,8 @@ import { CdkDragPlaceholder } from '@angular/cdk/drag-drop';
     WorkContextMenuComponent,
     ContextMenuComponent,
     CdkDragPlaceholder,
+    EmojiComponent,
+    CommonModule,
   ],
   templateUrl: './side-nav-item.component.html',
   styleUrl: './side-nav-item.component.scss',

--- a/src/app/features/config/config.module.ts
+++ b/src/app/features/config/config.module.ts
@@ -20,6 +20,8 @@ import { MatSliderModule } from '@angular/material/slider';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatInputModule } from '@angular/material/input';
 import { TranslateModule } from '@ngx-translate/core';
+import { SkinComponent } from '@ctrl/ngx-emoji-mart';
+import { EmojiComponent } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 
 @NgModule({
   imports: [
@@ -62,6 +64,8 @@ import { TranslateModule } from '@ngx-translate/core';
     MatSlideToggleModule,
     MatInputModule,
     TranslateModule,
+    EmojiComponent,
+    SkinComponent,
   ],
   declarations: [
     ConfigSectionComponent,

--- a/src/app/features/config/icon-input/icon-input.component.html
+++ b/src/app/features/config/icon-input/icon-input.component.html
@@ -1,7 +1,16 @@
 <!-- TODO make this work -->
 <!--<mat-icon matSuffix="">{{formControl.value}}</mat-icon>-->
 
-<mat-icon>{{ formControl.value }}</mat-icon>
+<ngx-emoji
+  *ngIf="isEmoji(); else icon_preview"
+  [emoji]="{id: formControl.value.split(':')[1]}"
+  [skin]="chosenSkin"
+  set="apple"
+  size="16"
+></ngx-emoji>
+<ng-template #icon_preview>
+  <mat-icon>{{ formControl.value }}</mat-icon>
+</ng-template>
 
 <input
   [ngModel]="formControl.value"
@@ -10,6 +19,12 @@
   [matAutocomplete]="auto"
   matInput
   type="text"
+/>
+<emoji-skins
+  *ngIf="isEmoji()"
+  [skin]="chosenSkin"
+  [i18n]="i18n"
+  (changeSkin)="changeSkin($event)"
 />
 <!--<span matPrefix>+1 &nbsp;</span>-->
 
@@ -24,5 +39,19 @@
   >
     <mat-icon>{{icon}}</mat-icon>
     <span>{{icon}}</span>
+  </mat-option>
+  <mat-option
+    *ngFor="let emojiId of (filteredEmojis); trackBy: trackByIndex"
+    [value]="emojiId"
+  >
+    <mat-icon>
+      <ngx-emoji
+        [emoji]="{id: emojiId.split(':')[1]}"
+        [skin]="chosenSkin"
+        set="apple"
+        size="20"
+      ></ngx-emoji>
+    </mat-icon>
+    <span>{{emojiId}}</span>
   </mat-option>
 </mat-autocomplete>

--- a/src/app/features/config/icon-input/icon-input.component.html
+++ b/src/app/features/config/icon-input/icon-input.component.html
@@ -34,13 +34,6 @@
   [autoActiveFirstOption]="false"
 >
   <mat-option
-    *ngFor="let icon of (filteredIcons); trackBy: trackByIndex"
-    [value]="icon"
-  >
-    <mat-icon>{{icon}}</mat-icon>
-    <span>{{icon}}</span>
-  </mat-option>
-  <mat-option
     *ngFor="let emojiId of (filteredEmojis); trackBy: trackByIndex"
     [value]="emojiId"
   >
@@ -53,5 +46,12 @@
       ></ngx-emoji>
     </mat-icon>
     <span>{{emojiId}}</span>
+  </mat-option>
+  <mat-option
+    *ngFor="let icon of (filteredIcons); trackBy: trackByIndex"
+    [value]="icon"
+  >
+    <mat-icon>{{icon}}</mat-icon>
+    <span>{{icon}}</span>
   </mat-option>
 </mat-autocomplete>

--- a/src/app/features/config/icon-input/icon-input.component.scss
+++ b/src/app/features/config/icon-input/icon-input.component.scss
@@ -2,14 +2,21 @@
 
 :host {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   box-sizing: border-box;
   width: 100%;
+  justify-content: space-between;
 
-  mat-icon {
+  mat-icon,
+  ngx-emoji {
     margin-right: $s;
     font-size: 16px;
     height: 16px;
     width: 16px;
   }
+}
+
+emoji-skins {
+  position: absolute;
+  right: 0;
 }

--- a/src/app/features/tag/tag.module.ts
+++ b/src/app/features/tag/tag.module.ts
@@ -10,6 +10,7 @@ import { TagListComponent } from './tag-list/tag-list.component';
 import { DialogEditTagsForTaskComponent } from './dialog-edit-tags/dialog-edit-tags-for-task.component';
 import { TagComponent } from './tag/tag.component';
 import { IssueModule } from '../issue/issue.module';
+import { EmojiComponent } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 
 @NgModule({
   imports: [
@@ -19,6 +20,7 @@ import { IssueModule } from '../issue/issue.module';
     StoreModule.forFeature(TAG_FEATURE_NAME, tagReducer),
     EffectsModule.forFeature([TagEffects]),
     IssueModule,
+    EmojiComponent,
   ],
   declarations: [
     TagListComponent,

--- a/src/app/features/tag/tag/tag.component.html
+++ b/src/app/features/tag/tag/tag.component.html
@@ -1,8 +1,18 @@
-<mat-icon
-  [style.background]="color()"
+<ngx-emoji
+  *ngIf="tag().icon?.startsWith('emoji:'); else icon_preview"
   class="tag-ico"
-  >{{tag().icon}}</mat-icon
->
+  [emoji]="{id: tag().icon.split(':')[1]}"
+  [skin]="tag().icon.split(':')[2]"
+  set="apple"
+  size="15"
+></ngx-emoji>
+<ng-template #icon_preview>
+  <mat-icon
+    [style.background]="color()"
+    class="tag-ico"
+    >{{tag().icon}}</mat-icon
+  >
+</ng-template>
 <span
   class="tag-title"
   *ngIf="!isHideTitle()"

--- a/src/app/features/tag/tag/tag.component.scss
+++ b/src/app/features/tag/tag/tag.component.scss
@@ -54,3 +54,9 @@ $pad: ($ico-size - $line-height + $ico-pad * 2) * 0.5;
   // needs to be important to overwrite inside mat option
   margin-right: 3px !important;
 }
+
+ngx-emoji.tag-ico {
+  position: relative;
+  top: -1px;
+  left: -2px;
+}

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -838,7 +838,7 @@ describe('shortSyntax', () => {
     it('should parse scheduled date using local time zone when unspecified', () => {
       const t = {
         ...TASK,
-        title: '@2024-10-12T13:37',
+        title: '@2030-10-12T13:37',
       };
       const plannedTimestamp = getPlannedDateTimestampFromShortSyntaxReturnValue(t);
       expect(checkIfCorrectDateAndTime(plannedTimestamp, 'saturday', 13, 37)).toBeTrue();

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -125,6 +125,8 @@ mat-icon.mat-icon[svgicon] {
   white-space: nowrap !important;
   overflow: hidden !important;
   text-overflow: ellipsis !important;
+  display: flex;
+  align-items: center;
 }
 
 // CDK DRAG


### PR DESCRIPTION
# Description

Add the option to use emojis as project and tag icons:

![image](https://github.com/user-attachments/assets/b9982693-2115-44cf-9d3f-ed2a63f2de2f)
![image](https://github.com/user-attachments/assets/be8316d8-9f2e-4b9b-9362-4c2c0a3188eb)

(I also fixed a test in the last commit - the test date has passed and it started failing because of that, I moved the date to 2030 so it stays on saturday and won't pass soon)


## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/3558

## Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
