### PR TITLE
Update README.md (Android documention link fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Packaging the app is done via [electron-builder](https://github.com/electron-use
 
 _This feature was added on October 7, 2024. See [Pull Request #57](https://github.com/johannesjo/super-productivity-android/pull/57)._
 
-To build the Android version of Super Productivity, please refer to the [Android Build Documentation](./android/offline.md), which includes instructions on configuring **Connectivity-Free Mode** and **Online-Only Mode (Compatibility Mode)**.
+To build the Android version of Super Productivity, please refer to the [Android Build Documentation](./android/README.md), which includes instructions on configuring **Connectivity-Free Mode** and **Online-Only Mode (Compatibility Mode)**.
 
 Ensure you follow the setup steps properly to configure the environment for building the app.
 

--- a/android/README_OFFLINE.md
+++ b/android/README_OFFLINE.md
@@ -17,7 +17,7 @@ For users performing a **new installation**, setting `LAUNCH_MODE` to `2` ensure
 To set up the project, clone the `super-productivity` repository instead of directly cloning the `super-productivity-android` repository. This ensures that all submodules, including the Android project, are properly initialized.
 
 ```bash
-git clone https://github.com/super-productivity/super-productivity.git
+git clone https://github.com/johannesjo/super-productivity.git
 cd super-productivity
 git submodule init
 git submodule update


### PR DESCRIPTION
This link [Android Build Documentation](https://github.com/johannesjo/super-productivity/blob/master/android/offline.md) was dead.

# Description

Gives you a working link ig

## Issues Resolved

Users facing an error 404 page when they try to access Android Build Documentation through README.md 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
