### PR TITLE
Use OpenProject Task Start Dates as Planned At Dates within Super-Productivity

### DIFF
--- a/src/app/features/issue/issue.model.ts
+++ b/src/app/features/issue/issue.model.ts
@@ -85,32 +85,32 @@ export type IssueData =
   | RedmineIssue;
 
 export type IssueDataReduced =
-  | GithubIssueReduced
-  | JiraIssueReduced
-  | GitlabIssue
-  | OpenProjectWorkPackageReduced
-  | CaldavIssueReduced
-  | ICalIssueReduced
-  | GiteaIssue
-  | RedmineIssue;
+  | (GithubIssueReduced & { plannedAt?: string | null })
+  | (JiraIssueReduced & { plannedAt?: string | null })
+  | (GitlabIssue & { plannedAt?: string | null })
+  | (OpenProjectWorkPackageReduced & { plannedAt?: string | null })
+  | (CaldavIssueReduced & { plannedAt?: string | null })
+  | (ICalIssueReduced & { plannedAt?: string | null })
+  | (GiteaIssue & { plannedAt?: string | null })
+  | (RedmineIssue & { plannedAt?: string | null });
 
 export type IssueDataReducedMap = {
   [K in IssueProviderKey]: K extends 'JIRA'
-    ? JiraIssueReduced
+    ? JiraIssueReduced & { plannedAt?: string | null }
     : K extends 'GITHUB'
-      ? GithubIssueReduced
+      ? GithubIssueReduced & { plannedAt?: string | null }
       : K extends 'GITLAB'
-        ? GitlabIssue
+        ? GitlabIssue & { plannedAt?: string | null }
         : K extends 'CALDAV'
-          ? CaldavIssueReduced
+          ? CaldavIssueReduced & { plannedAt?: string | null }
           : K extends 'ICAL'
-            ? ICalIssueReduced
+            ? ICalIssueReduced & { plannedAt?: string | null }
             : K extends 'OPEN_PROJECT'
-              ? OpenProjectWorkPackageReduced
+              ? OpenProjectWorkPackageReduced & { plannedAt?: string | null }
               : K extends 'GITEA'
-                ? GiteaIssue
+                ? GiteaIssue & { plannedAt?: string | null }
                 : K extends 'REDMINE'
-                  ? RedmineIssue
+                  ? RedmineIssue & { plannedAt?: string | null }
                   : never;
 };
 

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -441,12 +441,18 @@ export class IssueService {
       }
     };
 
+    const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+
     const taskData = {
       issueType: issueProviderKey,
       issueProviderId: issueProviderId,
       issueId: issueDataReduced.id.toString(),
       issueWasUpdated: false,
       issueLastUpdated: Date.now(),
+      plannedAt: issueDataReduced.plannedAt
+        ? new Date(new Date(issueDataReduced.plannedAt).setHours(6, 0, 0, 0)).getTime() +
+          oneDayInMilliseconds
+        : null, // Adjust plannedAt to 6 AM or set it to null if not present
       ...additionalFromProviderIssueService,
       // NOTE: if we were to add tags, this could be overwritten here
       ...(await getProjectOrTagId()),

--- a/src/app/features/issue/providers/open-project/open-project-issue/open-project-issue-map.util.ts
+++ b/src/app/features/issue/providers/open-project/open-project-issue/open-project-issue-map.util.ts
@@ -16,6 +16,7 @@ export const mapOpenProjectIssueReduced = (
 ): OpenProjectWorkPackageReduced => {
   return {
     ...issue,
+    plannedAt: issue.startDate,
     url: `${cfg.host}/projects/${cfg.projectId}/work_packages/${issue.id}`,
   };
 };

--- a/src/app/features/issue/providers/open-project/open-project-issue/open-project-issue.model.ts
+++ b/src/app/features/issue/providers/open-project/open-project-issue/open-project-issue.model.ts
@@ -7,6 +7,7 @@ export type OpenProjectWorkPackageReduced = OpenProjectOriginalWorkPackageReduce
   Readonly<{
     // added
     // transformed
+    plannedAt: string | null;
     url: string;
     // removed
   }>;


### PR DESCRIPTION
# Description

This change introduces support for the `plannedAt` field in the task scheduling process. Tasks imported from Open Project now include the `plannedAt` date field, and their scheduling is adjusted to  **6 AM** the day the task starts in open project. This enhancement improves integration with Open Project by ensuring tasks are accurately scheduled based on their planned dates.

I made it optional for the other integrated services to include the field as well
 - I also attempted to get the integration to work with the 'plannedFor' field, but it didn't work. I think it would have been nicer to have plannedFor, but plannedAt is still workable.  

## Issues Resolved


## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
