### PR TITLE
fix: solve local file sync directory path not being selectable

### DIFF
--- a/src/app/pfapi/api/sync/providers/local-file-sync/local-file-sync-android.ts
+++ b/src/app/pfapi/api/sync/providers/local-file-sync/local-file-sync-android.ts
@@ -33,7 +33,7 @@ export class LocalFileSyncAndroid extends LocalFileSyncBase {
   async setupSaf(): Promise<string | undefined> {
     try {
       const uri = await SafService.selectFolder();
-      await this.privateCfg.updatePartial({
+      await this.privateCfg.upsertPartial({
         safFolderUri: uri,
       });
       return uri;

--- a/src/app/pfapi/api/sync/providers/local-file-sync/local-file-sync-electron.ts
+++ b/src/app/pfapi/api/sync/providers/local-file-sync/local-file-sync-electron.ts
@@ -88,7 +88,7 @@ export class LocalFileSyncElectron extends LocalFileSyncBase {
     try {
       const dir = await (window as any).ea.pickDirectory();
       if (dir) {
-        await this.privateCfg.updatePartial({ syncFolderPath: dir });
+        await this.privateCfg.upsertPartial({ syncFolderPath: dir });
       }
       return dir;
     } catch (e) {

--- a/src/app/pfapi/api/sync/sync-provider-private-cfg-store.ts
+++ b/src/app/pfapi/api/sync/sync-provider-private-cfg-store.ts
@@ -83,6 +83,21 @@ export class SyncProviderPrivateCfgStore<PID extends SyncProviderId> {
   }
 
   /**
+   * Upserts the provider's private configuration with partial data
+   * If no existing configuration exists, creates a new one with the provided updates
+   * @param updates Partial configuration updates to apply
+   * @returns Promise resolving after save completes
+   * @throws Error if save fails
+   */
+  async upsertPartial(updates: Partial<PrivateCfgByProviderId<PID>>): Promise<unknown> {
+    const existing = await this.load();
+    const privateCfg = existing
+      ? { ...existing, ...updates }
+      : (updates as PrivateCfgByProviderId<PID>);
+    return this._save(privateCfg);
+  }
+
+  /**
    * Internal method to save configuration
    * @private
    */


### PR DESCRIPTION
# Description

On Android and the Electron app, it is not possible to use the local file sync as of the latest version, since you can't select the sync directory unless you already have a config generated. This PR fixes this by using an upsert function for the directory selection.

## Issues Resolved

fixes #4938 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
