### PR TITLE
fix: incorrect sidebar opening when dragging

### DIFF
--- a/src/app/ui/better-drawer/better-drawer-container/better-drawer-container.component.scss
+++ b/src/app/ui/better-drawer/better-drawer-container/better-drawer-container.component.scss
@@ -25,18 +25,10 @@ $z-this-backdrop: calc(var(--z-task-side-bar-over) - 1);
   position: relative;
   z-index: var(--z-side-panel-task-and-notes);
   transition: var(--transition-leave);
-  transition-property: opacity, margin-right, right, transform;
-  // NOTE: if this value is to big it might mess, with the push out logic, as
-  // the width is not really 40% any more
-  min-width: 200px;
+  transition-property: opacity, width, right, transform;
   // NOTE: prevents overlapping with nav when open
   max-width: 700px;
   background: var(--right-panel-bg);
-  //border: 1px solid;
-  //border-right: 0;
-  //border-bottom: 0;
-  //border-color: var(--extra-border-color);
-  //box-shadow: 0px 8px 10px -5px var(--c-dark-20), 0px 16px 24px 2px rgba(0, 0, 0, 0.14), 0px 6px 30px 5px var(--divider-color) !important;
 
   @include mq(sm, max) {
     // NOTE: prevents overlapping with nav when open

--- a/src/app/ui/better-drawer/better-drawer-container/better-drawer-container.component.ts
+++ b/src/app/ui/better-drawer/better-drawer-container/better-drawer-container.component.ts
@@ -21,6 +21,7 @@ import { NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { filter, map, switchMap, startWith } from 'rxjs/operators';
 import { of, timer } from 'rxjs';
 import { SwipeDirective } from '../../swipe-gesture/swipe.directive';
+import { CssString, StyleObject, StyleObjectToString } from '../../../util/styles';
 
 const SMALL_CONTAINER_WIDTH = 620;
 const VERY_SMALL_CONTAINER_WIDTH = 450;
@@ -145,19 +146,17 @@ export class BetterDrawerContainerComponent implements OnDestroy {
     this.wasClosed.emit();
   }
 
-  private _getWidthRelatedStyles(): string {
-    const widthStyle = ` width: ${this.sideWidth()}%;`;
-    const margin = this.isRTL() ? 'margin-left' : 'margin-right';
+  private _getWidthRelatedStyles(): CssString {
     const isOpen = this.isOpen();
     const isOver = this.isOver();
 
-    return isOver
-      ? isOpen
-        ? 'transform: translateX(0);'
-        : 'transform: translateX(100%);'
-      : isOpen
-        ? `${margin}: 0; ${widthStyle}`
-        : `${margin}: ${-1 * this.sideWidth()}%; ${widthStyle}`;
+    const styles: StyleObject = { width: isOpen ? `${this.sideWidth()}%` : '0' };
+
+    if (isOver) {
+      styles.transform = `${isOpen ? 'translateX(0)' : 'translateX(100%)'}`;
+    }
+
+    return StyleObjectToString(styles);
   }
 
   private _setupResizeObserver(element: HTMLElement): void {

--- a/src/app/util/styles.ts
+++ b/src/app/util/styles.ts
@@ -1,0 +1,27 @@
+/**
+ * Represents a CSS style object
+ * @example
+ * const style: StyleObject = { width: '100px', height: '200px' };
+ */
+export type StyleObject = Record<string, string>;
+
+/**
+ * Represents a CSS string
+ * @example
+ * const css: CssString = "width: 100px; height: 200px;";
+ */
+export type CssString = `${string}: ${string};`;
+
+/**
+ * Converts a StyleObject to CssString
+ *
+ * @example
+ * const style: StyleObject = { width: '100px', height: '200px' };
+ * const cssString: CssString = StyleObjectToString(style);
+ * console.log(cssString); // "width: 100px; height: 200px;"
+ */
+export const StyleObjectToString = (style: StyleObject): CssString => {
+  return Object.entries(style)
+    .map(([key, value]) => `${key}: ${value};`)
+    .join(' ') as CssString;
+};


### PR DESCRIPTION
# Description

This PR solves an issue where the right sidebar of better-drawer-container would unnecessarily expand when dragging elements to the right side, causing the entire layout to shift to the side and making the panel visible (even though isOpen: false)

A small refactoring was also done to make the code cleaner:
1. Unnecessary and old commented css properties were removed
2. Helper types `StyleObject` and `CssString` were created, as well as a function for converting `StyleObject` to a `CssString`

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/5017
