### PR TITLE
fix: Import fails when weekdays not defined

### DIFF
--- a/src/app/core/data-repair/data-repair.util.ts
+++ b/src/app/core/data-repair/data-repair.util.ts
@@ -62,9 +62,26 @@ export const dataRepair = (data: AppDataCompleteNew): AppDataCompleteNew => {
   dataOut = _addTodayTagIfNoProjectIdOrTagId(dataOut);
   dataOut = _removeDuplicatesFromArchive(dataOut);
   dataOut = _removeMissingReminderIds(dataOut);
+  dataOut = _fixTaskRepeatMissingWeekday(dataOut);
 
   // console.timeEnd('dataRepair');
   return dataOut;
+};
+
+const _fixTaskRepeatMissingWeekday = (data: AppDataCompleteNew): AppDataCompleteNew => {
+  if (data.taskRepeatCfg && data.taskRepeatCfg.entities) {
+    Object.keys(data.taskRepeatCfg.entities).forEach((key) => {
+      const cfg = data.taskRepeatCfg.entities[key] as TaskRepeatCfgCopy;
+      cfg.monday = true;
+      cfg.tuesday = true;
+      cfg.wednesday = true;
+      cfg.thursday = true;
+      cfg.friday = true;
+      cfg.saturday = true;
+      cfg.sunday = true;
+    });
+  }
+  return data;
 };
 
 const _fixEntityStates = (data: AppDataCompleteNew): AppDataCompleteNew => {

--- a/src/app/core/data-repair/data-repair.util.ts
+++ b/src/app/core/data-repair/data-repair.util.ts
@@ -72,13 +72,13 @@ const _fixTaskRepeatMissingWeekday = (data: AppDataCompleteNew): AppDataComplete
   if (data.taskRepeatCfg && data.taskRepeatCfg.entities) {
     Object.keys(data.taskRepeatCfg.entities).forEach((key) => {
       const cfg = data.taskRepeatCfg.entities[key] as TaskRepeatCfgCopy;
-      cfg.monday = true;
-      cfg.tuesday = true;
-      cfg.wednesday = true;
-      cfg.thursday = true;
-      cfg.friday = true;
-      cfg.saturday = true;
-      cfg.sunday = true;
+      cfg.monday = cfg.monday ?? true;
+      cfg.tuesday = cfg.tuesday ?? true;
+      cfg.wednesday = cfg.wednesday ?? true;
+      cfg.thursday = cfg.thursday ?? true;
+      cfg.friday = cfg.friday ?? true;
+      cfg.saturday = cfg.saturday ?? true;
+      cfg.sunday = cfg.sunday ?? true;
     });
   }
   return data;


### PR DESCRIPTION
# Description

Fix v0 -> v2 migration where monday-sunday expects boolean but gets undefined

## Issues Resolved

- #4272

Tested a bit - don't think it'll break anything. Realized that just setting it to true will cause unintended behavior when problems aren't here, so using ?? operator whatever its called in typescript to just reuse value if it exists, only set to true if it's missing