### PR TITLE
Fix #4083 (tasks): resolve tag removal issue

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -489,6 +489,82 @@ describe('shortSyntax', () => {
 
       expect(r).toEqual(undefined);
     });
+
+    it('should remove tag from title if task already has tag', () => {
+      const t = {
+        ...TASK,
+        title: 'Test tag #testing',
+        tagIds: ['testing_id'],
+      };
+      const r = shortSyntax(t, CONFIG, [
+        ...ALL_TAGS,
+        { ...DEFAULT_TAG, id: 'testing_id', title: 'testing' },
+      ]);
+
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: undefined,
+        taskChanges: {
+          title: 'Test tag',
+        },
+      });
+    });
+
+    it('should create new tag and remove both from title if task already has one given tag', () => {
+      const t = {
+        ...TASK,
+        title: 'Test tag #testing #blu',
+        tagIds: ['blu_id'],
+      };
+      const r = shortSyntax(t, CONFIG, [
+        ...ALL_TAGS,
+        { ...DEFAULT_TAG, id: 'blu_id', title: 'blu' },
+      ]);
+
+      expect(r).toEqual({
+        newTagTitles: ['testing'],
+        remindAt: null,
+        projectId: undefined,
+        taskChanges: {
+          title: 'Test tag',
+        },
+      });
+    });
+
+    it('should add existing tag and remove both from title if task already has one given tag', () => {
+      const t = {
+        ...TASK,
+        title: 'Test tag #testing #blu',
+        tagIds: ['blu_id'],
+      };
+      const r = shortSyntax(t, CONFIG, [
+        ...ALL_TAGS,
+        { ...DEFAULT_TAG, id: 'blu_id', title: 'blu' },
+        { ...DEFAULT_TAG, id: 'testing_id', title: 'testing' },
+      ]);
+
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: undefined,
+        taskChanges: {
+          title: 'Test tag',
+          tagIds: ['blu_id', 'testing_id'],
+        },
+      });
+    });
+
+    it('should not remove tag from title if task already has tag when disabled', () => {
+      const t = {
+        ...TASK,
+        title: 'Test tag #testing',
+        tagIds: ['testing_id'],
+      };
+      const r = shortSyntax(t, { ...CONFIG, isEnableTag: false }, ALL_TAGS);
+
+      expect(r).toEqual(undefined);
+    });
   });
   describe('should work with tags and time estimates combined', () => {
     it('tag before time estimate', () => {

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -235,7 +235,11 @@ const parseTagChanges = (task: Partial<TaskCopy>, allTags?: Tag[]): TagChanges =
         taskChanges.tagIds = [...(task.tagIds as string[]), ...tagIdsToAdd];
       }
 
-      if (newTagTitlesToCreate.length || tagIdsToAdd.length) {
+      if (
+        newTagTitlesToCreate.length ||
+        tagIdsToAdd.length ||
+        regexTagTitlesTrimmedAndFiltered.length
+      ) {
         taskChanges.title = initialTitle;
         regexTagTitlesTrimmedAndFiltered.forEach((tagTitle) => {
           taskChanges.title = taskChanges.title?.replace(`#${tagTitle}`, '');


### PR DESCRIPTION
#4083
Fix issue where tags were not removed from the task title correctly.

# Description

This PR fixes an issue where tags were not properly removed from the task title when they were already assigned to the task. Previously, tasks that had tags both in the title (`#tag`) and in the `tagIds` field were not processed correctly, leading to incorrect title formatting.

## Changes

- Previously, only newly added tags were removed from the title. The logic in short-syntax.ts has been updated to ensure all existing tags in the title are removed correctly. Now, if a task is created with a tag matching the current view, it will be automatically removed from the title.

- Added unit tests in `short-syntax.spec.ts` to confirm the fix.