### PR TITLE
Fix #4869

### DIFF
--- a/src/assets/themes/nord-snow-storm.css
+++ b/src/assets/themes/nord-snow-storm.css
@@ -110,7 +110,7 @@ body:not(.isDarkTheme) {
 
   /* Dark accent for contrast on light background */
   --palette-accent-500: var(--nord0);
-  --c-accent: var(--nord0);
+  --c-accent: var(--nord4);
   --palette-accent-100: #9fa5b0;
   --palette-accent-200: #7f879a;
   --palette-accent-300: #5f6984;


### PR DESCRIPTION
# Description

This PR will just change the accent color in the css theme file from --nord0 to --nord1

## Issues Resolved

I just resolved [my issue](https://github.com/johannesjo/super-productivity/issues/4869)

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.


## Thing to improve
I am not able to implement that but a system to detect if the background color is too dark to put the foreground color light (and vise-versa) would be appreciated
