### PR TITLE
feat(ui): add keyboard navigation for confirmation dialog box focusin…

### DIFF
--- a/src/app/ui/dialog-confirm/dialog-confirm.component.html
+++ b/src/app/ui/dialog-confirm/dialog-confirm.component.html
@@ -9,10 +9,12 @@
   <div class="wrap-buttons">
     <button
       tabindex="1"
+      #cancelButton
       (click)="close(false)"
       class="btn btn-primary"
       mat-button
       type="button"
+      (keydown.ArrowRight)="focusNextButton(confirmButton)"
     >
       <mat-icon>close</mat-icon>
       {{(data.cancelTxt || T.G.CANCEL)|translate}}
@@ -20,12 +22,14 @@
 
     <button
       tabindex="2"
+      #confirmButton
       (click)="close(true)"
       e2e="confirmBtn"
       class="btn btn-primary submit-button"
       color="primary"
       type="button"
       mat-stroked-button
+      (keydown.ArrowLeft)="focusNextButton(cancelButton)"
     >
       <mat-icon>check</mat-icon>
       {{(data.okTxt || T.G.OK)|translate}}

--- a/src/app/ui/dialog-confirm/dialog-confirm.component.ts
+++ b/src/app/ui/dialog-confirm/dialog-confirm.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, ViewChild } from '@angular/core';
 import {
   MAT_DIALOG_DATA,
   MatDialogActions,
@@ -18,6 +18,8 @@ import { TranslatePipe } from '@ngx-translate/core';
   imports: [MatDialogContent, MatDialogActions, MatButton, MatIcon, TranslatePipe],
 })
 export class DialogConfirmComponent {
+  @ViewChild('cancelButton', { read: MatButton }) cancelButton!: MatButton;
+  @ViewChild('confirmButton', { read: MatButton }) confirmButton!: MatButton;
   private _matDialogRef = inject<MatDialogRef<DialogConfirmComponent>>(MatDialogRef);
   data = inject(MAT_DIALOG_DATA);
 
@@ -25,5 +27,12 @@ export class DialogConfirmComponent {
 
   close(res: any): void {
     this._matDialogRef.close(res);
+  }
+
+  focusNextButton(nextButton: MatButton): void {
+    const buttonElement = nextButton._elementRef.nativeElement;
+    if (buttonElement) {
+      buttonElement.focus();
+    }
   }
 }


### PR DESCRIPTION
…g the next button with left,right arrow keys

# Description

Implemented functionality to focus the next button  in dialog box when the right arrow or left arrow key is pressed.

![chrome-capture-2025-1-19](https://github.com/user-attachments/assets/bf58d2d4-670e-4592-b38d-d0654b8c7584)


## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
