### PR TITLE
Android: Use DocumentFile Uri instead of Absolute Full Path

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Build
 import android.util.Base64
 import android.util.Log
@@ -18,6 +19,7 @@ import android.webkit.WebView
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import androidx.documentfile.provider.DocumentFile
 import com.anggrayudi.storage.SimpleStorageHelper
 import com.anggrayudi.storage.file.*
 import com.superproductivity.superproductivity.App
@@ -332,7 +334,8 @@ class JavaScriptInterface(
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             // Scoped storage permission management for Android 10+
             // Load file
-            val file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=false)
+            // val file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=false)
+            val file = DocumentFile.fromSingleUri(activity, Uri.parse(fullFilePath))
             // Get last modified date
             val lastModif = file?.lastModified().toString()
             Log.d("SuperProductivity", "getFileRev lastModified: $lastModif")
@@ -366,12 +369,17 @@ class JavaScriptInterface(
         val reader =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 // Scoped storage permission management for Android 10+
-                val file = DocumentFileCompat.fromFullPath(
+                val folder = DocumentFile.fromTreeUri(
                     activity,
-                    fullFilePath,
-                    requiresWriteAccess = false
+                    Uri.parse(fullFilePath),
                 )
-                file?.openInputStream(activity)?.reader()
+                val file: DocumentFile? = folder?.findFile(filePath)
+                if (file != null) {
+                    activity.contentResolver.openInputStream(file.uri)?.reader()
+                }
+                else {
+                    null
+                }
             } else {
                 // Older versions of Android <= 9 don't need scoped storage management
                 try {
@@ -415,15 +423,30 @@ class JavaScriptInterface(
             Log.d("SuperProductivity", "writeFile: trying to save to fullFilePath: " + fullFilePath)
             // Scoped storage permission management for Android 10+, but also works for Android < 10
             // Open file with write access, using SimpleStorage helper wrapper DocumentFileCompat
-            var file = DocumentFileCompat.fromFullPath(activity, fullFilePath, requiresWriteAccess=true, considerRawFile=true)
-            if ((file == null) || (!file.exists())) {  // if file does not exist, we create it
-                Log.d("SuperProductivity", "writeFile: file does not exist, try to create it")
-                val folder = DocumentFileCompat.fromFullPath(activity, folderPath, requiresWriteAccess=true)
-                Log.d("SuperProductivity", "writeFile: do we have access to parentFolder? " + folder.toString())
-                file = folder!!.makeFile(activity, filePath, mode=CreateMode.REPLACE) // do NOT specify a mimeType, otherwise Android will force a file extension
+            val folder = DocumentFile.fromTreeUri(activity, Uri.parse(folderPath))
+            var file = folder?.findFile(filePath)
+
+            if (file != null && file.exists()) {
+                // File exists, attempt to delete it
+                val deleted = file.delete()
+
+                if (!deleted) {
+                    Log.e("SuperProductivity", "Failed to delete the existing file: $filePath")
+                    return
+                } else {
+                    Log.d("SuperProductivity", "File deleted: $filePath")
+                }
             }
-            Log.d("SuperProductivity", "writeFile: erase file content by recreating it")
-            file = file?.recreateFile(activity)  // erase content first by recreating file. For some reason, DocumentFileCompat.fromFullPath(requiresWriteAccess=true) and openOutputStream(append=false) only open the file in append mode, so we need to recreate the file to truncate its content first
+
+            // File doesn't exist or was deleted successfully, so create it
+            file = folder?.createFile("text/plain", filePath)
+
+            if (file != null) {
+                Log.d("SuperProductivity", "File created successfully: ${file.uri}")
+            } else {
+                Log.e("SuperProductivity", "Failed to create the file: $filePath")
+            }
+            // file = file?.recreateFile(activity)  // erase content first by recreating file. For some reason, DocumentFileCompat.fromFullPath(requiresWriteAccess=true) and openOutputStream(append=false) only open the file in append mode, so we need to recreate the file to truncate its content first
             // Open a writer to an OutputStream to the file without append mode (so we write from the start of the file)
             Log.d("SuperProductivity", "writeFile: try to openOutputStream")
             val writer: Writer =file?.openOutputStream(activity, append=false)!!.writer()
@@ -525,7 +548,9 @@ class JavaScriptInterface(
             { requestCode, root -> // could also use simpleStorageHelper.onStorageAccessGranted()
                 Log.d("SuperProductivity", "Success Folder Pick! Now saving...")
                 // Get absolute path to folder
-                val fpath = root.getAbsolutePath(activity)
+                val fpath = root.uri.toString()
+                Log.d("SuperProductivity", "THEA: FileSyncFolder: " + fpath)
+                Log.d("SuperProductivity", "THEA: root: " + root)
                 // Open preferences to save folder to path
                 val sp = activity.getPreferences(Context.MODE_PRIVATE)
                 sp.edit().putString("filesyncFolder", fpath).apply()


### PR DESCRIPTION
# Description

- replaced `DocumentFileCompact` with `DocumentFile`
- replaced usage of absolute paths by `DocumentFile` uri
- add permanet permission request for read and write

## Issues Resolved

- #3577 

## Check List

- [x] New functionality includes testing (but only Android 14)
- [ ] New functionality has been documented in the README if applicable.

I got the following push verification failure, but am sure if it is related to my changes, because I did not touch any timezone settings. 
Can you please help me on this one ?

```
❯ git push fork fork/nextcloud-local-file
husky > pre-push (node v22.9.0)

> superProductivity@10.0.11 lint
> ng lint


Linting "sp2"...

All files pass linting.


> superProductivity@10.0.11 test
> cross-env TZ='Europe/Berlin' ng test --watch=false

✔ Browser application bundle generation complete.
26 10 2024 11:09:37.771:INFO [karma-server]: Karma v6.4.2 server started at http://localhost:9876/
26 10 2024 11:09:37.773:INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
26 10 2024 11:09:37.777:INFO [launcher]: Starting browser Chrome
26 10 2024 11:09:38.448:INFO [Chrome Headless 129.0.0.0 (Linux x86_64)]: Connected on socket q45Cf_CUcab8IWJmAAAB with id 83364907
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 209 of 381 SUCCESS (0 secs / 0.249 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 210 of 381 SUCCESS (0 secs / 0.551 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 211 of 381 SUCCESS (0 secs / 0.558 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 212 of 381 SUCCESS (0 secs / 0.563 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 213 of 381 SUCCESS (0 secs / 0.568 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 214 of 381 SUCCESS (0 secs / 0.573 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 215 of 381 SUCCESS (0 secs / 0.577 secs)
ALERT: 'The data you are trying to upload is invalid'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 216 of 381 SUCCESS (0 secs / 0.584 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 216 of 381 SUCCESS (0 secs / 0.584 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 217 of 381 SUCCESS (0 secs / 0.589 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 218 of 381 SUCCESS (0 secs / 0.595 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 220 of 381 SUCCESS (0 secs / 0.606 secs)
ALERT: 'Data damaged, repair not possible.'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 220 of 381 SUCCESS (0 secs / 0.606 secs)
Chrome Headless 129.0.0.0 (Linux x86_64) shortSyntax combined should parse scheduled date using local time zone when unspecified FAILED
	Expected false to be true.
	    at <Jasmine>
	    at UserContext.apply (src/app/features/tasks/short-syntax.spec.ts:844:79)
	    at _ZoneDelegate.invoke (node_modules/zone.js/fesm2015/zone.js:365:28)
	    at ProxyZoneSpec.onInvoke (node_modules/zone.js/fesm2015/zone-testing.js:2070:39)
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 272 of 381 (1 FAILED) (0 secs / 0.722 secs)
Chrome Headless 129.0.0.0 (Linux x86_64) shortSyntax combined should parse scheduled date using local time zone when unspecified FAILED
	Expected false to be true.
	    at <Jasmine>
	    at UserContext.apply (src/app/features/tasks/short-syntax.spec.ts:844:79)
	    at _ZoneDelegate.invoke (node_modules/zone.js/fesm2015/zone.js:365:28)
ALERT: 'Sync Error: lastSync value is newer than last local change, which should never happen if you were not manually manipulating the data!'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 370 of 381 (1 FAILED) (0 secs / 1.127 secs)
ALERT: 'Sync Error: lastSync value is newer than last local change, which should never happen if you wereALERT: 'Sync Warning: Dropbox date not up to date despite seemingly successful sync. (This might happen when: 1. You have conflict changes and decide to take the local version. 2. You open the other instance and also decide to use the local version.)'
Chrome Headless 129.0.0.0 (Linux x86_64): Executed 371 of 381 (1 FAILED) (0 secs / 1.127 secs)
ALERT: 'Sync Warning: Dropbox date not up to date despite seemingly successful sync. (This might happen when: 1. You have conflict changes and decide to take the local version. 2. You open the other instance anChrome Headless 129.0.0.0 (Linux x86_64): Executed 381 of 381 (1 FAILED) (1.352 secs / 1.147 secs)
TOTAL: 1 FAILED, 380 SUCCESS
TOTAL: 1 FAILED, 380 SUCCESS
husky > pre-push hook failed (add --no-verify to bypass)
error: failed to push some refs to 'github.com:theatischbein/super-productivity.git'
```