### PR TITLE
build: correct tsconfig.app.json file includes

### DIFF
--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -7,7 +7,14 @@
     "allowSyntheticDefaultImports": true
   },
   "files": ["main.ts", "polyfills.ts"],
-  "include": ["**/*.d.ts"],
+  "include": ["app/**/*.ts"],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.worker.ts",
+    "**/__mocks__/**",
+    "**/test-utils.ts",
+    "app/util/**/*.ts"
+  ],
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true


### PR DESCRIPTION
This appears to have been broken in the upgrade to angular 9 in 2020: https://github.com/johannesjo/super-productivity/commit/f9d9454034ee776d0bd07140dd65d4db98babf91#diff-90318a63edd01d7a315da6833f32e2c4f30c4048067598f0cd7b3be879963895

By only including the entrypoint "main.ts" in the files list, without any include glob, no downstream files can be associated with the tsconfig project file until the 'main.ts' entrypoint has been opened in the editor. As a result, language service features are limited. For example, in VSCode:

1. Close all editor files
2. Run "Developer: Reload window"
3. Open app.component.ts
4. right click on `AppComponent` and click "Find All References"

The references result will _not_ include 'main.ts' as it should. The typescript language service is able to provide only basic language features (which excludes full type checking, references, path alias resolution, etc) until the file can be associated with a tsconfig.

In addition, the Angular Language Service cannot operate until the `main.ts` file has been opened to associate the application files with the `tsconfig.app.json`.

This update more closely matches the `tsconfig.app.json` template used for new Angular projects, found here:
https://github.com/angular/angular-cli/blob/672ae14cd21d02a3b4727e2febd88747b9e4c684/packages/schematics/angular/application/files/common-files/tsconfig.app.json.template
