### PR TITLE
Fix keeping remote data for local file sync

### DIFF
--- a/src/app/pfapi/api/sync/sync.service.ts
+++ b/src/app/pfapi/api/sync/sync.service.ts
@@ -276,9 +276,8 @@ export class SyncService<const MD extends ModelCfgs> {
 
     // If nothing to update or provider limited to single file sync
     if (
-      !isDownloadAll &&
-      ((toUpdate.length === 0 && toDelete.length === 0) ||
-        this._currentSyncProvider$.getOrError().isLimitedToSingleFileSync)
+      (!isDownloadAll && toUpdate.length === 0 && toDelete.length === 0) ||
+        this._currentSyncProvider$.getOrError().isLimitedToSingleFileSync
     ) {
       await this._modelSyncService.updateLocalMainModelsFromRemoteMetaFile(remote);
       pfLog(3, 'RevMap comparison', {


### PR DESCRIPTION
I looked a bit further into https://github.com/johannesjo/super-productivity/issues/4433 and I _think_ the bug was introduced by wrongful bracketing in https://github.com/johannesjo/super-productivity/commit/d1a77c9ac3a697d1606adc05dd26f225b646ffa6.

The behavior I'm observing is that the initial sync correctly uses the meta sync service, but after selecting 'Keep remote', it wrongfully uses the model sync services and tries to download files other than `_meta_` that were never uploaded, even though the sync provider has `isLimitedToSingleFileSync` set to `true`. However, I'll admit that I don't understand the code 100% so this assumption should be double-checked. :sweat_smile: 