### PR TITLE
Fix for #3581: Added a concise product name and description for macOS…

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,5 +228,15 @@
     "angular-mentions": {
       "@angular/common": "$@angular/common"
     }
+  },
+  "build": {
+    "mac": {
+      "productName": "SuperProductivity",
+      "description": "Efficient task and time tracking app"
+    },
+    "win": {
+      "productName": "SuperProductivity",
+      "description": "Efficient task and time tracking app"
+    }
   }
 }


### PR DESCRIPTION
# Description

Added a concise product name and description for Windows and macOS builds

## Issues Resolved

[Windows] App description too long in Task manager #3581

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
