### PR TITLE
perf: prevent unnecessary change change detections with high-frequenc…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -322,15 +322,15 @@ export class AppComponent implements OnDestroy, AfterViewInit {
         this._initMultiInstanceWarning();
       }
     }
+
+    // prevent page reloads on missed drops
+    document.addEventListener('dragover', (ev) => {
+      ev.preventDefault();
+    });
   }
 
   @HostListener('document:keydown', ['$event']) onKeyDown(ev: KeyboardEvent): void {
     this._shortcutService.handleKeyDown(ev);
-  }
-
-  // prevent page reloads on missed drops
-  @HostListener('document:dragover', ['$event']) onDragOver(ev: DragEvent): void {
-    ev.preventDefault();
   }
 
   @HostListener('document:drop', ['$event']) onDrop(ev: DragEvent): void {

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -2,8 +2,8 @@
 import {
   Component,
   computed,
+  DestroyRef,
   effect,
-  HostListener,
   inject,
   input,
   OnDestroy,
@@ -50,6 +50,7 @@ const MOBILE_NAV_WIDTH = 300;
   animations: magicSideNavAnimations,
 })
 export class MagicSideNavComponent implements OnInit, OnDestroy {
+  private readonly _destroyRef = inject(DestroyRef);
   private readonly _sideNavConfigService = inject(MagicNavConfigService);
   private readonly _taskService = inject(TaskService);
   private readonly _layoutService = inject(LayoutService);
@@ -115,6 +116,11 @@ export class MagicSideNavComponent implements OnInit, OnDestroy {
         lsSetItem(LS.NAV_SIDEBAR_WIDTH, width.toString());
       }
     });
+    const resizeListener = (): void => this._checkScreenSize();
+    window.addEventListener('resize', resizeListener);
+    this._destroyRef.onDestroy(() => {
+      window.removeEventListener('resize', resizeListener);
+    });
   }
 
   ngOnDestroy(): void {
@@ -150,11 +156,6 @@ export class MagicSideNavComponent implements OnInit, OnDestroy {
       this.isFullMode.set(this.config().fullModeByDefault);
       this.currentWidth.set(this.config().defaultWidth);
     }
-  }
-
-  @HostListener('window:resize')
-  onWindowResize(): void {
-    this._checkScreenSize();
   }
 
   onNavKeyDown(event: KeyboardEvent): void {


### PR DESCRIPTION
…y listeners

Listeners schedule change detection, even in zoneless, so those that are high frequency should be used sparingly. The listeners in this commit do not require any template refreshes most of the time and should instead use native `addEventListener` to avoid unnecessary refreshes. While the application uses `OnPush`, doing a small amount of a lot of times can still have performance implications.

https://github.com/angular/angular/issues/61839
