### PR TITLE
Add apk releases for github

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -25,6 +25,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       #      - name: Build with Gradle
       #        run: ./gradlew build
+      - name: Setup android-sdk
+        uses: android-actions/setup-android@v3
+        with:
+          accept-android-sdk-licenses: true
+          log-accepted-android-sdk-licenses: true #make accepting the android sdk license verbose
 
       - name: Get npm cache directory
         id: npm-cache-dir

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,14 +1,14 @@
 name: Create android Play Store APK
 on:
   push:
-    branches: [test/git-actions]
+    branches: [master, release/*, test/git-actions]
     tags:
       - v*
   workflow_dispatch:
     inputs: {}
 
 jobs:
-  build:
+  build-android:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
        alt='F-Droid Badge'
        height="50" />
 </a>
-<a href='http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/fork-maintainers/iceraven-browser/releases'>
+<a href='http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/johannesjo/super-productivity/releases'>
   <img src='https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png'
        align="center"
        alt='Obtanium Badge'

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@
        alt='F-Droid Badge'
        height="50" />
 </a>
+<a href='http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/fork-maintainers/iceraven-browser/releases'
+  <img src='https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png'
+       align="center"
+       alt='Obtanium Badge'
+       height="50" />
+</a>
 </p>
 
 <br>

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
        alt='F-Droid Badge'
        height="50" />
 </a>
-<a href='http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/fork-maintainers/iceraven-browser/releases'
+<a href='http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/fork-maintainers/iceraven-browser/releases'>
   <img src='https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png'
        align="center"
        alt='Obtanium Badge'


### PR DESCRIPTION
# Description

improves the pipeline responsible for building and releasing a apk release for github actions 
- adds the obtanium badge
- fixes the build-android pipeline and change the run triggers
- adds the dependency for [android-actions/setup-android@v3](https://github.com/android-actions/setup-android)

IMPORTANT: this forces the CI to accept the android sdk license in order to work - this has been highlighted in the action file and the most verbose version for the license acceptance has beed selected for transparency 

## Issues Resolved

resolves #3596

## Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
