### PR TITLE
dialog-confirm: change default to 'OK'

### DIFF
--- a/src/app/ui/dialog-confirm/dialog-confirm.component.html
+++ b/src/app/ui/dialog-confirm/dialog-confirm.component.html
@@ -16,7 +16,7 @@
 <mat-dialog-actions align="end">
   <div class="wrap-buttons">
     <button
-      tabindex="1"
+      tabindex="2"
       #cancelButton
       (click)="close(false)"
       class="btn btn-primary"
@@ -29,7 +29,7 @@
     </button>
 
     <button
-      tabindex="2"
+      tabindex="1"
       #confirmButton
       (click)="close(true)"
       e2e="confirmBtn"


### PR DESCRIPTION
# Description

For dialog-confirm modals, change the initially selected / default button from 'cancel' to 'ok' (by switching the tabindex of both). This should make 'OK' the default action when pressing Return on a keyboard, and thus assuming that the user knows what they're doing, and don't need an extre keypress (right arrow) to confirm creating a new tag.

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/5180

## Check List

- [%] New functionality includes testing. _Haven't figured out how to compile the code from source yet, so haven't tested 🫣_
- [%] New functionality has been documented in the README if applicable. _Don't think it's needed._
