### PR TITLE
Fix #4130: shift+t to add subtasks to today

### DIFF
--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -739,7 +739,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
 
   moveToToday(): void {
     const t = this.task();
-    if (t.projectId && !t.parentId) {
+    if (t.projectId) {
       this._projectService.moveTaskToTodayList(t.id, t.projectId);
       this.addToMyDay();
     }
@@ -899,13 +899,11 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
 
     if (checkKeyCombo(ev, keys.moveToTodaysTasks) && t.projectId) {
-      if (!t.parentId) {
-        ev.preventDefault();
-        // same default shortcut as schedule so we stop propagation
-        ev.stopPropagation();
-        this.focusNext(true, true);
-        this.moveToToday();
-      }
+      ev.preventDefault();
+      // same default shortcut as schedule so we stop propagation
+      ev.stopPropagation();
+      this.focusNext(true, true);
+      this.moveToToday();
     }
 
     // collapse sub tasks


### PR DESCRIPTION
# Description

Pressing shift+T while a subtask is highlighted should schedule it for today

## Issue Resolved

#4130

## Check List

- Removed parentId check in moveToToday() method to allow subtasks to be moved to today
- Removed parentId check in keyboard shortcut handler for moveToTodaysTasks
- Maintains existing behavior for regular tasks while extending functionality to subtasks
