### PR TITLE
Fix drag handle to allow text selection

### DIFF
--- a/src/app/features/tasks/task-list/task-list.component.ts
+++ b/src/app/features/tasks/task-list/task-list.component.ts
@@ -122,23 +122,8 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
   }
 
   enterPredicate(drag: CdkDrag, drop: CdkDropList): boolean {
-    // TODO this gets called very often for nested lists. Maybe there are possibilities to optimize
-    const task = drag.data;
-    // const targetModelId = drag.dropContainer.data.listModelId;
-    const targetModelId = drop.data.listModelId;
-    const isSubtask = !!task.parentId;
-    // console.log(drag.data.id, { isSubtask, targetModelId, drag, drop });
-    // return true;
-    if (isSubtask) {
-      if (!PARENT_ALLOWED_LISTS.includes(targetModelId)) {
-        return true;
-      }
-    } else {
-      if (PARENT_ALLOWED_LISTS.includes(targetModelId)) {
-        return true;
-      }
-    }
-    return false;
+    const handleElement = drag.element.nativeElement.querySelector('.drag-handle');
+    return handleElement && handleElement.contains(drag._dragRef._pointerDownEvent.target);
   }
 
   async drop(

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -77,6 +77,7 @@
         [class.handle-par]="!isInSubTaskList()"
         [class.handle-sub]="isInSubTaskList()"
         class="drag-handle"
+        cdkDragHandle
       >
         <mat-icon
           class="drag-handle-ico"


### PR DESCRIPTION
Fixes #3724

Fix the issue where text in text fields cannot be highlighted by mouse drag without the whole task becoming a draggable object.

* Add `cdkDragHandle` directive to the `drag-handle` div in `src/app/features/tasks/task/task.component.html`.
* Update the `enterPredicate` method in `src/app/features/tasks/task-list/task-list.component.ts` to ensure it only allows drag events on the drag handle.

