### PR TITLE
fix: search results have incorrect capitalization

### DIFF
--- a/src/app/pages/search-page/search-page.component.ts
+++ b/src/app/pages/search-page/search-page.component.ts
@@ -92,8 +92,8 @@ export class SearchPageComponent implements OnInit {
 
       return {
         id: task.id,
-        title: task.title.toLowerCase(),
-        taskNotes: task.notes?.toLowerCase() || '',
+        title: task.title,
+        taskNotes: task.notes || '',
         projectId: task.projectId || null,
         parentId: task.parentId || null,
         tagId,
@@ -150,8 +150,8 @@ export class SearchPageComponent implements OnInit {
 
     const result = searchableItems.filter(
       (task) =>
-        task.title.includes(searchTerm.toLowerCase()) ||
-        task.taskNotes.includes(searchTerm.toLowerCase()),
+        task.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        task.taskNotes.toLowerCase().includes(searchTerm.toLowerCase()),
     );
 
     return result.slice(0, MAX_RESULTS);


### PR DESCRIPTION
## Description

[RecordRTC-2025724-hz8bopdrjla.webm](https://github.com/user-attachments/assets/281e24de-19d5-4d3c-9f5b-9fe56e5f3be1)

### Problem: 
The search functionality was incorrectly converting task titles and notes to lowercase during data preparation, causing search results to display with incorrect capitalization.

### Solution:
Data Preparation (lines 95-96): Removed .toLowerCase() calls when storing task title and notes in the searchable items array
Search Filtering (lines 153-154): Added .toLowerCase() calls during the actual search comparison to maintain case-insensitive search while preserving original text formatting
`Result`: Search results now display with proper capitalization while maintaining case-insensitive search functionality.

## Describe what this change achieves
This change fixes the search results capitalization issue in search-page.component.ts


## Issues Resolved
This PR closes #4967 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.