### PR TITLE
docs(README.md): fix link to caldav explanation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@
   - Need some extra focus? A **Pomodoro timer** is also always at hand.
   - **Collect personal metrics** to see, which of your work routines need adjustments.
 - Integrate with **Jira**, **GitHub**, **GitLab**, **Gitea** and **OpenProject**. Auto import tasks assigned to you, plan the details locally, automatically create work logs, and get notified immediately, when something changes.
-- Basic [**CalDAV**](https://github.com/johannesjo/super-productivity/blob/master/docs/caldav.md) integration.
+- Basic [**CalDAV**](/docs/ai/caldav.md) integration.
 - Back up and synchronize your data across multiple devices with **Dropbox** and **WebDAV** support
 - Attach context information to tasks and projects. Create **notes**, attach **files** or create **project-level bookmarks** for links, files, and even commands.
 - Super Productivity **respects your privacy** and **does NOT collect any data** and there are no user accounts or registration. **You decide where you store your data!**


### PR DESCRIPTION
# Description

caldav explanation file was moved, but the link in the readme still pointed to the old location. I also changed the link to be a relative link, not an absolute.
