### PR TITLE
feat: handle tasks scheduled without a specific time

### DIFF
--- a/src/app/features/tasks/add-task-bar/short-syntax-to-tags.ts
+++ b/src/app/features/tasks/add-task-bar/short-syntax-to-tags.ts
@@ -108,7 +108,7 @@ export const shortSyntaxToTags = ({
       ];
       displayedDayStr = `${weekdays[plannedDate.getDay()]}`;
     }
-    const displayedDateStr = `${displayedDayStr} ${displayedTimeStr}`;
+    const displayedDateStr = `${displayedDayStr}${r.taskChanges?.hasPlannedTime === false ? '' : '' + displayedTimeStr}`;
     shortSyntaxTags.push({
       title: displayedDateStr,
       color: defaultColor,

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -273,14 +273,13 @@ const parseScheduledDate = (task: Partial<TaskCopy>, now: Date): DueChanges => {
     if (parsedDateArr.length) {
       const parsedDateResult = parsedDateArr[0];
       const start = parsedDateResult.start;
-      let plannedAt = start.date().getTime();
+      const plannedAt = start.date().getTime();
       let hasPlannedTime = true;
       // If user doesn't explicitly enter time, set the scheduled date
       // to 9:00:00 of the given day
 
       if (!start.isCertain('hour')) {
         hasPlannedTime = false;
-        plannedAt = start.date().setHours(9, 0, 0, 0);
       }
       const inputDate = parsedDateResult.text;
       return {

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -274,10 +274,12 @@ const parseScheduledDate = (task: Partial<TaskCopy>, now: Date): DueChanges => {
       const parsedDateResult = parsedDateArr[0];
       const start = parsedDateResult.start;
       let plannedAt = start.date().getTime();
+      let hasPlannedTime = true;
       // If user doesn't explicitly enter time, set the scheduled date
       // to 9:00:00 of the given day
 
       if (!start.isCertain('hour')) {
+        hasPlannedTime = false;
         plannedAt = start.date().setHours(9, 0, 0, 0);
       }
       const inputDate = parsedDateResult.text;
@@ -285,6 +287,7 @@ const parseScheduledDate = (task: Partial<TaskCopy>, now: Date): DueChanges => {
         plannedAt,
         // Strip out the short syntax for scheduled date and given date
         title: task.title.replace(`@${inputDate}`, ''),
+        ...(hasPlannedTime ? {} : { hasPlannedTime: false }),
       };
     }
 

--- a/src/app/features/tasks/task.model.ts
+++ b/src/app/features/tasks/task.model.ts
@@ -77,6 +77,7 @@ export interface TaskCopy extends IssueFieldsForTask {
   isDone: boolean;
   doneOn?: number;
   plannedAt?: number;
+  hasPlannedTime?: boolean;
   // remindCfg: TaskReminderOptionId;
 
   notes: string;


### PR DESCRIPTION
# Description

With this PR, when a user schedules a task with short syntax but doesn't give a specific time, the task will simply be planned for the day, without any time attached.

Under the hood, scheduled tasks without a specific time will dispatch [`planTaskForDay`](https://github.com/johannesjo/super-productivity/blob/master/src/app/features/planner/store/planner.actions.ts) action. This is in contrast to scheduled tasks with a specific time which will trigger [`scheduleTask`](https://github.com/johannesjo/super-productivity/blob/master/src/app/features/tasks/store/task.actions.ts) action.

Visually, the task scheduled without time will be located at the top, underneath the relevant day column in the Planner view.

![Screenshot from 2025-03-08 16-08-01](https://github.com/user-attachments/assets/91b7e5cd-5a4f-4c90-9d92-d3a591ba5fa0)


## Issues Resolved

List any existing issues this PR resolves: #4049 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
