### PR TITLE
fix: start nginx via its built-in entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,12 +44,14 @@ COPY --from=build /app/dist/browser /usr/share/nginx/html
 # copy nginx config
 COPY ./nginx/default.conf.template /etc/nginx/templates/default.conf.template
 
-# copy entrypoint script
+# copy our custom entrypoint script
 COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # expose port: defaults to 80
 EXPOSE $PORT
 
-# run docker-entrypoint.sh
+# set working directory
 WORKDIR /usr/share/nginx/html
-CMD ["docker-entrypoint.sh"]
+
+# use our custom entrypoint script, to provide extra steps
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,5 +30,5 @@ if [ "$JSON" != "{}" ]; then
   echo "$JSON" >$JSON_PATH
 fi
 
-# run nginx
-nginx -g "daemon off;"
+# go back to nginx's built-in entrypoint script
+exec /docker-entrypoint.sh nginx -g "daemon off;"


### PR DESCRIPTION
# Description

Our custom `docker-entrypoint.sh` starts nginx by directly calling `nginx -g "daemon off;"`. However, we need the `docker-entrypoint.sh` built-in in the nginx docker image to convert `default.conf.template` to the actual nginx config file. Without going through nginx's `docker-entrypoint.sh`, the resultant docker image fallback to the default nginx configuration, which doesn't forward traffic to webdav backend server.

This patch fixes this by calling the nginx's `docker-entrypoint.sh` at the end of our custom `docker-entrypoint.sh`.

## Issues Resolved

The first issue in https://github.com/johannesjo/super-productivity/issues/4545#issuecomment-2974843258

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
