### PR TITLE
Re-enable the UI option to allow self-signed certs for Jira

### DIFF
--- a/src/app/features/issue/providers/jira/jira-cfg-form.const.ts
+++ b/src/app/features/issue/providers/jira/jira-cfg-form.const.ts
@@ -114,13 +114,13 @@ export const JIRA_CONFIG_FORM_SECTION: ConfigFormSection<IssueProviderJira> = {
       type: 'collapsible',
       props: { label: T.G.ADVANCED_CFG },
       fieldGroup: [
-        // {
-        //   key: 'isAllowSelfSignedCertificate',
-        //   type: 'checkbox',
-        //   templateOptions: {
-        //     label: T.F.JIRA.FORM_CRED.ALLOW_SELF_SIGNED,
-        //   },
-        // },
+        {
+          key: 'isAllowSelfSignedCertificate',
+          type: 'checkbox',
+          templateOptions: {
+            label: T.F.JIRA.FORM_CRED.ALLOW_SELF_SIGNED,
+          },
+        },
         {
           key: 'usePAT',
           type: 'checkbox',


### PR DESCRIPTION
# Description

I was looking for a way to allow super-productivity to connect to jira through a corporate proxy and realized the code already had support for it, but the UI config option was disabled.   All I'm doing is uncommenting it to let it show up in the ui again.

Note: The commit commenting the option out mentioned it being being an edge case, but I think a lot of corporate/enterprise users would run into the same issue due to corporate proxies mitm'ing everything and/or using a self-signed CA.   It also didn't look like there's a built-in way for electron apps to use the system trust store.

## Issues Resolved

- https://github.com/johannesjo/super-productivity/issues/348

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
