### PR TITLE
#4046: Mulitple Same Name Tags being created.

### DIFF
--- a/e2e/commands/addTaskWithRepeatedTags.ts
+++ b/e2e/commands/addTaskWithRepeatedTags.ts
@@ -1,0 +1,19 @@
+import { NightwatchAPI } from 'nightwatch';
+import { cssSelectors } from '../e2e.const';
+
+const { ADD_TASK_GLOBAL_SEL, ROUTER_WRAPPER, TAGS } = cssSelectors;
+const CONFIRMATION_DIALOG = 'dialog-confirm';
+const TAG = `${TAGS} div.tag`;
+
+module.exports = {
+  async command(this: NightwatchAPI, tagTitle: string) {
+    return this.waitForElementVisible(ROUTER_WRAPPER)
+      .setValue('body', 'A')
+      .waitForElementVisible(ADD_TASK_GLOBAL_SEL)
+      .setValue(ADD_TASK_GLOBAL_SEL, `Test creating new tag #${tagTitle} #${tagTitle}`)
+      .setValue(ADD_TASK_GLOBAL_SEL, this.Keys.ENTER)
+      .waitForElementVisible(CONFIRMATION_DIALOG)
+      .click('mat-dialog-actions button.mat-primary')
+      .waitForElementVisible(TAG);
+  },
+};

--- a/e2e/n-browser-interface.ts
+++ b/e2e/n-browser-interface.ts
@@ -9,6 +9,7 @@ export interface AddTaskWithReminderParams {
 export interface NBrowser extends NightwatchAPI {
   addTask: (taskTitle: string, isSkipClose?: boolean) => NBrowser;
   addTaskWithNewTag: (tagName: string) => NBrowser;
+  addTaskWithRepeatedTags: (tagName: string) => NBrowser;
   addNote: (noteTitle: string) => NBrowser;
   draftTask: (taskTitle: string) => NBrowser;
   goToDefaultProject: () => NBrowser;

--- a/e2e/src/short-syntax.e2e.ts
+++ b/e2e/src/short-syntax.e2e.ts
@@ -1,22 +1,58 @@
-import { BASE } from '../e2e.const';
 import { NBrowser } from '../n-browser-interface';
-/* eslint-disable @typescript-eslint/naming-convention */
+import { cssSelectors, WORK_VIEW_URL, BASE } from '../e2e.const';
 
+const { READY_TO_WORK_BTN } = cssSelectors;
+const CONFIRM_CREATE_TAG_BTN = `dialog-confirm button[e2e="confirmBtn"]`;
+const BASIC_TAG_TITLE = 'task tag-list tag:last-of-type .tag-title';
+const TASK_TAG_SELECTOR = 'task tag-list tag';
 const TASK = 'task';
 const TASK_TAGS = 'task tag';
-const WORK_VIEW_URL = `${BASE}/`;
-const READY_TO_WORK_BTN = '.ready-to-work-btn';
+const WORK_VIEW_URL_FULL = `${BASE}/`;
 
 module.exports = {
-  '@tags': ['work-view', 'task', 'short-syntax'],
+  '@tags': ['task', 'short-syntax', 'autocomplete', 'work-view'],
 
   'should add task with project via short syntax': (browser: NBrowser) =>
     browser
-      .loadAppAndClickAwayWelcomeDialog(WORK_VIEW_URL)
+      .loadAppAndClickAwayWelcomeDialog(WORK_VIEW_URL_FULL)
       .waitForElementVisible(READY_TO_WORK_BTN)
       .addTask('0 test task koko +i')
       .waitForElementVisible(TASK)
       .assert.visible(TASK)
       .assert.containsText(TASK_TAGS, 'Inbox')
       .end(),
+
+  'should add a task with repeated tags but only append one instance': (
+    browser: NBrowser,
+  ) => {
+    browser
+      .loadAppAndClickAwayWelcomeDialog(WORK_VIEW_URL)
+      .waitForElementVisible(READY_TO_WORK_BTN)
+
+      .addTaskWithRepeatedTags('some task <3 #duplicateTag')
+      .waitForElementPresent(CONFIRM_CREATE_TAG_BTN)
+      .click(CONFIRM_CREATE_TAG_BTN)
+      .waitForElementPresent(BASIC_TAG_TITLE)
+
+      // Ensure the tag is present
+      .assert.elementPresent(BASIC_TAG_TITLE)
+      .assert.textContains(BASIC_TAG_TITLE, 'duplicateTag')
+
+      // Verify that only one tag is appended
+      .elements(`css selector`, `${TASK}:last-of-type ${TASK_TAG_SELECTOR}`, (result) => {
+        if (Array.isArray(result.value)) {
+          console.log('Number of tags found for this task:', result.value.length);
+          // Assert that only one tag is appended to this task
+          browser.assert.strictEqual(
+            result.value.length,
+            1,
+            `Expected 1 tag for this task, but found ${result.value.length}`,
+          );
+        } else {
+          console.error('Unexpected result format:', result.value);
+          browser.assert.fail('Failed to retrieve elements correctly');
+        }
+      })
+      .end();
+  },
 };

--- a/src/app/features/tasks/store/short-syntax.effects.ts
+++ b/src/app/features/tasks/store/short-syntax.effects.ts
@@ -196,21 +196,24 @@ export class ShortSyntaxEffects {
       // needed cause otherwise task gets the focus after blur & hide
       tap((v) => this._layoutService.hideAddTaskBar()),
       concatMap(({ taskId, newTitles }) => {
+        //Making sure the user isnt trying to create two tags with the same name
+        const uniqueNewTitles = [...new Set(newTitles)];
+
         return this._matDialog
           .open(DialogConfirmComponent, {
             restoreFocus: true,
             autoFocus: true,
             data: {
               okTxt:
-                newTitles.length > 1
+                uniqueNewTitles.length > 1
                   ? T.F.TASK.D_CONFIRM_SHORT_SYNTAX_NEW_TAGS.OK
                   : T.F.TASK.D_CONFIRM_SHORT_SYNTAX_NEW_TAG.OK,
               message:
-                newTitles.length > 1
+                uniqueNewTitles.length > 1
                   ? T.F.TASK.D_CONFIRM_SHORT_SYNTAX_NEW_TAGS.MSG
                   : T.F.TASK.D_CONFIRM_SHORT_SYNTAX_NEW_TAG.MSG,
               translateParams: {
-                tagsTxt: `<strong>${newTitles.join(', ')}</strong>`,
+                tagsTxt: `<strong>${uniqueNewTitles.join(', ')}</strong>`,
               },
             },
           })
@@ -222,7 +225,7 @@ export class ShortSyntaxEffects {
               const actions: any[] = [];
               if (isConfirm) {
                 const newTagIds = [...task.tagIds];
-                newTitles.forEach((newTagTitle) => {
+                uniqueNewTitles.forEach((newTagTitle) => {
                   const { action, id } = this._tagService.getAddTagActionAndId({
                     title: newTagTitle,
                   });


### PR DESCRIPTION
When you create a new task you are able to use the pound sign to assign it tags, and if the tag dosent exist it creates it. There was an error in the parsing of the information you get from the user that allowed the user to utilize this method to create multiple tags with the same name, which was not what was intended

# Description

No functional changes. Changed uniqueness in short-syntax for the user input in creating tags

## Issues Resolved

User cannot create duplicate tags through task creation
