### PR TITLE
Fix: center material icon #4924

### DIFF
--- a/src/app/features/simple-counter/simple-counter-button/simple-counter-button.component.scss
+++ b/src/app/features/simple-counter/simple-counter-button/simple-counter-button.component.scss
@@ -19,7 +19,6 @@
   .mat-icon {
     position: relative;
     z-index: 2;
-    transform: translateY(-2px);
 
     :host(.isSuccess) & {
       opacity: 0.25;


### PR DESCRIPTION
# Description

I just removed the transform on the material icons 

## Issues Resolved

[#4924](https://github.com/johannesjo/super-productivity/issues/4924)
