### PR TITLE
remove check for startTime < currentTime

### DIFF
--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -279,8 +279,6 @@ const parseScheduledDate = (task: Partial<TaskCopy>, now: Date): DueChanges => {
 
       if (!start.isCertain('hour')) {
         plannedAt = start.date().setHours(9, 0, 0, 0);
-      } else if (start.date().getTime() < now.getTime()) {
-        plannedAt = start.date().setDate(start.date().getDate() + 1);
       }
       const inputDate = parsedDateResult.text;
       return {


### PR DESCRIPTION
# Description

This PR removes the check for task start time  < current time in the `parseScheduleDate` function.

With this condition, if an user schedules a task with a time less than current time, the day of the task will be set to the next day.

```
} else if (start.date().getTime() < now.getTime()) {
        plannedAt = start.date().setDate(start.date().getDate() + 1);
}
```

There are two holes with this logic:

- For example, the current time is 2024-10-17T14:37. If a user schedules the task as 2024-10-18T13:37, the date will be parsed as 2024-10-19T13:37 since 13:37 < 14:37
- There is a test in `short-syntax.spec.ts` that uses this condition. The tested time is 13:37. It will fail if anyone runs the test after 13:37.

```
it('should parse scheduled date using local time zone when unspecified', () => {
      const t = {
        ...TASK,
        title: '@2024-10-12T13:37',
      };
      const plannedTimestamp = getPlannedDateTimestampFromShortSyntaxReturnValue(t);
      expect(checkIfCorrectDateAndTime(plannedTimestamp, 'saturday', 13, 37)).toBeTrue();
    });
``` 

There is no need to check for schedule time < current time anyway. The date parser is configured as `forwardDate: true` and the reference date is now (`new Date()`). So any input date will be parsed as forward into the future.

## Issues Resolved

Relates to #3192 

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
