### PR TITLE
refactor: Dockerfile only copy package*.json before installing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,20 @@
 ### build ###
 
 # base image
-FROM --platform=$BUILDPLATFORM node:20 as build
-
-# add app
-COPY . /app
+FROM --platform=$BUILDPLATFORM node:20 AS build
 
 # set working directory
 WORKDIR /app
 
-# add `/app/node_modules/.bin` to $PATH
-ENV PATH /app/node_modules/.bin:$PATH
+# install dependencies
+COPY package*.json /app
+RUN (npm ci || npm i) && npm i -g @angular/cli
 
-RUN npm i
-RUN npm i -g @angular/cli
+# add `/app/node_modules/.bin` to $PATH
+ENV PATH=/app/node_modules/.bin:$PATH
+
+# add app
+COPY . /app
 
 # run linter
 RUN npm run lint


### PR DESCRIPTION
# Description

This patch reorders some commands in `Dockerfile` to save time on building the docker image.

The main goal is to only copy `package.json` and `package-lock.json` into the docker environment before installing dependencies via npm. Therefore, if the dependencies do not change (but other files may change), `docker build` will automatically use cached layers in previous build, instead of re-downloading the same set of dependencies again. This could save build time, especially during development at local machine.

Furthermore, use `npm ci` instead of `npm i` can speed up the build process in CI environment.

However, I notice that `package.json` and `package-lock.json` are out of sync now. So, `npm i` remains in `Dockerfile` as fallback for now. Once the two json files are in sync, this fallback can be removed.

## Issues Resolved

N/A

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
