### PR TITLE
Feat #4098: Add duplicate function to boards

### DIFF
--- a/src/app/features/boards/boards.component.html
+++ b/src/app/features/boards/boards.component.html
@@ -25,8 +25,13 @@
       </ng-template>
     </mat-tab>
     <mat-menu #contextMenu="matMenu">
+      <button
+        mat-menu-item
+        (click)="duplicateBoard()"
+      >
+        Duplicate
+      </button>
       <button mat-menu-item>Rename</button>
-      <button mat-menu-item>Duplicate</button>
     </mat-menu>
   }
 

--- a/src/app/features/boards/boards.component.html
+++ b/src/app/features/boards/boards.component.html
@@ -2,11 +2,21 @@
   mat-stretch-tabs="false"
   dynamicHeight="true"
   cdkScrollable
-  (selectedIndexChange)="selectedTabIndex.set($event)"
+  (selectedIndexChange)="onTabChange($event)"
   [selectedIndex]="selectedTabIndex()"
 >
   @for (board of boards(); track board.id) {
-    <mat-tab [label]="board.title | translate">
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <span [id]="board.id">
+          {{ board.title | translate }}
+        </span>
+        <span
+          class="menu-trigger"
+          #menuTrigger="matMenuTrigger"
+          [matMenuTriggerFor]="contextMenu"
+        ></span>
+      </ng-template>
       <ng-template matTabContent>
         <board
           [boardCfg]="board"
@@ -14,6 +24,10 @@
         ></board>
       </ng-template>
     </mat-tab>
+    <mat-menu #contextMenu="matMenu">
+      <button mat-menu-item>Rename</button>
+      <button mat-menu-item>Duplicate</button>
+    </mat-menu>
   }
 
   <mat-tab>

--- a/src/app/features/boards/boards.component.ts
+++ b/src/app/features/boards/boards.component.ts
@@ -8,6 +8,7 @@ import {
   OnDestroy,
   signal,
   viewChild,
+  viewChildren,
 } from '@angular/core';
 import { MatTab, MatTabContent, MatTabGroup, MatTabLabel } from '@angular/material/tabs';
 import { Store } from '@ngrx/store';
@@ -46,6 +47,7 @@ import { DEFAULT_BOARD_CFG } from './boards.const';
 })
 export class BoardsComponent implements AfterViewInit, OnDestroy {
   readonly contextMenuTrigger = viewChild.required<MatMenuTrigger>('menuTrigger');
+  readonly contextMenuTriggers = viewChildren<MatMenuTrigger>('menuTrigger');
   store = inject(Store);
   selectedTabIndex = signal(localStorage.getItem(LS.SELECTED_BOARD) || 0);
 
@@ -101,8 +103,7 @@ export class BoardsComponent implements AfterViewInit, OnDestroy {
     const clickedTabIdx = el.id.substring(el.id.length - 1);
     if (parseInt(clickedTabIdx) == activeTabIdx) {
       // Open context menu
-      console.log('Active tab clicked');
-      this.contextMenuTrigger().openMenu();
+      this.contextMenuTriggers()[activeTabIdx].openMenu();
     }
   }
 }

--- a/src/app/features/boards/boards.component.ts
+++ b/src/app/features/boards/boards.component.ts
@@ -15,6 +15,7 @@ import { Store } from '@ngrx/store';
 import { T } from '../../t.const';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { nanoid } from 'nanoid';
 import { BoardComponent } from './board/board.component';
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { CdkDropListGroup } from '@angular/cdk/drag-drop';
@@ -24,6 +25,7 @@ import { LS } from '../../core/persistence/storage-keys.const';
 import { TranslatePipe } from '@ngx-translate/core';
 import { BoardEditComponent } from './board-edit/board-edit.component';
 import { DEFAULT_BOARD_CFG } from './boards.const';
+import { BoardsActions } from './store/boards.actions';
 
 @Component({
   selector: 'boards',
@@ -105,5 +107,27 @@ export class BoardsComponent implements AfterViewInit, OnDestroy {
       // Open context menu
       this.contextMenuTriggers()[activeTabIdx].openMenu();
     }
+  }
+
+  duplicateBoard(): void {
+    const selectedTabId = this.selectedTabIndex();
+    const boardToDuplicate = this.boards()?.[selectedTabId];
+    if (!boardToDuplicate) {
+      console.warn('No board selected to duplicate');
+      return;
+    }
+    this.store.dispatch(
+      BoardsActions.addBoard({
+        board: {
+          cols: boardToDuplicate.cols,
+          id: nanoid(),
+          panels: boardToDuplicate.panels.map((panel) => ({
+            ...panel,
+            taskIds: [],
+          })),
+          title: `${boardToDuplicate.title} (copy)`,
+        },
+      }),
+    );
   }
 }

--- a/src/app/features/boards/boards.component.ts
+++ b/src/app/features/boards/boards.component.ts
@@ -84,7 +84,6 @@ export class BoardsComponent implements AfterViewInit, OnDestroy {
   goToLastIndex(): void {
     // NOTE: since the index number does not change (the add tab index is at the same index as the newly added tab) we need to do this in two steps
     const newIndex = (this.boards()?.length || 1) - 1;
-    this.selectedTabIndex.set(newIndex + 1);
     setTimeout(() => {
       this.selectedTabIndex.set(newIndex);
     });

--- a/src/app/features/boards/boards.component.ts
+++ b/src/app/features/boards/boards.component.ts
@@ -51,6 +51,7 @@ export class BoardsComponent implements AfterViewInit, OnDestroy {
   readonly contextMenuTrigger = viewChild.required<MatMenuTrigger>('menuTrigger');
   readonly contextMenuTriggers = viewChildren<MatMenuTrigger>('menuTrigger');
   store = inject(Store);
+  elementRef = inject(ElementRef);
   selectedTabIndex = signal(localStorage.getItem(LS.SELECTED_BOARD) || 0);
 
   boards = toSignal(this.store.select(selectAllBoards));
@@ -58,7 +59,7 @@ export class BoardsComponent implements AfterViewInit, OnDestroy {
 
   DEFAULT_BOARD_CFG = DEFAULT_BOARD_CFG;
 
-  constructor(private elementRef: ElementRef) {
+  constructor() {
     effect(() => {
       localStorage.setItem(LS.SELECTED_BOARD, this.selectedTabIndex().toString());
     });


### PR DESCRIPTION
# Description

- Create `MatMenu` for each tab. The menu trigger is in an empty `<span>` element.
- Attach click event handlers to each tab. It will open the menu if the **clicked tab is the active tab**. Logic for checking it is a bit hacky because tab index update happens before the click event finishes propagation. Idea comes from [here](https://stackoverflow.com/a/50574107/12160227)
- Dispatch the action for creating a new board, passing the same `cols` and `panels parameters as the selected board. The `id` is created on the spot. The `title` parameter is as `${selectedBoard} (copy)`.

**Feature preview**

https://github.com/user-attachments/assets/5bb42028-ec22-4f6a-b331-7464ce91fbac

The newly duplicated board has a different title from the original board because that's how the latter's title was stored. I can't change its title.

## Issues Resolved
resolves #4098 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
