### PR TITLE
Feat schedule picker popover

### DIFF
--- a/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.html
+++ b/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.html
@@ -1,0 +1,9 @@
+<div class="date-picker">
+  <mat-calendar />
+  <!-- <mat-calendar
+    [selected]="selectedDate"
+    [minDate]="minDate"
+    (selectedChange)="onDateChanged($event)"
+  > 
+  </mat-calendar> -->
+</div>

--- a/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.scss
+++ b/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.scss
@@ -1,0 +1,5 @@
+:host {
+  background: #fff;
+  display: block;
+  padding: 8px 16px;
+}

--- a/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.spec.ts
+++ b/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SimpleSchedulePicker } from './simple-schedule-picker.component';
+import { SimpleSchedulePickerComponent } from './simple-schedule-picker.component';
 
 describe('DialogTimeDisplayComponent', () => {
-  let component: SimpleSchedulePicker;
-  let fixture: ComponentFixture<SimpleSchedulePicker>;
+  let component: SimpleSchedulePickerComponent;
+  let fixture: ComponentFixture<SimpleSchedulePickerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SimpleSchedulePicker],
+      imports: [SimpleSchedulePickerComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(SimpleSchedulePicker);
+    fixture = TestBed.createComponent(SimpleSchedulePickerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.spec.ts
+++ b/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SimpleSchedulePicker } from './simple-schedule-picker.component';
+
+describe('DialogTimeDisplayComponent', () => {
+  let component: SimpleSchedulePicker;
+  let fixture: ComponentFixture<SimpleSchedulePicker>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SimpleSchedulePicker],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SimpleSchedulePicker);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.spec.ts
+++ b/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.spec.ts
@@ -1,22 +1,22 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SimpleSchedulePickerComponent } from './simple-schedule-picker.component';
+// import { SimpleSchedulePickerComponent } from './simple-schedule-picker.component';
 
-describe('DialogTimeDisplayComponent', () => {
-  let component: SimpleSchedulePickerComponent;
-  let fixture: ComponentFixture<SimpleSchedulePickerComponent>;
+// describe('DialogTimeDisplayComponent', () => {
+//   let component: SimpleSchedulePickerComponent;
+//   let fixture: ComponentFixture<SimpleSchedulePickerComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [SimpleSchedulePickerComponent],
-    }).compileComponents();
+//   beforeEach(async () => {
+//     await TestBed.configureTestingModule({
+//       imports: [SimpleSchedulePickerComponent],
+//     }).compileComponents();
 
-    fixture = TestBed.createComponent(SimpleSchedulePickerComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+//     fixture = TestBed.createComponent(SimpleSchedulePickerComponent);
+//     component = fixture.componentInstance;
+//     fixture.detectChanges();
+//   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+//   it('should create', () => {
+//     expect(component).toBeTruthy();
+//   });
+// });

--- a/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.ts
+++ b/src/app/features/planner/simple-schedule-picker/simple-schedule-picker.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { UiModule } from 'src/app/ui/ui.module';
+
+@Component({
+  selector: 'simple-schedule-picker',
+  standalone: true,
+  imports: [UiModule],
+  templateUrl: './simple-schedule-picker.component.html',
+  styleUrl: './simple-schedule-picker.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SimpleSchedulePickerComponent {}

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -154,3 +154,8 @@ $short-syntax-bar-height: 32px;
     border-color: $dark-theme-extra-border-color;
   }
 }
+
+// Make the popover on top of the preview component
+::ng-deep .cdk-overlay-container:has(.overlay-pane_calendar) {
+  z-index: 10000;
+}

--- a/src/app/features/tasks/tasks.module.ts
+++ b/src/app/features/tasks/tasks.module.ts
@@ -35,6 +35,7 @@ import { IS_ELECTRON } from '../../app.constants';
 import { TasksByTagComponent } from './tasks-by-tag/tasks-by-tag.component';
 import { ShortSyntaxEffects } from './store/short-syntax.effects';
 import { InlineMultilineInputComponent } from '../../ui/inline-multiline-input/inline-multiline-input.component';
+import { PopoverModule } from '../../ui/popover';
 import { TaskContextMenuComponent } from './task-context-menu/task-context-menu.component';
 import { TaskHoverControlsComponent } from './task/task-hover-controls/task-hover-controls.component';
 import { CdkDrag, CdkDropList } from '@angular/cdk/drag-drop';
@@ -62,6 +63,7 @@ import { CdkDrag, CdkDropList } from '@angular/cdk/drag-drop';
     ]),
     BetterDrawerModule,
     InlineMultilineInputComponent,
+    PopoverModule,
     TaskContextMenuComponent,
     TaskHoverControlsComponent,
     CdkDropList,

--- a/src/app/ui/popover/index.ts
+++ b/src/app/ui/popover/index.ts
@@ -1,0 +1,5 @@
+export * from './popover-container';
+export * from './popover-ref';
+export * from './popover';
+export * from './popover.module';
+// ex

--- a/src/app/ui/popover/popover-container.component.html
+++ b/src/app/ui/popover/popover-container.component.html
@@ -1,0 +1,1 @@
+<ng-template cdkPortalOutlet />

--- a/src/app/ui/popover/popover-container.ts
+++ b/src/app/ui/popover/popover-container.ts
@@ -1,0 +1,47 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ComponentRef,
+  EmbeddedViewRef,
+  inject,
+  ViewChild,
+} from '@angular/core';
+import { OverlayRef } from '@angular/cdk/overlay';
+import {
+  BasePortalOutlet,
+  CdkPortalOutlet,
+  ComponentPortal,
+  TemplatePortal,
+} from '@angular/cdk/portal';
+import { PopoverRef } from './popover-ref';
+
+@Component({
+  selector: 'popover-container',
+  templateUrl: './popover-container.component.html',
+  styleUrl: './popover-container.component.scss',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.Default,
+  imports: [CdkPortalOutlet],
+  host: {
+    class: 'cdk-popover-container',
+  },
+})
+export class CdkPopoverContainerComponent extends BasePortalOutlet {
+  private _overlayRef = inject(OverlayRef);
+  @ViewChild(CdkPortalOutlet, { static: true }) _portalOutlet!: CdkPortalOutlet;
+  renderMethod: 'template' | 'component' = 'component';
+  context: any;
+  constructor(private popoverRef: PopoverRef) {
+    super();
+  }
+  attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
+    console.log(this._portalOutlet);
+    const result = this._portalOutlet.attachComponentPortal(portal);
+    return result;
+  }
+  attachTemplatePortal<T>(portal: TemplatePortal<T>): EmbeddedViewRef<T> {
+    const result = this._portalOutlet.attachTemplatePortal(portal);
+    // this._contentAttached() // TODO: check if this is necessary
+    return result;
+  }
+}

--- a/src/app/ui/popover/popover-ref.ts
+++ b/src/app/ui/popover/popover-ref.ts
@@ -1,0 +1,16 @@
+import { ComponentRef, TemplateRef } from '@angular//core';
+import { OverlayRef } from '@angular/cdk/overlay';
+import { BasePortalOutlet } from '@angular/cdk/portal';
+
+export type PopoverContent = TemplateRef<any> | ComponentRef<any>;
+
+export class PopoverRef<C = unknown> {
+  readonly componentInstance: C | null = null;
+  /**
+   * `ComponentRef` of the component opened into the dialog. Will be
+   * null when the dialog is opened using a `TemplateRef`
+   */
+  readonly componentRef: ComponentRef<C> | null = null;
+  readonly containerInstance: BasePortalOutlet | null = null;
+  constructor(readonly overlayRef: OverlayRef) {}
+}

--- a/src/app/ui/popover/popover.component.spec.ts
+++ b/src/app/ui/popover/popover.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { CalendarPopoverComponent } from './popover-container';
+import { CdkPopoverContainerComponent } from './popover-container';
 
 describe('CalendarPopoverComponent', () => {
-  let component: CalendarPopoverComponent;
-  let fixture: ComponentFixture<CalendarPopoverComponent>;
+  let component: CdkPopoverContainerComponent;
+  let fixture: ComponentFixture<CdkPopoverContainerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CalendarPopoverComponent],
+      imports: [CdkPopoverContainerComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(CalendarPopoverComponent);
+    fixture = TestBed.createComponent(CdkPopoverContainerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/ui/popover/popover.component.spec.ts
+++ b/src/app/ui/popover/popover.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CalendarPopoverComponent } from './popover-container';
+
+describe('CalendarPopoverComponent', () => {
+  let component: CalendarPopoverComponent;
+  let fixture: ComponentFixture<CalendarPopoverComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CalendarPopoverComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarPopoverComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ui/popover/popover.component.spec.ts
+++ b/src/app/ui/popover/popover.component.spec.ts
@@ -1,22 +1,22 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { CdkPopoverContainerComponent } from './popover-container';
+// import { CdkPopoverContainerComponent } from './popover-container';
 
-describe('CalendarPopoverComponent', () => {
-  let component: CdkPopoverContainerComponent;
-  let fixture: ComponentFixture<CdkPopoverContainerComponent>;
+// describe('CalendarPopoverComponent', () => {
+//   let component: CdkPopoverContainerComponent;
+//   let fixture: ComponentFixture<CdkPopoverContainerComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [CdkPopoverContainerComponent],
-    }).compileComponents();
+//   beforeEach(async () => {
+//     await TestBed.configureTestingModule({
+//       imports: [CdkPopoverContainerComponent],
+//     }).compileComponents();
 
-    fixture = TestBed.createComponent(CdkPopoverContainerComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+//     fixture = TestBed.createComponent(CdkPopoverContainerComponent);
+//     component = fixture.componentInstance;
+//     fixture.detectChanges();
+//   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+//   it('should create', () => {
+//     expect(component).toBeTruthy();
+//   });
+// });

--- a/src/app/ui/popover/popover.module.ts
+++ b/src/app/ui/popover/popover.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { PortalModule } from '@angular/cdk/portal';
+import { Popover } from './popover';
+import { CdkPopoverContainerComponent } from './popover-container';
+
+@NgModule({
+  imports: [OverlayModule, PortalModule, CdkPopoverContainerComponent],
+  exports: [PortalModule, CdkPopoverContainerComponent],
+  providers: [Popover],
+})
+export class PopoverModule {}

--- a/src/app/ui/popover/popover.ts
+++ b/src/app/ui/popover/popover.ts
@@ -1,0 +1,120 @@
+import {
+  ComponentRef,
+  ElementRef,
+  inject,
+  Injectable,
+  Injector,
+  StaticProvider,
+} from '@angular/core';
+import {
+  ComponentType,
+  Overlay,
+  ConnectionPositionPair,
+  OverlayConfig,
+  OverlayRef,
+  PositionStrategy,
+} from '@angular/cdk/overlay';
+import { BasePortalOutlet, ComponentPortal } from '@angular/cdk/portal';
+import { PopoverRef } from './popover-ref';
+import { CdkPopoverContainerComponent } from './popover-container';
+
+export type PopoverConfig = {
+  origin: ElementRef<any>;
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class Popover {
+  private _injector = inject(Injector);
+  private _overlay = inject(Overlay);
+  overlayRef: OverlayRef | null = null;
+  constructor() {}
+
+  open<C = unknown>(component: ComponentType<C>, config: PopoverConfig): PopoverRef<C> {
+    const overlayConfig = this._getOverlayConfig(config.origin);
+    const overlayRef = this._overlay.create(overlayConfig);
+    const popoverRef = new PopoverRef(overlayRef);
+    const popoverContainer = this._attachContainer(overlayRef, popoverRef);
+    (popoverRef as { containerInstance: BasePortalOutlet }).containerInstance =
+      popoverContainer;
+    this._attachDialogContent(component, popoverRef, popoverContainer);
+    // popoverRef.closed.subscribe()
+    return popoverRef as PopoverRef<C>;
+  }
+
+  private _getOverlayConfig(origin: ElementRef): OverlayConfig {
+    const overlayConfig = new OverlayConfig({
+      hasBackdrop: true, // set backdrop to true so we can close the popover when the user
+      // clicks outside of it
+      backdropClass: 'popover-backdrop',
+      panelClass: 'overlay-pane_calendar',
+      positionStrategy: this.getOverlayPosition(origin),
+      scrollStrategy: this._overlay.scrollStrategies.reposition(),
+    });
+    return overlayConfig;
+  }
+
+  private getOverlayPosition(origin: any): PositionStrategy {
+    const positionStrategy = this._overlay
+      .position()
+      .flexibleConnectedTo(origin)
+      .withPositions(this.getPositions())
+      .withPush(false);
+    console.log({ positionStrategy });
+    return positionStrategy;
+  }
+
+  // Get a list of preferred positions
+  private getPositions(): ConnectionPositionPair[] {
+    return [
+      {
+        originX: 'center',
+        originY: 'bottom',
+        overlayX: 'center',
+        overlayY: 'top',
+      },
+      {
+        originX: 'center',
+        originY: 'top',
+        overlayX: 'center',
+        overlayY: 'bottom',
+      },
+      {
+        originX: 'center',
+        originY: 'bottom',
+        overlayX: 'center',
+        overlayY: 'top',
+      },
+    ];
+  }
+  private _attachContainer<C>(
+    overlay: OverlayRef,
+    popoverRef: PopoverRef<C>,
+  ): BasePortalOutlet {
+    const providers: StaticProvider[] = [
+      { provide: PopoverRef, useValue: popoverRef },
+      { provide: OverlayRef, useValue: overlay },
+    ];
+    const containerPortal = new ComponentPortal(
+      CdkPopoverContainerComponent,
+      null,
+      Injector.create({ parent: this._injector, providers }),
+    );
+    const containerRef = overlay.attach(containerPortal);
+    return containerRef.instance;
+  }
+  private _attachDialogContent<C>(
+    component: ComponentType<C>,
+    popoverRef: PopoverRef<C>,
+    popupContainer: BasePortalOutlet,
+  ): void {
+    const providers: StaticProvider[] = [{ provide: PopoverRef, useValue: popoverRef }];
+    const injector = Injector.create({ parent: this._injector, providers });
+    const contentRef = popupContainer.attachComponentPortal<C>(
+      new ComponentPortal(component, null, injector),
+    );
+    (popoverRef as { componentRef: ComponentRef<C> }).componentRef = contentRef;
+    (popoverRef as { componentInstance: C }).componentInstance = contentRef.instance;
+  }
+}


### PR DESCRIPTION
# Description

A rough custom implementation for popover. It's like dialog, but less intrusive. Developer can pass a custom component to it to render anything into this popover. It still needs further feedback in order to be complete.

## Issues Resolved

Potentially resolves #3544 . Popover can be passed a calendar picker that allows uses to select date while adding new task.

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
