### PR TITLE
feat: Add due date for gitlab provider

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -15,6 +15,7 @@ import {
 } from './gitlab.const';
 import { isGitlabEnabled } from './is-gitlab-enabled';
 import { IssueProviderService } from '../../issue-provider.service';
+import { getWorklogStr } from '../../../../util/get-work-log-str';
 
 @Injectable({
   providedIn: 'root',
@@ -176,6 +177,7 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
       issueLastUpdated: new Date(issue.updated_at).getTime(),
       issueId: issue.id,
       isDone: this._isIssueDone(issue),
+      dueDay: issue.due_date ? getWorklogStr(issue.due_date) : undefined,
     };
   }
 

--- a/src/app/features/issue/providers/gitlab/gitlab-issue/gitlab-issue-map.util.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-issue/gitlab-issue-map.util.ts
@@ -22,6 +22,7 @@ export const mapGitlabIssue = (
     closed_at: issue.closed_at,
     created_at: issue.created_at,
     updated_at: issue.updated_at,
+    due_date: issue.due_date,
 
     // added
     wasUpdated: false,

--- a/src/app/features/issue/providers/gitlab/gitlab-issue/gitlab-issue.model.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-issue/gitlab-issue.model.ts
@@ -30,6 +30,7 @@ export type GitlabIssue = Readonly<{
   closed_at: string;
   created_at: string;
   updated_at: string;
+  due_date?: string;
   // added
   wasUpdated: boolean;
   commentsNr: number;


### PR DESCRIPTION
# Description

Add due date from gitlab issue, in this way the planner is in sync with gitlab due dates

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
