### PR TITLE
Some Mobile UI Fixes (Task list + Side Nav)

### DIFF
--- a/src/app/core-ui/side-nav/side-nav.component.scss
+++ b/src/app/core-ui/side-nav/side-nav.component.scss
@@ -67,6 +67,13 @@
   }
 }
 
+@media (max-width: 500px) {
+  :host {
+    max-width: var(--side-nav-width-mobile);
+    width: var(--side-nav-width-mobile);
+  }
+}
+
 section {
   display: flex;
   flex-direction: column;

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -34,7 +34,9 @@
 
   // Component dimensions
   --component-max-width: 800px;
+  --side-nav-width-switch-mobile: 500px;
   --side-nav-width-switch-l: 1500px;
+  --side-nav-width-mobile: calc(100vw - var(--s7));
   --side-nav-width: 200px;
   --side-nav-width-l: 400px;
   --bar-height-large: 56px;

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -121,7 +121,7 @@ body {
 }
 
 .task-list-wrapper {
-  padding: 0 0 var(--s7);
+  padding: 0 var(--s) var(--s7);
   // for a little bit of extra space for 800 width
   max-width: calc(var(--component-max-width) - 40px);
   margin: auto;


### PR DESCRIPTION
# Description

This pull request includes some small UI tweaks that should improve the mobile version of super productivity. 

Changes:

- Added Extra Padding for task list for mobile. (shown in screenshots)
- Made Side Nav Bigger on mobile. (shown in screenshots)
  *Side Nav was too small for some devices this makes the Side Nav follow screen size with subtracted padding (`100vw - var(--s7)`). Mobile Menu triggers when screen size is less than 500px*


## Screenshots

### Tasklist Padding (Before/After)


<img width="400" height="831" alt="image" src="https://github.com/user-attachments/assets/8383a9da-e3b4-425e-ac04-c92ea9d0a8c1" />

<img width="400" height="831" alt="image" src="https://github.com/user-attachments/assets/a7788543-b284-45ac-9d22-91e607b5de12" />



### Navbar on mobile (Before/After)

<img width="400" height="831" alt="image" src="https://github.com/user-attachments/assets/382b0b39-04ad-4d94-a2b8-f7638eee9423" />

<img width="400" height="831" alt="image" src="https://github.com/user-attachments/assets/53adff4a-7892-4c01-85e7-7bab049485c5" />


## Issues Resolved

None

## Check List

- [X] New functionality includes testing.
