### PR TITLE
Standardize App Name Across Platforms (#3576)

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
         \"site\": \"https://app.super-productivity.com\"}
         }]
     </string>
-    <string name="title_activity_fullscreen">SupProd</string>
+    <string name="title_activity_fullscreen">Super Prod</string>
     <string name="widget_no_data">Please tap here to load data</string>
     <string name="empty_task_list_text">Tap to refresh task list</string>
     <string name="service_background">Service is running background</string>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "superProductivity",
+  "productName": "Super Productivity",
   "version": "10.0.11",
   "description": "Experience the best ToDo app for digital professionals and get more done! Super Productivity comes with integrated time-boxing and time tracking capabilities and you can load your task from your calendars and from Jira, Gitlab, GitHub, Open Project and others all into a single ToDo list.",
   "main": "./electron/main.js",


### PR DESCRIPTION
# Description

This PR standardizes the application name across platforms to improve brand consistency. 

The app name is now set to Super Productivity on Mac, and Super Prod on Android to avoid truncation issues. 

## Issues Resolved

- https://github.com/johannesjo/super-productivity/issues/3576

## Check List

- [✅] New functionality includes testing.
- [✅] New functionality has been documented in the README if applicable. (No needed)
