### PR TITLE
feat: Add sort by and group by options to board panels

### DIFF
--- a/src/app/features/boards/board-panel/board-panel.component.html
+++ b/src/app/features/boards/board-panel/board-panel.component.html
@@ -9,6 +9,53 @@
       >task_alt</mat-icon
     >{{ this.tasks().length }}
   </div>
+  
+  <!-- Sort Controls -->
+  <div class="sort-controls">
+    <mat-select
+      [(value)]="currentSortField"
+      (selectionChange)="onSortFieldChange($event.value)"
+      placeholder="Sort by"
+      class="sort-select"
+    >
+      <mat-option value="none">No Sort</mat-option>
+      <mat-option value="dueDate">Due Date</mat-option>
+      <mat-option value="timeEstimate">Time Estimate</mat-option>
+      <mat-option value="priority">Priority</mat-option>
+      <mat-option value="createdAt">Created Date</mat-option>
+      <mat-option value="title">Title</mat-option>
+      <mat-option value="project">Project</mat-option>
+    </mat-select>
+    
+    @if (currentSortField !== 'none') {
+      <button
+        mat-icon-button
+        (click)="toggleSortDirection()"
+        [title]="currentSortDirection === 'asc' ? 'Sort Ascending' : 'Sort Descending'"
+        class="sort-direction-btn"
+      >
+        <mat-icon>{{ currentSortDirection === 'asc' ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
+      </button>
+    }
+  </div>
+
+  <!-- Group Controls -->
+  <div class="group-controls">
+    <mat-select
+      [(value)]="currentGroupField"
+      (selectionChange)="onGroupFieldChange($event.value)"
+      placeholder="Group by"
+      class="group-select"
+    >
+      <mat-option value="none">No Group</mat-option>
+      <mat-option value="tags">Tags</mat-option>
+      <mat-option value="project">Project</mat-option>
+      <mat-option value="priority">Priority</mat-option>
+      <mat-option value="dueDateRange">Due Date Range</mat-option>
+      <mat-option value="timeEstimateRange">Time Estimate Range</mat-option>
+    </mat-select>
+  </div>
+
   <button
     mat-icon-button
     (click)="editBoard.emit()"
@@ -36,41 +83,100 @@
   [cdkDropListData]="panelCfg()"
   (cdkDropListDropped)="drop($event)"
 >
-  @for (task of tasks(); track task.id) {
-    <planner-task
-      cdkDrag
-      [cdkDragData]="task"
-      [task]="task"
-      [tagsToHide]="panelCfg().includedTagIds || []"
-    >
-      @if (task.reminderId) {
-        <button
-          (click)="scheduleTask(task, $event)"
-          [title]="T.F.TASK.CMP.EDIT_SCHEDULED | translate"
-          class="ico-btn schedule-btn"
-          color=""
-          mat-icon-button
-        >
-          <mat-icon>alarm</mat-icon>
-          <div
-            class="time-badge"
-            [innerHTML]="task.dueWithTime | shortPlannedAt"
-          ></div>
-        </button>
-      }
-      @if (task.dueDay) {
-        <button
-          (click)="scheduleTask(task, $event)"
-          [title]="T.F.TASK.CMP.SCHEDULE | translate"
-          class="ico-btn schedule-btn"
-          color=""
-          mat-icon-button
-        >
-          <mat-icon>today</mat-icon>
-          <div class="time-badge">{{ task.dueDay | localDateStr }}</div>
-        </button>
-      }
-    </planner-task>
+  @if (currentGroupField === 'none') {
+    <!-- Ungrouped tasks -->
+    @for (task of tasks(); track task.id) {
+      <planner-task
+        cdkDrag
+        [cdkDragData]="task"
+        [task]="task"
+        [tagsToHide]="panelCfg().includedTagIds || []"
+      >
+        @if (task.reminderId) {
+          <button
+            (click)="scheduleTask(task, $event)"
+            [title]="T.F.TASK.CMP.EDIT_SCHEDULED | translate"
+            class="ico-btn schedule-btn"
+            color=""
+            mat-icon-button
+          >
+            <mat-icon>alarm</mat-icon>
+            <div
+              class="time-badge"
+              [innerHTML]="task.dueWithTime | shortPlannedAt"
+            ></div>
+          </button>
+        }
+        @if (task.dueDay) {
+          <button
+            (click)="scheduleTask(task, $event)"
+            [title]="T.F.TASK.CMP.SCHEDULE | translate"
+            class="ico-btn schedule-btn"
+            color=""
+            mat-icon-button
+          >
+            <mat-icon>today</mat-icon>
+            <div class="time-badge">{{ task.dueDay | localDateStr }}</div>
+          </button>
+        }
+      </planner-task>
+    }
+  } @else {
+    <!-- Grouped tasks -->
+    @for (group of taskGroups(); track group.key) {
+      <div class="task-group">
+        <div class="group-header" (click)="toggleGroupCollapse(group.key)">
+          <mat-icon class="group-expand-icon">
+            {{ group.collapsed ? 'expand_more' : 'expand_less' }}
+          </mat-icon>
+          <span class="group-title">{{ group.title }}</span>
+          <span class="group-count">({{ group.tasks.length }})</span>
+          <span class="group-estimate">{{ getGroupEstimate(group.tasks) | msToString }}</span>
+        </div>
+        
+        @if (!group.collapsed) {
+          <div class="group-tasks">
+            @for (task of group.tasks; track task.id) {
+              <planner-task
+                cdkDrag
+                [cdkDragData]="task"
+                [task]="task"
+                [tagsToHide]="panelCfg().includedTagIds || []"
+                class="grouped-task"
+              >
+                @if (task.reminderId) {
+                  <button
+                    (click)="scheduleTask(task, $event)"
+                    [title]="T.F.TASK.CMP.EDIT_SCHEDULED | translate"
+                    class="ico-btn schedule-btn"
+                    color=""
+                    mat-icon-button
+                  >
+                    <mat-icon>alarm</mat-icon>
+                    <div
+                      class="time-badge"
+                      [innerHTML]="task.dueWithTime | shortPlannedAt"
+                    ></div>
+                  </button>
+                }
+                @if (task.dueDay) {
+                  <button
+                    (click)="scheduleTask(task, $event)"
+                    [title]="T.F.TASK.CMP.SCHEDULE | translate"
+                    class="ico-btn schedule-btn"
+                    color=""
+                    mat-icon-button
+                  >
+                    <mat-icon>today</mat-icon>
+                    <div class="time-badge">{{ task.dueDay | localDateStr }}</div>
+                  </button>
+                }
+              </planner-task>
+            }
+          </div>
+        }
+      </div>
+    }
   }
 
   <!--  @if (tasks().length === 0) {-->

--- a/src/app/features/boards/board-panel/board-panel.component.html
+++ b/src/app/features/boards/board-panel/board-panel.component.html
@@ -13,7 +13,7 @@
   <!-- Sort Controls -->
   <div class="sort-controls">
     <mat-select
-      [(value)]="currentSortField"
+      [value]="currentSortField"
       (selectionChange)="onSortFieldChange($event.value)"
       placeholder="Sort by"
       class="sort-select"

--- a/src/app/features/boards/board-panel/board-panel.component.scss
+++ b/src/app/features/boards/board-panel/board-panel.component.scss
@@ -131,3 +131,206 @@ header {
     font-size: 10px;
   }
 }
+
+
+// Sort controls styling
+.sort-controls {
+  display: flex;
+  align-items: center;
+  margin-left: 8px;
+  gap: 4px;
+
+  .sort-select {
+    min-width: 100px;
+    font-size: 12px;
+    
+    ::ng-deep {
+      .mat-mdc-select-trigger {
+        padding: 4px 8px;
+        min-height: 32px;
+      }
+      
+      .mat-mdc-select-value {
+        font-size: 12px;
+      }
+      
+      .mat-mdc-select-arrow {
+        margin-left: 4px;
+      }
+    }
+  }
+
+  .sort-direction-btn {
+    width: 32px;
+    height: 32px;
+    opacity: 0.7;
+    
+    &:hover {
+      opacity: 1;
+    }
+    
+    ::ng-deep .mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+  }
+}
+
+@include mq(xs, max) {
+  .sort-controls {
+    .sort-select {
+      min-width: 80px;
+      font-size: 11px;
+      
+      ::ng-deep {
+        .mat-mdc-select-trigger {
+          padding: 2px 6px;
+          min-height: 28px;
+        }
+        
+        .mat-mdc-select-value {
+          font-size: 11px;
+        }
+      }
+    }
+    
+    .sort-direction-btn {
+      width: 28px;
+      height: 28px;
+      
+      ::ng-deep .mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+}
+
+
+
+// Group controls styling
+.group-controls {
+  display: flex;
+  align-items: center;
+  margin-left: 8px;
+  gap: 4px;
+
+  .group-select {
+    min-width: 100px;
+    font-size: 12px;
+    
+    ::ng-deep {
+      .mat-mdc-select-trigger {
+        padding: 4px 8px;
+        min-height: 32px;
+      }
+      
+      .mat-mdc-select-value {
+        font-size: 12px;
+      }
+      
+      .mat-mdc-select-arrow {
+        margin-left: 4px;
+      }
+    }
+  }
+}
+
+// Task group styling
+.task-group {
+  margin-bottom: 16px;
+  
+  .group-header {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    background: var(--bg-lighter);
+    border: 1px solid var(--extra-border-color);
+    border-radius: 6px;
+    cursor: pointer;
+    margin-bottom: 8px;
+    transition: background-color 0.2s ease;
+    
+    &:hover {
+      background: var(--bg-light);
+    }
+    
+    .group-expand-icon {
+      margin-right: 8px;
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      transition: transform 0.2s ease;
+    }
+    
+    .group-title {
+      font-weight: 500;
+      font-size: 13px;
+      flex-grow: 1;
+    }
+    
+    .group-count {
+      font-size: 12px;
+      opacity: 0.7;
+      margin-left: 8px;
+    }
+    
+    .group-estimate {
+      font-size: 12px;
+      opacity: 0.7;
+      margin-left: 8px;
+      font-style: italic;
+    }
+  }
+  
+  .group-tasks {
+    padding-left: 16px;
+    
+    .grouped-task {
+      margin-bottom: 6px;
+      margin-right: 4px;
+    }
+  }
+}
+
+@include mq(xs, max) {
+  .group-controls {
+    .group-select {
+      min-width: 80px;
+      font-size: 11px;
+      
+      ::ng-deep {
+        .mat-mdc-select-trigger {
+          padding: 2px 6px;
+          min-height: 28px;
+        }
+        
+        .mat-mdc-select-value {
+          font-size: 11px;
+        }
+      }
+    }
+  }
+  
+  .task-group {
+    .group-header {
+      padding: 6px 10px;
+      
+      .group-title {
+        font-size: 12px;
+      }
+      
+      .group-count,
+      .group-estimate {
+        font-size: 11px;
+      }
+    }
+    
+    .group-tasks {
+      padding-left: 12px;
+    }
+  }
+}
+

--- a/src/app/features/boards/board-panel/board-panel.component.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.ts
@@ -5,6 +5,7 @@ import {
   inject,
   input,
   output,
+  signal,
 } from '@angular/core';
 import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
 import { PlannerTaskComponent } from '../../planner/planner-task/planner-task.component';
@@ -13,6 +14,11 @@ import {
   BoardPanelCfgScheduledState,
   BoardPanelCfgTaskDoneState,
   BoardPanelCfgTaskTypeFilter,
+  BoardPanelSortField,
+  BoardPanelSortDirection,
+  BoardPanelSortCfg,
+  BoardPanelGroupField,
+  BoardPanelGroupCfg,
 } from '../boards.model';
 import { select, Store } from '@ngrx/store';
 import {
@@ -32,6 +38,7 @@ import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions'
 import { LocalDateStrPipe } from '../../../ui/pipes/local-date-str.pipe';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconButton } from '@angular/material/button';
+import { MatSelect, MatOption } from '@angular/material/select';
 import { TranslatePipe } from '@ngx-translate/core';
 import { DialogScheduleTaskComponent } from '../../planner/dialog-schedule-task/dialog-schedule-task.component';
 import { MatDialog } from '@angular/material/dialog';
@@ -40,6 +47,13 @@ import { first, take } from 'rxjs/operators';
 import { ShortPlannedAtPipe } from '../../../ui/pipes/short-planned-at.pipe';
 import { MsToStringPipe } from '../../../ui/duration/ms-to-string.pipe';
 import { selectUnarchivedVisibleProjects } from '../../project/store/project.selectors';
+
+export interface TaskGroup {
+  key: string;
+  title: string;
+  tasks: TaskCopy[];
+  collapsed: boolean;
+}
 
 @Component({
   selector: 'board-panel',
@@ -52,6 +66,8 @@ import { selectUnarchivedVisibleProjects } from '../../project/store/project.sel
     LocalDateStrPipe,
     MatIcon,
     MatIconButton,
+    MatSelect,
+    MatOption,
     TranslatePipe,
     ShortPlannedAtPipe,
     MsToStringPipe,
@@ -69,6 +85,14 @@ export class BoardPanelComponent {
   store = inject(Store);
   taskService = inject(TaskService);
   _matDialog = inject(MatDialog);
+
+  // Sort-related signals
+  currentSortField = signal<BoardPanelSortField>(BoardPanelSortField.None);
+  currentSortDirection = signal<BoardPanelSortDirection>(BoardPanelSortDirection.Asc);
+
+  // Group-related signals
+  currentGroupField = signal<BoardPanelGroupField>(BoardPanelGroupField.None);
+  collapsedGroups = signal<Set<string>>(new Set());
 
   allTasks$ = this.store.select(selectAllTasksWithoutHiddenProjects);
   allTasks = toSignal(this.allTasks$, {
@@ -176,7 +200,32 @@ export class BoardPanelComponent {
         nonOrderedTasks.push(task);
       }
     });
-    return [...orderedTasks, ...nonOrderedTasks].filter((t) => !!t);
+    
+    let finalTasks = [...orderedTasks, ...nonOrderedTasks].filter((t) => !!t);
+    
+    // Apply sorting if configured
+    const sortCfg = panelCfg.sortCfg || {
+      primary: this.currentSortField(),
+      direction: this.currentSortDirection()
+    };
+    
+    if (sortCfg.primary !== BoardPanelSortField.None) {
+      finalTasks = this._sortTasks(finalTasks, sortCfg);
+    }
+    
+    return finalTasks;
+  });
+
+  taskGroups = computed(() => {
+    const groupField = this.currentGroupField();
+    const tasks = this.tasks();
+    const collapsedGroups = this.collapsedGroups();
+
+    if (groupField === BoardPanelGroupField.None) {
+      return [];
+    }
+
+    return this._groupTasks(tasks, groupField, collapsedGroups);
   });
 
   async drop(ev: CdkDragDrop<BoardPanelCfg, string, TaskCopy>): Promise<void> {
@@ -300,6 +349,243 @@ export class BoardPanelComponent {
           isSkipToast: false,
         }),
       );
+    }
+  }
+
+  // Sort-related methods
+  onSortFieldChange(field: BoardPanelSortField): void {
+    this.currentSortField.set(field);
+    this._updatePanelSortConfig();
+  }
+
+  toggleSortDirection(): void {
+    const newDirection = this.currentSortDirection() === BoardPanelSortDirection.Asc 
+      ? BoardPanelSortDirection.Desc 
+      : BoardPanelSortDirection.Asc;
+    this.currentSortDirection.set(newDirection);
+    this._updatePanelSortConfig();
+  }
+
+  private _updatePanelSortConfig(): void {
+    const panelCfg = this.panelCfg();
+    const sortCfg: BoardPanelSortCfg = {
+      primary: this.currentSortField(),
+      direction: this.currentSortDirection()
+    };
+
+    this.store.dispatch(
+      BoardsActions.updatePanelSortConfig({
+        panelId: panelCfg.id,
+        sortCfg
+      })
+    );
+  }
+
+  // Group-related methods
+  onGroupFieldChange(field: BoardPanelGroupField): void {
+    this.currentGroupField.set(field);
+    this._updatePanelGroupConfig();
+  }
+
+  toggleGroupCollapse(groupKey: string): void {
+    const collapsed = this.collapsedGroups();
+    const newCollapsed = new Set(collapsed);
+    
+    if (newCollapsed.has(groupKey)) {
+      newCollapsed.delete(groupKey);
+    } else {
+      newCollapsed.add(groupKey);
+    }
+    
+    this.collapsedGroups.set(newCollapsed);
+  }
+
+  getGroupEstimate(tasks: TaskCopy[]): number {
+    return tasks.reduce((acc, task) => acc + (task.timeEstimate || 0), 0);
+  }
+
+  private _updatePanelGroupConfig(): void {
+    const panelCfg = this.panelCfg();
+    const groupCfg: BoardPanelGroupCfg = {
+      field: this.currentGroupField(),
+      showUngrouped: true,
+      collapseGroups: false
+    };
+
+    this.store.dispatch(
+      BoardsActions.updatePanelGroupConfig({
+        panelId: panelCfg.id,
+        groupCfg
+      })
+    );
+  }
+
+  private _groupTasks(tasks: TaskCopy[], groupField: BoardPanelGroupField, collapsedGroups: Set<string>): TaskGroup[] {
+    const groups = new Map<string, TaskCopy[]>();
+
+    // Group tasks by the specified field
+    tasks.forEach(task => {
+      const groupKeys = this._getTaskGroupKeys(task, groupField);
+      
+      groupKeys.forEach(key => {
+        if (!groups.has(key)) {
+          groups.set(key, []);
+        }
+        groups.get(key)!.push(task);
+      });
+    });
+
+    // Convert to TaskGroup array and sort
+    const taskGroups: TaskGroup[] = Array.from(groups.entries()).map(([key, groupTasks]) => ({
+      key,
+      title: this._getGroupTitle(key, groupField),
+      tasks: groupTasks,
+      collapsed: collapsedGroups.has(key)
+    }));
+
+    // Sort groups by title
+    taskGroups.sort((a, b) => a.title.localeCompare(b.title));
+
+    return taskGroups;
+  }
+
+  private _getTaskGroupKeys(task: TaskCopy, groupField: BoardPanelGroupField): string[] {
+    switch (groupField) {
+      case BoardPanelGroupField.Tags:
+        return task.tagIds.length > 0 ? task.tagIds : ['no-tags'];
+        
+      case BoardPanelGroupField.Project:
+        return task.projectId ? [task.projectId] : ['no-project'];
+        
+      case BoardPanelGroupField.Priority:
+        const priority = task.priority || 0;
+        if (priority >= 3) return ['high-priority'];
+        if (priority >= 1) return ['medium-priority'];
+        return ['low-priority'];
+        
+      case BoardPanelGroupField.DueDateRange:
+        const now = Date.now();
+        const today = new Date(now).setHours(0, 0, 0, 0);
+        const tomorrow = today + 24 * 60 * 60 * 1000;
+        const nextWeek = today + 7 * 24 * 60 * 60 * 1000;
+        
+        const dueDate = task.dueWithTime || task.dueDay;
+        if (!dueDate) return ['no-due-date'];
+        
+        if (dueDate < today) return ['overdue'];
+        if (dueDate < tomorrow) return ['today'];
+        if (dueDate < nextWeek) return ['this-week'];
+        return ['later'];
+        
+      case BoardPanelGroupField.TimeEstimateRange:
+        const estimate = task.timeEstimate || 0;
+        const estimateHours = estimate / (60 * 60 * 1000);
+        
+        if (estimate === 0) return ['no-estimate'];
+        if (estimateHours < 0.5) return ['quick-tasks'];
+        if (estimateHours < 2) return ['medium-tasks'];
+        return ['long-tasks'];
+        
+      default:
+        return ['ungrouped'];
+    }
+  }
+
+  private _getGroupTitle(key: string, groupField: BoardPanelGroupField): string {
+    switch (groupField) {
+      case BoardPanelGroupField.Tags:
+        if (key === 'no-tags') return 'No Tags';
+        // TODO: Get actual tag name from tag service
+        return `Tag: ${key}`;
+        
+      case BoardPanelGroupField.Project:
+        if (key === 'no-project') return 'No Project';
+        // TODO: Get actual project name from project service
+        return `Project: ${key}`;
+        
+      case BoardPanelGroupField.Priority:
+        switch (key) {
+          case 'high-priority': return 'High Priority';
+          case 'medium-priority': return 'Medium Priority';
+          case 'low-priority': return 'Low Priority';
+          default: return 'Unknown Priority';
+        }
+        
+      case BoardPanelGroupField.DueDateRange:
+        switch (key) {
+          case 'overdue': return 'Overdue';
+          case 'today': return 'Today';
+          case 'this-week': return 'This Week';
+          case 'later': return 'Later';
+          case 'no-due-date': return 'No Due Date';
+          default: return 'Unknown';
+        }
+        
+      case BoardPanelGroupField.TimeEstimateRange:
+        switch (key) {
+          case 'quick-tasks': return 'Quick Tasks (<30min)';
+          case 'medium-tasks': return 'Medium Tasks (30min-2h)';
+          case 'long-tasks': return 'Long Tasks (>2h)';
+          case 'no-estimate': return 'No Estimate';
+          default: return 'Unknown';
+        }
+        
+      default:
+        return key;
+    }
+  }
+
+  private _sortTasks(tasks: TaskCopy[], sortCfg: BoardPanelSortCfg): TaskCopy[] {
+    return [...tasks].sort((a, b) => {
+      const result = this._compareTasksByField(a, b, sortCfg.primary);
+      const multiplier = sortCfg.direction === BoardPanelSortDirection.Asc ? 1 : -1;
+      
+      if (result !== 0) {
+        return result * multiplier;
+      }
+      
+      // Secondary sort if primary values are equal
+      if (sortCfg.secondary) {
+        const secondaryResult = this._compareTasksByField(a, b, sortCfg.secondary.field);
+        const secondaryMultiplier = sortCfg.secondary.direction === BoardPanelSortDirection.Asc ? 1 : -1;
+        return secondaryResult * secondaryMultiplier;
+      }
+      
+      return 0;
+    });
+  }
+
+  private _compareTasksByField(a: TaskCopy, b: TaskCopy, field: BoardPanelSortField): number {
+    switch (field) {
+      case BoardPanelSortField.DueDate:
+        const aDue = a.dueWithTime || a.dueDay || Number.MAX_SAFE_INTEGER;
+        const bDue = b.dueWithTime || b.dueDay || Number.MAX_SAFE_INTEGER;
+        return aDue - bDue;
+        
+      case BoardPanelSortField.TimeEstimate:
+        const aEstimate = a.timeEstimate || 0;
+        const bEstimate = b.timeEstimate || 0;
+        return aEstimate - bEstimate;
+        
+      case BoardPanelSortField.Priority:
+        // Assuming higher priority values mean higher priority
+        const aPriority = a.priority || 0;
+        const bPriority = b.priority || 0;
+        return bPriority - aPriority; // Higher priority first
+        
+      case BoardPanelSortField.CreatedAt:
+        return a.createdAt - b.createdAt;
+        
+      case BoardPanelSortField.Title:
+        return a.title.localeCompare(b.title);
+        
+      case BoardPanelSortField.Project:
+        const aProject = a.projectId || '';
+        const bProject = b.projectId || '';
+        return aProject.localeCompare(bProject);
+        
+      default:
+        return 0;
     }
   }
 

--- a/src/app/features/boards/board-panel/board-panel.component.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.ts
@@ -87,11 +87,17 @@ export class BoardPanelComponent {
   _matDialog = inject(MatDialog);
 
   // Sort-related signals
-  currentSortField = signal<BoardPanelSortField>(BoardPanelSortField.None);
-  currentSortDirection = signal<BoardPanelSortDirection>(BoardPanelSortDirection.Asc);
+  currentSortField = signal<BoardPanelSortField>(
+    this.panelCfg?.sortCfg?.field ?? BoardPanelSortField.None
+  );
+  currentSortDirection = signal<BoardPanelSortDirection>(
+    this.panelCfg?.sortCfg?.direction ?? BoardPanelSortDirection.Asc
+  );
 
   // Group-related signals
-  currentGroupField = signal<BoardPanelGroupField>(BoardPanelGroupField.None);
+  currentGroupField = signal<BoardPanelGroupField>(
+    this.panelCfg?.groupCfg?.field ?? BoardPanelGroupField.None
+  );
   collapsedGroups = signal<Set<string>>(new Set());
 
   allTasks$ = this.store.select(selectAllTasksWithoutHiddenProjects);

--- a/src/app/features/boards/boards.model.ts
+++ b/src/app/features/boards/boards.model.ts
@@ -16,6 +16,46 @@ export enum BoardPanelCfgTaskTypeFilter {
   OnlyBacklog = 3,
 }
 
+export enum BoardPanelSortField {
+  None = 'none',
+  DueDate = 'dueDate',
+  TimeEstimate = 'timeEstimate',
+  Priority = 'priority',
+  CreatedAt = 'createdAt',
+  Title = 'title',
+  Project = 'project',
+}
+
+export enum BoardPanelSortDirection {
+  Asc = 'asc',
+  Desc = 'desc',
+}
+
+export enum BoardPanelGroupField {
+  None = 'none',
+  Tags = 'tags',
+  Project = 'project',
+  Priority = 'priority',
+  DueDateRange = 'dueDateRange',
+  TimeEstimateRange = 'timeEstimateRange',
+}
+
+export interface BoardPanelSortCfg {
+  primary: BoardPanelSortField;
+  direction: BoardPanelSortDirection;
+  secondary?: {
+    field: BoardPanelSortField;
+    direction: BoardPanelSortDirection;
+  };
+}
+
+export interface BoardPanelGroupCfg {
+  field: BoardPanelGroupField;
+  customTags?: string[]; // for tag grouping
+  showUngrouped: boolean;
+  collapseGroups: boolean;
+}
+
 export interface BoardSrcCfg {
   // projectId?: string;
   includedTagIds: string[];
@@ -26,6 +66,8 @@ export interface BoardSrcCfg {
   isParentTasksOnly: boolean;
   // optional since newly added
   backlogState?: BoardPanelCfgTaskTypeFilter;
+  sortCfg?: BoardPanelSortCfg;
+  groupCfg?: BoardPanelGroupCfg;
 }
 
 export interface BoarFieldsToRemove {

--- a/src/app/features/boards/store/boards.actions.ts
+++ b/src/app/features/boards/store/boards.actions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { createActionGroup, props } from '@ngrx/store';
-import { BoardCfg, BoardPanelCfg } from '../boards.model';
+import { BoardCfg, BoardPanelCfg, BoardPanelSortCfg, BoardPanelGroupCfg } from '../boards.model';
 
 export const BoardsActions = createActionGroup({
   source: 'Boards',
@@ -10,5 +10,7 @@ export const BoardsActions = createActionGroup({
     'Remove Board': props<{ id: string }>(),
     'Update Panel Cfg': props<{ panelCfg: BoardPanelCfg }>(),
     'Update Panel Cfg TaskIds': props<{ panelId: string; taskIds: string[] }>(),
+    'Update Panel Sort Config': props<{ panelId: string; sortCfg: BoardPanelSortCfg }>(),
+    'Update Panel Group Config': props<{ panelId: string; groupCfg: BoardPanelGroupCfg }>(),
   },
 });

--- a/src/app/features/boards/store/boards.reducer.ts
+++ b/src/app/features/boards/store/boards.reducer.ts
@@ -108,6 +108,72 @@ export const boardsReducer = createReducer(
 
     return state;
   }),
+
+  on(BoardsActions.updatePanelSortConfig, (state, { panelId, sortCfg }) => {
+    let panelCfgToUpdate;
+    const boardCfg = state.boardCfgs.find((cfg) => {
+      panelCfgToUpdate = cfg.panels.find((panel) => panel.id === panelId);
+      return !!panelCfgToUpdate;
+    });
+
+    if (boardCfg && panelCfgToUpdate) {
+      return {
+        ...state,
+        boardCfgs: state.boardCfgs.map((boardCfgInner) => {
+          if (boardCfgInner.id === boardCfg.id) {
+            return {
+              ...boardCfgInner,
+              panels: boardCfgInner.panels.map((panel) => {
+                if (panel.id === panelId) {
+                  return {
+                    ...panel,
+                    sortCfg,
+                  };
+                }
+                return panel;
+              }),
+            };
+          }
+          return boardCfgInner;
+        }),
+      };
+    }
+
+    return state;
+  }),
+
+  on(BoardsActions.updatePanelGroupConfig, (state, { panelId, groupCfg }) => {
+    let panelCfgToUpdate;
+    const boardCfg = state.boardCfgs.find((cfg) => {
+      panelCfgToUpdate = cfg.panels.find((panel) => panel.id === panelId);
+      return !!panelCfgToUpdate;
+    });
+
+    if (boardCfg && panelCfgToUpdate) {
+      return {
+        ...state,
+        boardCfgs: state.boardCfgs.map((boardCfgInner) => {
+          if (boardCfgInner.id === boardCfg.id) {
+            return {
+              ...boardCfgInner,
+              panels: boardCfgInner.panels.map((panel) => {
+                if (panel.id === panelId) {
+                  return {
+                    ...panel,
+                    groupCfg,
+                  };
+                }
+                return panel;
+              }),
+            };
+          }
+          return boardCfgInner;
+        }),
+      };
+    }
+
+    return state;
+  }),
 );
 
 export const boardsFeature = createFeature({


### PR DESCRIPTION
- Add comprehensive sort functionality (due date, time estimate, priority, created date, title, project)
- Add group by functionality (tags, project, priority, due date range, time estimate range)
- Support ascending/descending sort directions
- Implement collapsible group headers with task count and time estimates
- Add responsive UI controls for sort and group selection
- Extend BoardPanelCfg with sortCfg and groupCfg properties
- Add NgRx actions and reducers for persistent configuration
- Support GTD methodology with context-based organization
- Maintain backward compatibility with existing configurations

Fixes #4688

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
