### PR TITLE
sync title (aka summary) from SP -> CalDAV server

### DIFF
--- a/docs/caldav.md
+++ b/docs/caldav.md
@@ -1,33 +1,35 @@
 # CalDAV Features and Roadmap
 
 ## Overview
+
 Super Productivity offers basic CalDAV integration for importing and syncing tasks. This document outlines the current capabilities and limitations of the integration. If you're a developer and would like to improve the integration help would be very welcome.
 
 ## Feature Support Matrix
 
-| Feature | Import | Sync SP → CalDAV | Sync CalDAV → SP |
-|---------|---------|------------------|------------------|
-| Title | ✅ | ❌ | ❌ |
-| Description | ✅ | ❌ | ❌ |
-| Tags | ✅ | ❌ | ❌ |
-| Complete/Incomplete Status | ✅ | ✅* | ❌ |
-| New Tasks | ✅ | ❌ [^3017] | ✅* |
-| Subtasks | ✅ [^2876] | ❌ | ❌ |
-| Deleted Tasks | ❌ | ❌ | ❌ [^2915]|
-| Start Date | ❌ | ❌ | ❌ |
-| Due Date | ❌ | ❌ | ❌ |
-| Attachments | ❌ | ❌ | ❌ |
-| Recurrence Rules | ❌ | ❌ | ❌ |
-| Created Time | ❌ | ❌ | ❌ |
-| Last Modified Time | ❌ | ❌ | ❌ |
-| Status (Needs Action, In Progress, Cancelled) | ❌ | ❌ | ❌ |
-| Priority | ❌ | ❌ | ❌ |
+| Feature                                       | Import     | Sync SP → CalDAV | Sync CalDAV → SP |
+| --------------------------------------------- | ---------- | ---------------- | ---------------- |
+| Title                                         | ✅         | ✅               | ❌               |
+| Description                                   | ✅         | ❌               | ❌               |
+| Tags                                          | ✅         | ❌               | ❌               |
+| Complete/Incomplete Status                    | ✅         | ✅\*             | ❌               |
+| New Tasks                                     | ✅         | ❌ [^3017]       | ✅\*             |
+| Subtasks                                      | ✅ [^2876] | ❌               | ❌               |
+| Deleted Tasks                                 | ❌         | ❌               | ❌ [^2915]       |
+| Start Date                                    | ❌         | ❌               | ❌               |
+| Due Date                                      | ❌         | ❌               | ❌               |
+| Attachments                                   | ❌         | ❌               | ❌               |
+| Recurrence Rules                              | ❌         | ❌               | ❌               |
+| Created Time                                  | ❌         | ❌               | ❌               |
+| Last Modified Time                            | ❌         | ❌               | ❌               |
+| Status (Needs Action, In Progress, Cancelled) | ❌         | ❌               | ❌               |
+| Priority                                      | ❌         | ❌               | ❌               |
 
-*Requires enabling in advanced configuration
+\*Requires enabling in advanced configuration
 
 ## Current Features
 
 ### Advanced Config Options
+
 - Auto import to Default Project (configurable per calendar)
 - Poll imported for changes and notify (only supports new tasks, see above table)
 - Automatically complete CalDAV todos on task completion
@@ -35,16 +37,20 @@ Super Productivity offers basic CalDAV integration for importing and syncing tas
 ## Limitations
 
 ### Configuration Restrictions
+
 - Each CalDAV calendar/list requires a separate configuration
 - Cannot import from multiple calendars with a single configuration
 
 ## Future Development
 
 ### Note on Integration Roadmap
+
 As [stated](https://github.com/johannesjo/super-productivity/issues/3017#issuecomment-2577469193) by the repository maintainer in Jan 2025:
+
 > "It's important to understand that this will always be limited since CalDAV is likely not completely mappable to the model of Super Productivity. First step for this would be a feasibility analysis to check what parts of the model can be mapped and which not. Next step would be making a concept how this all could work."
 
 ### Developer Contributions Welcome
+
 If you have experience with CalDAV development and are interested in improving this integration, your help would be greatly appreciated. Key areas that need attention include:
 
 - Feasibility analysis of CalDAV-to-SP model mapping
@@ -54,6 +60,9 @@ If you have experience with CalDAV development and are interested in improving t
 Feel free to reach out if you'd like to contribute.
 
 ## Related Issues
+
 [^2876]: [Import Multilevel Subtasks from CalDAV](https://github.com/johannesjo/super-productivity/issues/2876)
+
 [^2915]: [CalDav task status and deleted tasks are not updated](https://github.com/johannesjo/super-productivity/issues/2915)
+
 [^3017]: [Unable to upload new local tasks to CalDav](https://github.com/johannesjo/super-productivity/issues/3017)

--- a/src/app/features/issue/providers/caldav/caldav-issue/caldav-issue.effects.ts
+++ b/src/app/features/issue/providers/caldav/caldav-issue/caldav-issue.effects.ts
@@ -26,7 +26,9 @@ export class CaldavIssueEffects {
     () =>
       this._actions$.pipe(
         ofType(updateTask),
-        filter(({ task }): boolean => 'isDone' in task.changes),
+        filter(
+          ({ task }): boolean => 'isDone' in task.changes || 'title' in task.changes,
+        ),
         concatMap(({ task }) => this._taskService.getByIdOnce$(task.id.toString())),
         filter((task: Task) => task && task.issueType === CALDAV_TYPE),
         concatMap((task: Task) => {
@@ -50,7 +52,7 @@ export class CaldavIssueEffects {
 
   private _handleTransitionForIssue$(caldavCfg: CaldavCfg, task: Task): Observable<any> {
     return this._caldavClientService
-      .updateCompletedState$(caldavCfg, assertTruthy(task.issueId), task.isDone)
+      .updateState$(caldavCfg, assertTruthy(task.issueId), task.isDone, task.title)
       .pipe(concatMap(() => this._issueService.refreshIssueTask(task, true)));
   }
 }


### PR DESCRIPTION
# Description

Have a task that was imported from CalDAV?
Now, when you update the title/summary it'll be pushed to the CalDAV server.

This is a basic draft for the PR. Looking to hear if there's any feedback.
The codebase has quite a lot going on so I'm not sure if I'm breaking any conventions.
Look forward to hearing more!

PS: I only changed the one line of the table in the readme but the linter changed the rest. Let me know if that needs to be pulled into a separate PR.

## Issues Resolved

Closes #3886

## Check List

- [ ] New functionality includes testing.
  - I don't see any testing infra setup for CalDAV and I'm not so familiar with the tooling so pointers would be appreciated.
- [x] New functionality has been documented in the README if applicable.
