### PR TITLE
Update Arch Linux PKGBUILD_template for new artifacts changes

### DIFF
--- a/build/linux/PKGBUILD_template
+++ b/build/linux/PKGBUILD_template
@@ -14,13 +14,13 @@ provides=("${_pkgname}")
 conflicts=("${_pkgname}"
 		   "${_pkgname}-git")
 md5sums=('SKIP')
-source=("https://github.com/johannesjo/super-productivity/releases/download/v${pkgver}/superProductivity_${pkgver}_amd64.deb")
+source=("https://github.com/johannesjo/super-productivity/releases/download/v${pkgver}/superProductivity-amd64.deb")
 
 package() {
 	tar -xvf data.tar.xz -C "${pkgdir}"
 	rm -rf "${pkgdir}/usr/share/doc"
     install -d "${pkgdir}/usr/bin"
-	ln -sf "/opt/superProductivity/${_pkgname}" "${pkgdir}/usr/bin/${_pkgname}"
+	ln -sf "/opt/Super Productivity/${_pkgname}" "${pkgdir}/usr/bin/${_pkgname}"
     install -Dm644 -t "${pkgdir}/usr/share/licenses/${pkgname}" \
-    "${pkgdir}/opt/superProductivity/"{'LICENSE.electron.txt','LICENSES.chromium.html'}
+    "${pkgdir}/opt/Super Productivity/"{'LICENSE.electron.txt','LICENSES.chromium.html'}
 }


### PR DESCRIPTION
New packaging seems to change a couple of things:

1. Package version is no longer included on the filename of the release artifact
2. Looks like the directory inside the package new includes spaces on the target install dir

Closes https://github.com/johannesjo/super-productivity/issues/3656
