### PR TITLE
chore: change the display name of the android app to "Super Prod" #3576

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
         \"site\": \"https://app.super-productivity.com\"}
         }]
     </string>
-    <string name="title_activity_fullscreen">SupProd</string>
+    <string name="title_activity_fullscreen">Super Prod</string>
     <string name="widget_no_data">Please tap here to load data</string>
     <string name="empty_task_list_text">Tap to refresh task list</string>
     <string name="service_background">Service is running background</string>


### PR DESCRIPTION
# Description

The app name is now set to Super Prod on Android to avoid truncation issues.

## Issues Resolved

- https://github.com/johannesjo/super-productivity/issues/3576

## Check List

- [✅] New functionality includes testing.
- [✅] New functionality has been documented in the README if applicable. (No needed)
