### PR TITLE
AUR: Use package version on download deb to avoid caching issues

### DIFF
--- a/build/linux/PKGBUILD_template
+++ b/build/linux/PKGBUILD_template
@@ -14,7 +14,7 @@ provides=("${_pkgname}")
 conflicts=("${_pkgname}"
 		   "${_pkgname}-git")
 md5sums=('SKIP')
-source=("https://github.com/johannesjo/super-productivity/releases/download/v${pkgver}/superProductivity-amd64.deb")
+source=("superproductivity-${pkgver}-amd64.deb::https://github.com/johannesjo/super-productivity/releases/download/v${pkgver}/superProductivity-amd64.deb")
 
 package() {
 	tar -xvf data.tar.xz -C "${pkgdir}"


### PR DESCRIPTION
Proposed by Dominiquini on the AUR comments section

# Description

On the PKGBUILD for AUR, it will rename the tar.gz with the version name, to avoid cache systems thinking it's the same file.

## Issues Resolved

Should fix the issue on the AUR comments section: https://aur.archlinux.org/packages/superproductivity-bin#comment-1024146

## Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
