### PR TITLE
add flathub package to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@
 </p>
 
 <p align="center" style="text-align: center;">
-<a href="https://snapcraft.io/superproductivity"        target="_blank">
+  
+<a href='https://flathub.org/apps/com.super_productivity.SuperProductivity' target="_blank">
+  <img alt='Get it on Flathub'
+       src='https://flathub.org/api/badge?locale=en'
+       align="center"
+       height="50" />
+  </a>
+  
+<a href="https://snapcraft.io/superproductivity" target="_blank">
   <img alt="Get it from the Snap Store"
        src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg"
        align="center"


### PR DESCRIPTION
# Description

Hi, I would appreciate if we can include the flathub package near the top of the readme, I personally did not know the flathub package was supported until a few days ago because i did not see it listed there and didn't scroll down.

## Issues Resolved

> List any existing issues this PR resolves

I was not able to find any issues regarding this.

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
