### PR TITLE
fix: gitlab issue tracking submit dialog opening #3902

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-issue/gitlab-issue.effects.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-issue/gitlab-issue.effects.ts
@@ -1,6 +1,71 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { first } from 'rxjs/operators';
+import { GITLAB_TYPE } from '../../../issue.const';
+import { IssueProviderService } from '../../../issue-provider.service';
+import { TaskCopy } from '../../../../tasks/task.model';
+import { DialogGitlabSubmitWorklogForDayComponent } from '../dialog-gitlab-submit-worklog-for-day/dialog-gitlab-submit-worklog-for-day.component';
+import { BeforeFinishDayService } from '../../../../before-finish-day/before-finish-day.service';
+import { WorkContextService } from '../../../../work-context/work-context.service';
 
 @Injectable()
 export class GitlabIssueEffects {
-  constructor() {}
+  private readonly _matDialog = inject(MatDialog);
+  private readonly _beforeFinishDayService = inject(BeforeFinishDayService);
+  private readonly _workContextService = inject(WorkContextService);
+  private readonly _issueProviderService = inject(IssueProviderService);
+
+  constructor() {
+    this._beforeFinishDayService.addAction(async () => {
+      const tasksForCurrentList =
+        await this._workContextService.allTasksForCurrentContext$
+          .pipe(first())
+          .toPromise();
+      const gitlabTasks = tasksForCurrentList.filter((t) => t.issueType === GITLAB_TYPE);
+      if (gitlabTasks.length > 0) {
+        // sort gitlab tasks by issueProviderId
+        const gitlabTasksByIssueProviderId: { [key: string]: TaskCopy[] } =
+          gitlabTasks.reduce(
+            (acc, task) => {
+              if (typeof task.issueProviderId === 'string') {
+                acc[task.issueProviderId] = acc[task.issueProviderId] || [];
+                acc[task.issueProviderId].push(task);
+              }
+              return acc;
+            },
+            {} as { [key: string]: TaskCopy[] },
+          );
+        await Promise.all(
+          Object.keys(gitlabTasksByIssueProviderId).map(async (issueProviderId) => {
+            const tasksForIssueProvider = gitlabTasksByIssueProviderId[issueProviderId];
+            const gitlabCfgForProvider = await this._issueProviderService
+              .getCfgOnce$(issueProviderId, 'GITLAB')
+              .pipe(first())
+              .toPromise();
+            if (
+              gitlabCfgForProvider &&
+              gitlabCfgForProvider.isEnabled &&
+              gitlabCfgForProvider.isEnableTimeTracking
+            ) {
+              await this._matDialog
+                .open(DialogGitlabSubmitWorklogForDayComponent, {
+                  restoreFocus: true,
+                  disableClose: true,
+                  closeOnNavigation: false,
+                  data: {
+                    gitlabCfg: gitlabCfgForProvider,
+                    issueProviderId,
+                    tasksForIssueProvider,
+                  },
+                })
+                .afterClosed()
+                .toPromise();
+            }
+          }),
+        );
+      }
+
+      return 'SUCCESS';
+    });
+  }
 }


### PR DESCRIPTION
# Description

Fix for the gitlab dialog not opening on finished day. Removed code from https://github.com/johannesjo/super-productivity/commit/d524b8f3b36a4ba07acdcd2d60c53700b499e712#diff-f6deb54e22b334f31e4f46c15d7da12badc57ba085ce01a24f505d4dc58d5ec8 added to the constructor of `src/app/features/issue/providers/gitlab/gitlab-issue/gitlab-issue.effects.ts`.

## Issues Resolved

#3902 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
