### PR TITLE
fix: wrong hint for reschedule button

### DIFF
--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
@@ -80,7 +80,7 @@
       tabindex="0"
       [matTooltip]="
         (task.reminderId
-          ? T.F.TASK.CMP.EDIT_SCHEDULED
+          ? (T.F.TASK.CMP.EDIT_SCHEDULED | translate)
           : (T.F.TASK.CMP.SCHEDULE | translate)) +
         (kb.taskSchedule ? ' [' + kb.taskSchedule + ']' : '')
       "


### PR DESCRIPTION
# Description

Fixes the wrong hint for the rescheduling button. Example of the current wrong behavior:

![image](https://github.com/user-attachments/assets/93bf59ab-4f48-41fe-9a08-aff43e5b478c)


## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/4024

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
