### PR TITLE
fix: close task-detail-panel by shortcut

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,6 +86,7 @@ import { ProjectService } from './features/project/project.service';
 import { TagService } from './features/tag/tag.service';
 import { ContextMenuComponent } from './ui/context-menu/context-menu.component';
 import { WorkContextThemeCfg } from './features/work-context/work-context.model';
+import { IsInputElement } from './util/dom-element';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
@@ -334,29 +335,17 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   }
 
   @HostListener('document:paste', ['$event']) onPaste(ev: ClipboardEvent): void {
-    // Only handle paste if not in an input/textarea
+    // Skip handling inside input elements
     const target = ev.target as HTMLElement;
-    if (
-      target.tagName === 'INPUT' ||
-      target.tagName === 'TEXTAREA' ||
-      target.isContentEditable
-    ) {
-      return;
-    }
+    if (IsInputElement(target)) return;
 
     const clipboardData = ev.clipboardData;
-    if (!clipboardData) {
-      return;
-    }
+    if (!clipboardData) return;
 
     const pastedText = clipboardData.getData('text/plain');
-    if (!pastedText) {
-      return;
-    }
+    if (!pastedText) return;
 
-    if (!this._markdownPasteService.isMarkdownTaskList(pastedText)) {
-      return;
-    }
+    if (!this._markdownPasteService.isMarkdownTaskList(pastedText)) return;
 
     // Prevent default paste behavior
     ev.preventDefault();

--- a/src/app/core-ui/shortcut/shortcut.service.ts
+++ b/src/app/core-ui/shortcut/shortcut.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { IS_ELECTRON } from '../../app.constants';
 import { checkKeyCombo } from '../../util/check-key-combo';
+import { IsInputElement } from '../../util/dom-element';
 import { GlobalConfigService } from '../../features/config/global-config.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LayoutService } from '../layout/layout.service';
@@ -81,15 +82,8 @@ export class ShortcutService {
     const keys = cfg.keyboard;
     const el = ev.target as HTMLElement;
 
-    // don't run when inside input or text area and if no special keys are used
-    if (
-      ((el && el.tagName.toUpperCase() === 'INPUT') ||
-        el.tagName.toUpperCase() === 'TEXTAREA' ||
-        el.getAttribute('contenteditable')) &&
-      !ev.metaKey
-    ) {
-      return;
-    }
+    // Skip handling if no special keys are used and inside input elements
+    if (!ev.metaKey && IsInputElement(el)) return;
 
     if (
       checkKeyCombo(ev, keys.toggleBacklog) &&

--- a/src/app/features/note/note.service.ts
+++ b/src/app/features/note/note.service.ts
@@ -22,6 +22,7 @@ import { DropPasteInput } from '../../core/drop-paste-input/drop-paste.model';
 import { WorkContextService } from '../work-context/work-context.service';
 import { WorkContextType } from '../work-context/work-context.model';
 import { PfapiService } from '../../pfapi/pfapi.service';
+import { IsInputElement } from '../../util/dom-element';
 
 @Injectable({
   providedIn: 'root',
@@ -111,15 +112,11 @@ export class NoteService {
 
   private async _handleInput(drop: DropPasteInput, ev: Event): Promise<void> {
     // properly not intentional so we leave
-    if (!drop || !drop.path || drop.type === 'FILE') {
-      return;
-    }
+    if (!drop || !drop.path || drop.type === 'FILE') return;
 
-    // don't intervene with text inputs
+    // Skip handling inside input elements
     const target = ev.target as HTMLElement;
-    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
-      return;
-    }
+    if (IsInputElement(target)) return;
 
     const note: Partial<Note> = {
       content: drop.path,

--- a/src/app/features/tasks/task-attachment/task-attachment.service.ts
+++ b/src/app/features/tasks/task-attachment/task-attachment.service.ts
@@ -13,6 +13,7 @@ import {
 import { TaskState } from '../task.model';
 import { createFromDrop } from 'src/app/core/drop-paste-input/drop-paste-input';
 import { TaskLog } from '../../../core/log';
+import { IsInputElement } from '../../../util/dom-element';
 
 @Injectable({
   providedIn: 'root',
@@ -76,14 +77,7 @@ export class TaskAttachmentService {
 
     // don't intervene with text inputs
     const targetEl = ev.target as HTMLElement;
-    if (
-      !isSkipTextareaCheck &&
-      (targetEl.tagName === 'INPUT' ||
-        (targetEl.tagName === 'TEXTAREA' &&
-          targetEl.parentElement?.tagName.toLowerCase() !== 'inline-multiline-input'))
-    ) {
-      return;
-    }
+    if (!isSkipTextareaCheck && IsInputElement(targetEl)) return;
 
     ev.preventDefault();
     ev.stopPropagation();

--- a/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.ts
@@ -16,6 +16,7 @@ import {
   MatExpansionPanelHeader,
   MatExpansionPanelTitle,
 } from '@angular/material/expansion';
+import { IsInputElement } from '../../../../util/dom-element';
 
 @Component({
   selector: 'task-detail-item',
@@ -53,11 +54,9 @@ export class TaskDetailItemComponent {
   @HostBinding('tabindex') readonly tabindex: number = 3;
 
   @HostListener('keydown', ['$event']) onKeyDown(ev: KeyboardEvent): void {
-    const tagName = (ev.target as HTMLElement).tagName.toLowerCase();
-
-    if (tagName === 'input' || tagName === 'textarea') {
-      return;
-    }
+    // Skip handling inside input elements
+    const targetEl = ev.target as HTMLElement;
+    if (IsInputElement(targetEl)) return;
 
     this.keyPress.emit(ev);
     if (ev.code === 'Escape') {

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -75,6 +75,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { isMarkdownChecklist } from '../../markdown-checklist/is-markdown-checklist';
 import { Log } from '../../../core/log';
+import { IsInputElement } from '../../../util/dom-element';
 
 @Component({
   selector: 'task-detail-panel',
@@ -142,6 +143,21 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
 
   // Observable conversions
   private _task$ = toObservable(this.task);
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(ev: KeyboardEvent): void {
+    // Skip handling inside input elements
+    const target = ev.target as HTMLElement;
+    if (IsInputElement(target)) return;
+
+    const cfg = this._globalConfigService.cfg();
+    if (!cfg) throw new Error('No config service available');
+
+    const keys = cfg.keyboard;
+    const matchesKeybinding = keys.taskToggleDetailPanelOpen === ev.key;
+
+    if (matchesKeybinding) this.collapseParent();
+  }
 
   // Parent task data
   parentTaskData = toSignal(

--- a/src/app/util/dom-element.ts
+++ b/src/app/util/dom-element.ts
@@ -1,0 +1,10 @@
+// HERE YOU CAN PUT HELPFUL UTIL FUNCTIONS RELATED TO DOM ELEMENTS
+
+/** Checks if the element is an input (input, textarea, or contenteditable) */
+export const IsInputElement = (el: HTMLElement): boolean => {
+  return !!(
+    el.tagName.toUpperCase() === 'INPUT' ||
+    el.tagName.toUpperCase() === 'TEXTAREA' ||
+    el.isContentEditable
+  );
+};


### PR DESCRIPTION
# Description

- First commit: handled the shortcut for closing the task-detail-panel
- Second commit: made a small refactoring: use `IsInputElement` function to avoid code duplication

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/4978
