### PR TITLE
Allow simple hostnames in CalDAV URL

### DIFF
--- a/src/app/features/issue/providers/caldav/caldav-cfg-form.const.ts
+++ b/src/app/features/issue/providers/caldav/caldav-cfg-form.const.ts
@@ -14,8 +14,7 @@ export const CALDAV_CONFIG_FORM: LimitedFormlyFieldConfig<IssueProviderCaldav>[]
       required: true,
       label: T.F.CALDAV.FORM.CALDAV_URL,
       type: 'url',
-      pattern:
-        /^(http(s)?:\/\/)?(localhost|[\w.\-]+(?:\.[\w\.\-]+)+)(:\d+)?(\/[^\s]*)?$/i,
+      pattern: /^(http(s)?:\/\/)?([\w\-]+(?:\.[\w\-]+)*)(:\d+)?(\/\S*)?$/i,
     },
   },
   {


### PR DESCRIPTION
# Description

Currently, the pattern to validate the base URL for a CalDAV instance needs to contain a domain, like `example.com`. The only exception is the fixed hostname `localhost`. As it is also possible to host a CalDAV server like Nextcloud using another local hostname without a domain, the pattern should also accept these.
For example, my Nextcloud instance is available using `https://local/nextcloud`.

This PR changed the URL Regex to `/^(http(s)?:\/\/)?([\w\-]+(?:\.[\w\-]+)*)(:\d+)?(\/\S*)?$/i`, to support both domains and simple hostnames in validation.

## Issues Resolved


## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.

### Question
As a question, I only found about Super Productivity today and I am already in love with it. Are you open for constributions to the issues providers? I would like to improve the sync and add some providers. Also two-way sync like partially supported by CalDAV would be a goal.