### PR TITLE
Prevent page from closing when pressing back in task detail panel

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -9,6 +9,7 @@ import {
   input,
   LOCALE_ID,
   OnDestroy,
+  OnInit,
   viewChild,
   viewChildren,
 } from '@angular/core';
@@ -124,7 +125,7 @@ interface IssueDataAndType {
     IssueIconPipe,
   ],
 })
-export class TaskDetailPanelComponent implements AfterViewInit, OnDestroy {
+export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestroy {
   attachmentService = inject(TaskAttachmentService);
   taskService = inject(TaskService);
   layoutService = inject(LayoutService);
@@ -403,6 +404,14 @@ export class TaskDetailPanelComponent implements AfterViewInit, OnDestroy {
     this.isDragOver = false;
   }
 
+  @HostListener('window:popstate') onBack(): void {
+    this.collapseParent();
+  }
+
+  ngOnInit(): void {
+    window.history.pushState({ taskDetailPanel: true }, '');
+  }
+
   ngAfterViewInit(): void {
     this.taskService.taskDetailPanelTargetPanel$
       .pipe(
@@ -429,6 +438,10 @@ export class TaskDetailPanelComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (window.history.state.taskDetailPanel) {
+      window.history.back();
+    }
+
     this._onDestroy$.next();
     this._onDestroy$.complete();
     window.clearTimeout(this._focusTimeout);


### PR DESCRIPTION
# Description

Prevents page from changing or app from closing upon pressing the back button (in android or with a mouse). This is done by using `window.history` to keep the panel as another history state. When the panel is destroyed, the history entry is deleted. And when going back in history is attempted, the panel closes itself.

## Issues Resolved

#3607

## Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
