### PR TITLE
Fix #4184: Added fractional time parsing when creating a new task

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -171,6 +171,44 @@ describe('shortSyntax', () => {
       });
     });
 
+    it('', () => {
+      const t = {
+        ...TASK,
+        title: 'Fun title whatever 1.5h',
+      };
+      const r = shortSyntax(t, CONFIG);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: undefined,
+        taskChanges: {
+          title: 'Fun title whatever',
+          timeEstimate: 5400000,
+        },
+      });
+    });
+
+    it('', () => {
+      const t = {
+        ...TASK,
+        title: 'Fun title whatever 1.5h/2.5h',
+      };
+      const r = shortSyntax(t, CONFIG);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: undefined,
+        taskChanges: {
+          title: 'Fun title whatever',
+          // timeSpent: 7200000,
+          timeSpentOnDay: {
+            [getWorklogStr()]: 5400000,
+          },
+          timeEstimate: 9000000,
+        },
+      });
+    });
+
     it('should ignore time short syntax when disabled', () => {
       const t = {
         ...TASK,

--- a/src/app/ui/duration/string-to-ms.pipe.ts
+++ b/src/app/ui/duration/string-to-ms.pipe.ts
@@ -5,6 +5,24 @@ export const stringToMs = (strValue: string, args?: any): number => {
     return 0;
   }
 
+  // First try to parse simple formats like "1.5h", "30m", etc.
+  const simpleFormatMatch = strValue.trim().match(/^([0-9]*\.?[0-9]+)([smhd])$/i);
+  if (simpleFormatMatch) {
+    const amount = parseFloat(simpleFormatMatch[1]);
+    const unit = simpleFormatMatch[2].toLowerCase();
+
+    switch (unit) {
+      case 's':
+        return amount * 1000;
+      case 'm':
+        return amount * 1000 * 60;
+      case 'h':
+        return amount * 1000 * 60 * 60;
+      case 'd':
+        return amount * 1000 * 60 * 60 * 24;
+    }
+  }
+
   let d: number | undefined;
   let h: number | undefined;
   let m: number | undefined;


### PR DESCRIPTION
# Description

 Fixed the issue #4184 where you could not insert 1.5h or any decimal value when inputing time stamp in the quick add method of creating a task. To test execute project with instructions given in the repository and add a new task (shift+A) and write the title of a new task such as "task 1.5h" or "task 1.5h/3.5h". Also added test cases for this fix.

## Check List

- [✅] New functionality includes testing.
- [❌] New functionality has been documented in the README if applicable.
