### PR TITLE
fix: Changing settings (not related to the Pomodoro) resets the Pomodoro timer

### DIFF
--- a/src/app/features/pomodoro/pomodoro.service.ts
+++ b/src/app/features/pomodoro/pomodoro.service.ts
@@ -52,6 +52,7 @@ export class PomodoroService {
 
   cfg$: Observable<PomodoroConfig> = this._configService.cfg$.pipe(
     map((cfg) => cfg && cfg.pomodoro),
+    distinctUntilChanged(),
   );
   soundConfig$: Observable<SoundConfig> = this._configService.cfg$.pipe(
     map((cfg) => cfg && cfg.sound),


### PR DESCRIPTION
# Description

This change fixes the issue reported in #4879 where changing any of the settings other than pomodoro settings reset the pomodoro timer

## Issues Resolved

#4879 

