### PR TITLE
Fix 995 define BACKUP_DIR_WINSTORE and return it for getBackupPath

### DIFF
--- a/electron/backup.ts
+++ b/electron/backup.ts
@@ -14,6 +14,7 @@ import { error, log } from 'electron-log/main';
 import { AppDataCompleteLegacy } from '../src/app/imex/sync/sync.model';
 
 export const BACKUP_DIR = path.join(app.getPath('userData'), `backups`);
+export const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace('Roaming', `Local\\Packages\\53707johannesjo.SuperProductivity_ch45amy23cdv6\\LocalCache\\Roaming`);
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function initBackupAdapter(): void {

--- a/electron/ipc-handler.ts
+++ b/electron/ipc-handler.ts
@@ -1,6 +1,6 @@
 // FRONTEND EVENTS
 // ---------------
-import { app, dialog, globalShortcut, ipcMain, IpcMainEvent, shell } from 'electron';
+import { app, dialog, globalShortcut, ipcMain, IpcMainEvent, shell, process } from 'electron';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 import { lockscreen } from './lockscreen';
 import { errorHandlerWithFrontendInform } from './error-handler-with-frontend-inform';
@@ -20,7 +20,13 @@ export const initIpcInterfaces = (): void => {
   ipcMain.handle(IPC.GET_PATH, (ev, name: string) => {
     return app.getPath(name as any);
   });
-  ipcMain.handle(IPC.GET_BACKUP_PATH, () => BACKUP_DIR);
+  ipcMain.handle(IPC.GET_BACKUP_PATH, () => {
+    if (process.windowsStore) {
+      return BACKUP_DIR_WINSTORE;
+    } else {
+      return BACKUP_DIR;
+    }
+  });
 
   // BACKEND EVENTS
   // --------------


### PR DESCRIPTION
# Description

If we are running from the Windows store, we return a modified version of BACKUP_DIR to getBackupPath which is only called for the UI in settings. We cannot change BACKUP_DIR itself as it is used for the actual backup calls. 

The logging in backup.ts was not changed. The extra const was probably not necessary but I felt it was cleaner and is available if you want to correct the logging as well.

I have never coded in JS, Node, or Electron, have no way to test this code (tested the CONST.replace syntax on w3schools). Despite Microsoft mentioning Roaming going away in Windows 11, I did an install on Windows 11 and verified that it matched Windows 10.

3h20m and it's complaining about me not taking a break.

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/995

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
