### PR TITLE
fix: Error When Building Solid Js Plugin

### DIFF
--- a/packages/plugin-dev/boilerplate-solid-js/src/plugin.ts
+++ b/packages/plugin-dev/boilerplate-solid-js/src/plugin.ts
@@ -1,10 +1,10 @@
 import {
   AnyTaskUpdatePayload,
   PluginAPI,
-  PluginHooks,
   TaskCompletePayload,
   TaskUpdatePayload,
 } from '@super-productivity/plugin-api';
+import type { PluginHooks } from '@super-productivity/plugin-api';
 
 declare const plugin: PluginAPI;
 


### PR DESCRIPTION
# Description

When running `npm run build` inside `boilerplate-solid-js` project, an error will appear:

> error during build:
src/plugin.ts (4:2): "PluginHooks" is not exported by "../../plugin-api/dist/index.js", imported by "src/plugin.ts".

Since `PluginHooks` is a type, not an interface, I've changed the import syntax to `import type { PluginHooks } ...`.
## Issues Resolved

NA

## Check List

- [x] New functionality includes testing.
