### PR TITLE
fix: preserve default sync folder path when no overriding

### DIFF
--- a/src/app/imex/sync/sync-config.service.ts
+++ b/src/app/imex/sync/sync-config.service.ts
@@ -42,6 +42,10 @@ export class SyncConfigService {
               return {
                 ...baseConfig,
                 ...defaultOverride,
+                webDav: {
+                  ...baseConfig.webDav,
+                  ...defaultOverride.webDav,
+                },
                 encryptKey: '',
               };
             })


### PR DESCRIPTION
# Description

The spread operator `...` replaces `baseConfig.webDav` with `defaultOverride.webDav` entirely, instead of merging them. Hence, the default sync folder path in `baseConfig.webDav` is wiped out.

This patch fixes this issue by manually providing a merged `webDav`.

## Issues Resolved

The second issue in https://github.com/johannesjo/super-productivity/issues/4545#issuecomment-2974843258

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
