### PR TITLE
AUR: include checksums

### DIFF
--- a/.github/workflows/build-publish-to-aur-on-release.yml
+++ b/.github/workflows/build-publish-to-aur-on-release.yml
@@ -18,10 +18,11 @@ jobs:
       - run: sed "s/PACKAGE_VERSION/${package_version}/g" build/linux/PKGBUILD_template > build/linux/PKGBUILD
 
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
         with:
           pkgname: superproductivity-bin
           pkgbuild: build/linux/PKGBUILD
+          updpkgsums: true
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/build/linux/PKGBUILD_template
+++ b/build/linux/PKGBUILD_template
@@ -13,8 +13,8 @@ depends=('gtk3' 'nss')
 provides=("${_pkgname}")
 conflicts=("${_pkgname}"
 		   "${_pkgname}-git")
-md5sums=('SKIP')
 source=("superproductivity-${pkgver}-amd64.deb::https://github.com/johannesjo/super-productivity/releases/download/v${pkgver}/superProductivity-amd64.deb")
+sha256sums=('SKIP')
 
 package() {
 	tar -xvf data.tar.xz -C "${pkgdir}"


### PR DESCRIPTION
# Description

Users asked for checksums to be included in the AUR comments, https://github.com/johannesjo/super-productivity/pull/4495#issuecomment-2953933666 suggests adding a checksums file to the releases first, but I figured that the github actions that is being used already includes a feature to handle that, so this became an straightforward one. Also now it uses sha265 sums which should be more satisfactory.

cc: @alosarjos

## Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
