### PR TITLE
[macOS] Remove unnecessary dock hide logic

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -241,10 +241,6 @@ const appCloseHandler = (app: App): void => {
       getSettings(mainWin, (appCfg: GlobalConfigState) => {
         if (appCfg && appCfg.misc.isMinimizeToTray && !(app as any).isQuiting) {
           mainWin.hide();
-
-          if (IS_MAC) {
-            app.dock.hide();
-          }
           return;
         }
 
@@ -276,9 +272,6 @@ const appMinimizeHandler = (app: App): void => {
         if (appCfg.misc.isMinimizeToTray) {
           event.preventDefault();
           mainWin.hide();
-          if (IS_MAC) {
-            app.dock.hide();
-          }
         } else if (IS_MAC) {
           app.dock.show();
         }


### PR DESCRIPTION
# Description

Removed the logic that was causing the app to be hidden from the Dock when the user closes and it's not the expected behavior from users in macOS.

There is a configuration right now that the user can enabled that it's called minimize to tray.

### Minimize to Tray (OFF)
<img width="829" alt="image" src="https://github.com/user-attachments/assets/6c9a1de9-ea88-455c-aa8b-94eb61d41c53" />

- if the user closes the app clicking on the red dot the app will close as expected (same behavior)
- if the user minimizes the app clicking on the yellow dot, it will minimize to the dock and keep it showing there (new behavior)

<img width="209" alt="image" src="https://github.com/user-attachments/assets/0d352315-1168-43d8-86d0-8c97c9effb5f" />

### Minimize to Tray (ON)
<img width="497" alt="image" src="https://github.com/user-attachments/assets/2271e39b-9e50-483d-88e1-c70a23f08ec5" />

- if the user closes the app clicking on the red dot the app will minimize to the tray and keep it showing on the dock as Mac users expected (new behavior) 
![image](https://github.com/user-attachments/assets/bde01212-b96e-478b-b099-6028bf3df40d)
<img width="134" alt="image" src="https://github.com/user-attachments/assets/63ce088c-95c7-41cf-8eac-9c004e960c57" />

- if the user minimizes the app clicking on the yellow dot, the same behavior described above (minimize to tray off) will happen.

## Issues Resolved

[Issue 3668](https://github.com/johannesjo/super-productivity/issues/3668)
