### PR TITLE
fix: Send User-Agent to office365.com as it appearently needs it #4677

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -118,7 +118,8 @@ export const createWindow = ({
     removeKeyInAnyCase(requestHeaders, 'accept');
 
     // NOTE this is needed for GitHub api requests to work :(
-    if (!details.url.includes('github.com')) {
+    // office365 needs a User-Agent as well (#4677)
+    if (!details.url.includes('github.com') && !details.url.includes('office365.com')) {
       removeKeyInAnyCase(requestHeaders, 'User-Agent');
     }
     callback({ requestHeaders });


### PR DESCRIPTION
# Description

Appearently office365 needs the User-Agent to be set in http requests since a few weeks.
Not sending it broke Office365 calendar integration

## Issues Resolved

#4677 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
