### PR TITLE
Fix: Remove progressbar on task completion in electron

### DIFF
--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -104,7 +104,10 @@ export interface ElectronAPI {
 
   setDoneRegisterBeforeClose(id: string): void;
 
-  setProgressBar(args: { progress: number; progressBarMode: 'normal' | 'pause' }): void;
+  setProgressBar(args: {
+    progress: number;
+    progressBarMode: 'normal' | 'pause' | 'none';
+  }): void;
 
   sendAppSettingsToElectron(globalCfg: GlobalConfigState): void;
 

--- a/electron/ipc-handler.ts
+++ b/electron/ipc-handler.ts
@@ -1,6 +1,14 @@
 // FRONTEND EVENTS
 // ---------------
-import { app, dialog, globalShortcut, ipcMain, IpcMainEvent, shell } from 'electron';
+import {
+  app,
+  dialog,
+  globalShortcut,
+  ipcMain,
+  IpcMainEvent,
+  ProgressBarOptions,
+  shell,
+} from 'electron';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 import { lockscreen } from './lockscreen';
 import { errorHandlerWithFrontendInform } from './error-handler-with-frontend-inform';
@@ -83,10 +91,16 @@ export const initIpcInterfaces = (): void => {
     }
   });
 
-  ipcMain.on(IPC.SET_PROGRESS_BAR, (ev, { progress, mode }) => {
+  ipcMain.on(IPC.SET_PROGRESS_BAR, (ev, { progress, progressBarMode }) => {
     const mainWin = getWin();
     if (mainWin) {
-      mainWin.setProgressBar(Math.min(Math.max(progress, 0), 1), { mode });
+      if (progressBarMode === 'none') {
+        mainWin.setProgressBar(-1);
+      } else {
+        mainWin.setProgressBar(Math.min(Math.max(progress, 0), 1), {
+          mode: progressBarMode as ProgressBarOptions['mode'],
+        });
+      }
     }
   });
 

--- a/src/app/features/tasks/store/task-electron.effects.ts
+++ b/src/app/features/tasks/store/task-electron.effects.ts
@@ -21,6 +21,7 @@ import {
 import { IPC } from '../../../../../electron/shared-with-frontend/ipc-events.const';
 import { ipcAddTaskFromAppUri$ } from '../../../core/ipc-events';
 import { TaskService } from '../task.service';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 
 // TODO send message to electron when current task changes here
 
@@ -124,8 +125,24 @@ export class TaskElectronEffects {
         tap(({ id }) => {
           if (!id) {
             window.ea.setProgressBar({
-              progress: 0,
-              progressBarMode: 'pause',
+              progress: -1,
+              progressBarMode: 'none',
+            });
+          }
+        }),
+      ),
+    { dispatch: false },
+  );
+
+  clearTaskBarOnTaskDone$ = createEffect(
+    () =>
+      this._actions$.pipe(
+        ofType(TaskSharedActions.updateTask),
+        tap(({ task }) => {
+          if (task.changes.isDone) {
+            window.ea.setProgressBar({
+              progress: -1,
+              progressBarMode: 'none',
             });
           }
         }),


### PR DESCRIPTION
# Description

This PR implements handling progressBarMode none in the electron API and uses that to remove the progressbar when a task with one is marked as done.

## Issues Resolved

Fixes #3701 

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
