### PR TITLE
feat: improve durations input format #3736

### DIFF
--- a/src/app/ui/duration/string-to-ms.pipe.spec.ts
+++ b/src/app/ui/duration/string-to-ms.pipe.spec.ts
@@ -16,4 +16,24 @@ describe('stringToMs', () => {
   it('should not return NaN for just h', () => {
     expect(stringToMs('h')).toBe(0);
   });
+
+  // @covers #3737
+  it('should work improved', () => {
+    // Case: no spaces.
+    expect(stringToMs('1h10m')).toBe(4200000);
+
+    // Case: missing last unit.
+    expect(stringToMs('1h 10')).toBe(4200000);
+    expect(stringToMs('1h10')).toBe(4200000);
+
+    // Case: missing all units.
+    expect(stringToMs('10')).toBe(0);
+
+    // Case: using floats (with dot or comma separator).
+    expect(stringToMs('1.5h')).toBe(5400000);
+    expect(stringToMs('1,5h')).toBe(5400000);
+
+    // Case: combining floats with subunits (opinionated choice: adds up).
+    expect(stringToMs('1,5h 10m')).toBe(6000000);
+  });
 });

--- a/src/app/ui/duration/string-to-ms.pipe.ts
+++ b/src/app/ui/duration/string-to-ms.pipe.ts
@@ -9,26 +9,40 @@ export const stringToMs = (strValue: string, args?: any): number => {
   let h: number | undefined;
   let m: number | undefined;
   let s: number | undefined;
+  let previousLastChar: string | undefined;
 
-  const arrValue = strValue.split(' ');
+  // Add spaces after letters to ease further splitting.
+  strValue = strValue.replace(/([a-zA-Z]+)\s*/g, '$1 ');
+  // Replace commas by dots to allow using them as float separator.
+  strValue = strValue.replace(',', '.');
+
+  const arrValue = strValue.trim().split(' ');
 
   arrValue.forEach((val: string) => {
     if (val.length > 0) {
-      const lastChar = val.slice(-1);
-      const amount = parseInt(val.slice(0, val.length - 1), 10);
+      const lastChar = val.slice(-1).toLowerCase();
+      const amount = parseFloat(val);
 
       if (lastChar === 's') {
         s = amount;
-      }
-      if (lastChar === 'm') {
+      } else if (lastChar === 'm') {
         m = amount;
-      }
-      if (lastChar === 'h') {
+      } else if (lastChar === 'h') {
         h = amount;
-      }
-      if (lastChar === 'd') {
+      } else if (lastChar === 'd') {
         d = amount;
+      } else {
+        if (previousLastChar === 's') {
+          // Don't track milliseconds.
+        } else if (previousLastChar === 'm') {
+          s = amount;
+        } else if (previousLastChar === 'h') {
+          m = amount;
+        } else if (previousLastChar === 'd') {
+          h = amount;
+        }
       }
+      previousLastChar = lastChar;
     }
   });
 


### PR DESCRIPTION
# Description

Allow:
1. to input duration without spaces: `2h30m`
2. to use floats: `2.5h`
3. to omit last unit: `1h30`

## Issues Resolved

#3736

## Check List

- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable.
