### PR TITLE
fix: plugin icons not shown on the left sidebar #5125

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
+++ b/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
@@ -337,14 +337,20 @@ export class MagicNavConfigService {
   private _buildPluginItems(): NavItem[] {
     const pluginEntries = this._pluginMenuEntries();
 
-    return pluginEntries.map((entry) => ({
-      type: 'plugin',
-      id: `plugin-${entry.pluginId}-${entry.label}`,
-      label: entry.label,
-      icon: entry.icon || 'extension',
-      pluginId: entry.pluginId,
-      action: entry.onClick,
-    }));
+    return pluginEntries.map((entry) => {
+      const hasSvgIcon = /\.svg$/i.test(entry.icon || '');
+      return {
+        type: 'plugin',
+        id: `plugin-${entry.pluginId}-${entry.label}`,
+        label: entry.label,
+        icon: entry.icon || 'extension',
+        ...(hasSvgIcon && {
+          svgIcon: `assets/bundled-plugins/${entry.pluginId}/${entry.icon}`,
+        }),
+        pluginId: entry.pluginId,
+        action: entry.onClick,
+      };
+    });
   }
 
   // Public computed signals for expansion state (for component to check)

--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.html
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.html
@@ -189,7 +189,7 @@
           [class.expand-icon]="container() === 'group' && svgIcon() === 'expand_more'"
           [class.icon--svg]="true"
           [class.icon--early-on]="svgIcon() === 'early_on'"
-          [svgIcon]="svgIcon()"
+          [svgIcon]="namedSvgIcon()"
         ></mat-icon>
       } @else if (icon()) {
         <mat-icon

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -189,6 +189,13 @@ export class GlobalThemeService {
     return Promise.all(iconPromises);
   }
 
+  registerSvgIcon(iconName: string, url: string): void {
+    this._matIconRegistry.addSvgIcon(
+      iconName,
+      this._domSanitizer.bypassSecurityTrustResourceUrl(url),
+    );
+  }
+
   private _initThemeWatchers(): void {
     // init theme watchers
     this._workContextService.currentTheme$.subscribe((theme: WorkContextThemeCfg) =>


### PR DESCRIPTION
# Description

- Register SVG icons in the Global Theme service in order to associate an icon's name with icon URL
- Generate names for SVG icons based on the plugin ID. This is to avoid collision. If two plugin uses the same name for their icons, the one who is registered later will override the previous one.
- Test if any activated plugin contains SVG icon. If yes, add a property `svgIcon` to the plugin entry. This will take precedence over the `icon` property.

## Issues Resolved

fixes #5125

After the fix

<img width="1217" height="684" alt="Screenshot from 2025-09-22 23-59-51" src="https://github.com/user-attachments/assets/ee09a6c8-c222-412b-b890-63e8388f4169" />

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
