### PR TITLE
Fix #4034: Task context menu hidden by tutorial dialogue

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -140,7 +140,7 @@ $z-celebrate: 102;
 $z-backdrop: 222;
 $z-add-task-bar: 10000;
 $z-search-bar: 10000;
-$z-tour: 10001;
+$z-tour: 99;
 
 // COMPONENTS
 // ----------


### PR DESCRIPTION
When following the tutorial, users are prompted to delete a task by right-clicking it. However, the task context menu was being obscured by the tutorial dialogue, making it impossible to access the delete option

# Description

The issue was resolved by adjusting the z-index of the tutorial dialogue, ensuring that the task context menu always appears on top when right-clicking a task during the tutorial.

## Issues Resolved

The task context menu is no longer obscured by the tutorial dialogue.
Users can now properly interact with the menu options and delete tasks while following the tutorial.


## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
