### PR TITLE
fix(task): improve project name parsing from task input (#4225)

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1021,6 +1021,35 @@ describe('shortSyntax', () => {
     });
   });
 
+  describe('projects using special delimiters', () => {
+    const taskTemplates = [
+      'Task *',
+      'Task * 10m',
+      'Task * 1h / 2d',
+      'Task * @tomorrow',
+      'Task * @in 1 day',
+      'Task * #A',
+    ];
+
+    const projects = ['a+b', '10 contracts', 'c++', 'my@email.com', 'issue#123'].map(
+      (title) => ({ id: title, title }) as Project,
+    );
+
+    for (const taskTemplate of taskTemplates) {
+      for (const project of projects) {
+        const taskTitle = taskTemplate.replaceAll('*', `+${project.title}`);
+        it(`should parse project "${project.title}" from "${taskTitle}"`, () => {
+          const task = {
+            ...TASK,
+            title: taskTitle,
+          };
+          const result = shortSyntax(task, CONFIG, ALL_TAGS, projects);
+          expect(result?.projectId).toBe(project.id);
+        });
+      }
+    }
+  });
+
   // This group of tests address Chrono's parsing the format "<date> <month> <yy}>" as year
   // This will cause unintended parsing result when the date syntax is used together with the time estimate syntax
   // https://github.com/johannesjo/super-productivity/issues/4194

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -66,7 +66,13 @@ customDateParser.refiners.push({
   },
 });
 
-const SHORT_SYNTAX_PROJECT_REG_EX = new RegExp(`\\${CH_PRO}[^${ALL_SPECIAL}]+`, 'gi');
+// The following project name extraction pattern attempts to improve on the
+// previous version by not immediately terminating upon encountering a short
+// syntax delimiting character and looks ahead to consider usage context
+const SHORT_SYNTAX_PROJECT_REG_EX = new RegExp(
+  `\\${CH_PRO}((?:(?!\\s+(?:\\${CH_TAG}|\\${CH_DUE}|t?\\d+[mh]\\b)).)+)`,
+  'i',
+);
 const SHORT_SYNTAX_TAGS_REG_EX = new RegExp(`\\${CH_TAG}[^${ALL_SPECIAL}|\\s]+`, 'gi');
 
 // Literal notation: /\@[^\+|\#|\@]/gi
@@ -198,7 +204,10 @@ const parseProjectChanges = (
 
     if (existingProject) {
       return {
-        title: task.title?.replace(`${CH_PRO}${projectTitle}`, '').trim(),
+        title: task.title
+          ?.replace(`${CH_PRO}${projectTitle}`, '')
+          .trim()
+          .replace('  ', ' '),
         projectId: existingProject.id,
       };
     }


### PR DESCRIPTION
# Description

Hello there,

I've revised the regular expression that was being used to parse project names from task text input for better accuracy. When adding new tasks, it should better cope with project names which happen to use special characters part of the short syntax feature.

The following screen capture is behaviour based on `15.0.3` via https://app.super-productivity.com.

![old behaviour](https://github.com/user-attachments/assets/34bbf526-7d54-471e-98c8-3947a189f3f4)

And here's the behaviour based on the current state of `master` plus my changes.

![new behaviour](https://github.com/user-attachments/assets/70d5d70f-6577-4061-b937-5ecf91cbba47)

I've included a whole slew of data-driven tests to try capture as many parse cases as possible. If this is too much, let me know and I can redact as necessary.

## Issues Resolved

#4225

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.