### PR TITLE
Update node version requirement for development server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ There are several ways to help.
 
 If you don't want or cannot use Codespaces for any reason, here are the instructions for local development.
 
-To run the development server you need to have Node installed at least in the version 14. Go to https://nodejs.org for installation instructions.
+To run the development server you need to have Node installed (version 20 or higher required). Go to https://nodejs.org for installation instructions.
 
 **Clone repo**
 


### PR DESCRIPTION
# Description

Currently the README states that at least node version 14 is required to build the development server. However when you try to do this with the current main you get the following error:

```
~/Repositories/super-productivity master
❯ ng serve
Node.js version v14.21.3 detected.
The Angular CLI requires a minimum Node.js version of v20.11.

Please update your Node.js version or visit https://nodejs.org/ for additional instructions.
```

So this PRs proposes to update this number to the right version and change the wording slightly to make it feel more like native English.

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
