### PR TITLE
Fix #3612: wrong index for Calendars in tutorial

### DIFF
--- a/src/app/features/shepherd/shepherd-steps.const.ts
+++ b/src/app/features/shepherd/shepherd-steps.const.ts
@@ -543,7 +543,7 @@ export const SHEPHERD_STEPS = (
       text: `On the settings page, you can also find the <strong>Calendars</strong> section. ${CLICK_B} on it!`,
       beforeShowPromise: () => promiseTimeout(500),
       attachTo: {
-        element: '.config-section:nth-of-type(6)',
+        element: '.config-section:nth-of-type(5)',
         on: 'top',
       },
       when: (() => {


### PR DESCRIPTION
# Description

Fixes 'Reminders' being highlighted instead of 'Calendars' in the onboarding tutorial.

## Issues Resolved

Closes #3612.

## Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
