### PR TITLE
fix(task): prefer shortest project title prefix match (#4225)

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -892,6 +892,25 @@ describe('shortSyntax', () => {
       const r = shortSyntax(t, CONFIG, [], projects);
       expect(r).toEqual(undefined);
     });
+
+    it('should prefer shortest prefix full project title match', () => {
+      const t = {
+        ...TASK,
+        title: 'Task +print',
+      };
+      projects = ['printer', 'imprints', 'print', 'printable'].map(
+        (title) => ({ id: title, title }) as Project,
+      );
+      const r = shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: 'print',
+        taskChanges: {
+          title: 'Task',
+        },
+      });
+    });
   });
 
   describe('combined', () => {

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -187,7 +187,7 @@ const parseProjectChanges = (
 
   if (rr && rr[0]) {
     const projectTitle: string = rr[0].trim().replace(CH_PRO, '');
-    const projectTitleToMatch = projectTitle.replace(' ', '').toLowerCase();
+    const projectTitleToMatch = projectTitle.replaceAll(' ', '').toLowerCase();
     const indexBeforePlus =
       task.title.toLowerCase().lastIndexOf(CH_PRO + projectTitleToMatch) - 1;
     const charBeforePlus = task.title.charAt(indexBeforePlus);
@@ -197,9 +197,15 @@ const parseProjectChanges = (
       return {};
     }
 
-    const existingProject = allProjects.find(
+    // Prefer shortest prefix-based project title match
+    const sortedAllProjects = allProjects
+      .slice()
+      .sort((p1, p2) => p1.title.length - p2.title.length);
+
+    const existingProject = sortedAllProjects.find(
       (project) =>
-        project.title.replace(' ', '').toLowerCase().indexOf(projectTitleToMatch) === 0,
+        project.title.replaceAll(' ', '').toLowerCase().indexOf(projectTitleToMatch) ===
+        0,
     );
 
     if (existingProject) {
@@ -215,9 +221,10 @@ const parseProjectChanges = (
     // also try only first word after special char
     const projectTitleFirstWordOnly = projectTitle.split(' ')[0];
     const projectTitleToMatch2 = projectTitleFirstWordOnly.replace(' ', '').toLowerCase();
-    const existingProjectForFirstWordOnly = allProjects.find(
+    const existingProjectForFirstWordOnly = sortedAllProjects.find(
       (project) =>
-        project.title.replace(' ', '').toLowerCase().indexOf(projectTitleToMatch2) === 0,
+        project.title.replaceAll(' ', '').toLowerCase().indexOf(projectTitleToMatch2) ===
+        0,
     );
 
     if (existingProjectForFirstWordOnly) {


### PR DESCRIPTION
# Description

Hello there,

This is a follow-up to an earlier changeset I submitted to try improve how project titles are parsed out of task input (#5223).

Specifically, it tries to address cases where there are multiple projects that share a common prefix with one another. The project parsing step of short syntax can incorrectly return the first project it comes across that matches with a prefix being typed in the task text input. This can be influenced by the (chronological) order in which projects themselves are created (i.e. creating a project with the shortest prefix first can mitigate this issue).

Here are screen captures demonstrating the same interactions without and with my new changeset.

![4](https://github.com/user-attachments/assets/5efa0d94-3475-44aa-8ed2-02fea56f265e)

![5](https://github.com/user-attachments/assets/a49ecb7b-c979-4a5d-9c34-4c1fa5d29fbd)

And another which is more specific to the case presented in #4225:

![6](https://github.com/user-attachments/assets/2ad6c3c3-a268-420a-a021-1dd22a573714)

Some leftover thoughts I had but didn't act on, though I'm happy to try improve upon further if there are concrete suggestions:

- I was unsure if the aggressive project auto-completion (bottom-left of add task bar) is an intentional feature. For example, if I had two projects: "Management" and "Marketing", if my task input is "task +ma" the add task bar can assign either one of these, even though the auto-completion is ambiguous at that point. An alternative could be to defer auto-completion until it's clear that the entered project short syntax isn't ambiguous (e.g. "task +man").
- The usefulness for the fallback phase of project parsing (i.e. using the first word only of user input) isn't obvious to me. We can consider an example: "task +team one" with projects "Team 1" and "Team 2". Since a full project input title match isn't possible, a match by "team" is tried instead, which can assign (non-deterministically at the moment) either projects. And since the replacement, at the moment, is only going to use the first word, the consumed task input ends up being "task one". One might say the latter is incorrect, in that the replacement should've also consumed "one", but this is unclear to me.


## Issues Resolved

#4225

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
