### PR TITLE
feat: add os module support to plugin node executor

### DIFF
--- a/electron/plugin-node-executor.ts
+++ b/electron/plugin-node-executor.ts
@@ -102,7 +102,7 @@ class PluginNodeExecutor {
   private canExecuteDirectly(script: string): boolean {
     // Check if script only uses safe operations
     const dangerousPatterns =
-      /require\s*\(\s*['"`](?!fs|path)[^'"]+['"`]\s*\)|child_process|exec|spawn|eval|Function|process\.exit/;
+      /require\s*\(\s*['"`](?!fs|path|os)[^'"]+['"`]\s*\)|child_process|exec|spawn|eval|Function|process\.exit/;
     return !dangerousPatterns.test(script);
   }
 
@@ -110,12 +110,14 @@ class PluginNodeExecutor {
     // Safe modules
     const fs = await import('fs');
     const path = await import('path');
+    const os = await import('os');
 
     // Create sandboxed context
     const sandbox = {
       require: (module: string) => {
         if (module === 'fs') return fs;
         if (module === 'path') return path;
+        if (module === 'os') return os;
         throw new Error(`Module '${module}' is not allowed`);
       },
       console: {


### PR DESCRIPTION
# Description

Enable plugins to access the Node.js 'os' module for system information gathering alongside the existing fs and path modules.

Changes:
- Updated canExecuteDirectly() regex pattern to allow 'os' module imports
- Added os module import to executeDirectly() sandbox environment
- Extended sandbox require() function to provide access to os module

This allows plugins to access system information like platform, architecture, memory usage, CPU info, and network interfaces through the standard Node.js os module while maintaining the existing security restrictions.

The os module is considered safe as it provides read-only system information and doesn't allow file system modifications or process execution.

## Issues Resolved

Fixes #4849

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
