### PR TITLE
added User-Agent Header to outlook.live.com requests

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -119,7 +119,7 @@ export const createWindow = ({
 
     // NOTE this is needed for GitHub api requests to work :(
     // office365 needs a User-Agent as well (#4677)
-    if (!details.url.includes('github.com') && !details.url.includes('office365.com')) {
+    if (!details.url.includes('github.com') && !details.url.includes('office365.com') && !details.url.includes('outlook.live.com') {
       removeKeyInAnyCase(requestHeaders, 'User-Agent');
     }
     callback({ requestHeaders });


### PR DESCRIPTION
# Description

A friend of mine had a similar issue with outlook.live.com calender links, since he is not using a business account.
Appearently outlook.live.com needs the User-Agent to be set in http requests since a few weeks.
Not sending it broke Outlook Live calendar integration

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/4677

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
