### PR TITLE
fix: remove line breaks on paste in task title (#4669)

### DIFF
--- a/src/app/ui/task-title/task-title.component.ts
+++ b/src/app/ui/task-title/task-title.component.ts
@@ -98,7 +98,31 @@ export class TaskTitleComponent {
   }
 
   updateTmpValue(value: string): void {
-    this.tmpValue = value;
+    this.tmpValue = this._cleanValue(value);
+  }
+
+  handlePaste(event: ClipboardEvent): void {
+    event.preventDefault();
+
+    const pastedText = event.clipboardData?.getData('text/plain') || '';
+    const cleaned = this._cleanValue(pastedText);
+
+    const textarea = this.textarea().nativeElement;
+    const start = textarea.selectionStart || 0;
+    const end = textarea.selectionEnd || 0;
+
+    const currentVal = textarea.value;
+    const newVal = currentVal.slice(0, start) + cleaned + currentVal.slice(end);
+
+    // Update both textarea and tmpValue
+    textarea.value = newVal;
+    this.tmpValue = newVal;
+    this.updateTmpValue(newVal);
+
+    // Reset cursor position
+    requestAnimationFrame(() => {
+      textarea.selectionStart = textarea.selectionEnd = start + cleaned.length;
+    });
   }
 
   private _forceBlur(): void {


### PR DESCRIPTION
# Description

This PR fixes an issue where line breaks were incorrectly preserved when pasting into the task title input field during editing. It ensures that any pasted text is cleaned to remove \n and \r, maintaining a consistent single-line format across the application.

## Issues Resolved

Fixes #4669

## Check List

 -New functionality includes testing (manual UI testing done for paste behavior).
 -New functionality has been documented in the code via comments (no README change needed).

##Demo
Attached below is a screen recording of the manual testing, demonstrating the updated paste behavior in the task title input.
[demo line breaks.webm](https://github.com/user-attachments/assets/cb094af9-27c7-48a1-a7a1-884cf3659965)
