### PR TITLE
fix: Manually confirm starting next break conflicts with Disable auto-start of session after break

### DIFF
--- a/src/app/features/pomodoro/pomodoro.service.ts
+++ b/src/app/features/pomodoro/pomodoro.service.ts
@@ -158,6 +158,10 @@ export class PomodoroService {
       .subscribe(([val, cfg, isBreak]) => {
         if (cfg.isManualContinueBreak && !isBreak) {
           this.pauseBreak(true);
+
+          if (cfg.isDisableAutoStartAfterBreak) {
+            this._taskService.pauseCurrent();
+          }
         } else if (cfg.isManualContinue && isBreak) {
           this.pause(true);
 


### PR DESCRIPTION
# Description

After releasing the new option of Pomodoro @kurt-steiner found a bug: the tracker still tracks time when "Manually confirm starting the next break" is enabled. This fix addresses that bug.

## Issues Resolved
[the bug](https://github.com/johannesjo/super-productivity/issues/5023)

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
