### PR TITLE
fix: remove unnecessary condition to show subtasks in task-detail-pan…

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -278,11 +278,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
   // Template helper computed signals
   showSubTasksPanel = computed(() => {
     const task = this.task();
-    return (
-      task &&
-      !task.parentId &&
-      (this.layoutService.isRightPanelOver() || this.isDialogMode())
-    );
+    return task && !task.parentId;
   });
 
   showTimeEstimate = computed(() => !this.task().subTasks?.length);


### PR DESCRIPTION
# Description

Removed unnecessary (IMHO) conditions for displaying subtasks in the task-detail-panel component. Now the "subtasks" section will always be shown if the task is not a subtask (don't have a `parentId`)

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/5053
