### PR TITLE
Fix #4549: Inconsistent date format for Linux and Android devices

### DIFF
--- a/src/app/util/get-work-log-str.ts
+++ b/src/app/util/get-work-log-str.ts
@@ -1,14 +1,14 @@
-// export const WORKLOG_DATE_STR_FORMAT = 'YYYY-MM-DD';
+// export const WORKLOG_DATE_STR_FORMAT = 'DD-MM-YYYY';
 
-// YYYY-MM-DD is the format we use
+// DD-MM-YYYY is the format we use
 export const getWorklogStr = (date: Date | number | string = new Date()): string => {
   const d = new Date(date);
   const year = d.getFullYear();
   const month = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+  return `${day}/${month}/${year}`;
 };
 
 export const isWorklogStr = (str: string): boolean => {
-  return /^\d{4}-\d{2}-\d{2}$/.test(str);
+  return /^\d{2}\/\d{2}\/\d{4}$/.test(str);  // dd/mm/yyyy
 };


### PR DESCRIPTION
# Description

Fixes the worklog date formatting to use dd/mm/yyyy instead of the previous yyy/mm/dd format, aligning with more common formatting on Linux and Android devices.

## Issues Resolved

Closes #4549 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
