### PR TITLE
fix: Adding @date incorrectly adds task to today when @date is listed…

### DIFF
--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -308,7 +308,7 @@ const parseScheduledDate = (task: Partial<TaskCopy>, now: Date): DueChanges => {
   const rr = task.title.match(SHORT_SYNTAX_DUE_REG_EX);
 
   if (rr && rr[0]) {
-    const parsedDateArr = customDateParser.parse(task.title, now, {
+    const parsedDateArr = customDateParser.parse(rr[0], now, {
       forwardDate: true,
     });
 


### PR DESCRIPTION
… last #4644

# Description

Fix for 🚨 Adding @date incorrectly adds task to today when @date is listed last #4644

## Issues Resolved

The root cause of the issue was passing the full input text directly from the task creation field. For example, when entering a phrase like "task 1h @tomorrow", the first recognized value was "1h". As a result, the scheduling logic added 1 hour to the current date, and the @tomorrow part was ignored.

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
