### PR TITLE
Fix for #3415: Added tooltip to entire repeat task element, instead o…

### DIFF
--- a/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.html
+++ b/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.html
@@ -1,4 +1,7 @@
-<div (click)="editTaskRepeatCfg()">
+<div
+  (click)="editTaskRepeatCfg()"
+  matTooltip="{{ T.F.PLANNER.EDIT_REPEATED_TASK|translate: {taskName: repeatCfg().title} }}"
+>
   <mat-icon svgIcon="repeat"></mat-icon>
   <div class="title">
     {{ repeatCfg().title }}

--- a/src/app/features/planner/planner-task/planner-task.component.html
+++ b/src/app/features/planner/planner-task/planner-task.component.html
@@ -11,10 +11,7 @@
     >play_arrow
   </mat-icon>
   <div class="type-ico-wrapper">
-    <div
-      *ngIf="task.repeatCfgId"
-      matTooltip="{{ T.F.PLANNER.EDIT_REPEATED_TASK|translate: {taskName: task.title} }}"
-    >
+    <div *ngIf="task.repeatCfgId">
       <div
         class="repeat-date-badge"
         *ngIf="!isRepeatTaskCreatedToday"


### PR DESCRIPTION
# Description

Added a tooltip for the entire repeat task element, instead of just the repeat button

![Screenshot 2024-10-21 at 10 17 26 PM](https://github.com/user-attachments/assets/a650319c-30a3-4245-879a-8c6738d02914)

## Issues Resolved

Add hover text to button in Planner (UI Improvement) [#3415](https://github.com/johannesjo/super-productivity/issues/3415#top)

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
