### PR TITLE
fix(settings): add color input for cross-browser consistency (#3931)

### DIFF
--- a/src/app/features/config/color-input/color-input.component.html
+++ b/src/app/features/config/color-input/color-input.component.html
@@ -1,0 +1,11 @@
+<mat-form-field>
+  <mat-label>{{ to.label }}</mat-label>
+  <input
+    type="color"
+    class="color-input"
+    [formControl]="formControl"
+    [formlyAttributes]="field"
+    (focus)="onFocus($event)"
+    matInput
+  />
+</mat-form-field>

--- a/src/app/features/config/color-input/color-input.component.scss
+++ b/src/app/features/config/color-input/color-input.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+  width: 100%;
+}

--- a/src/app/features/config/color-input/color-input.component.ts
+++ b/src/app/features/config/color-input/color-input.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatFormField, MatInput, MatLabel } from '@angular/material/input';
+import { FieldType, FormlyModule } from '@ngx-formly/core';
+import { IS_FIREFOX } from '../../../util/is-firefox';
+import { IS_MOBILE } from '../../../util/is-mobile';
+
+/**
+ * This component deliberately avoids Formly's field type abstractions for the
+ * Material UI components because the form field wrapper implementation uses
+ * a focus monitoring service that is counterproductive for certain native
+ * color input controls.
+ */
+@Component({
+  selector: 'color-input',
+  templateUrl: './color-input.component.html',
+  styleUrls: ['./color-input.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormlyModule, MatFormField, MatInput, MatLabel, ReactiveFormsModule],
+})
+export class ColorInputComponent extends FieldType {
+  onFocus(event: FocusEvent): void {
+    if (!IS_FIREFOX || IS_MOBILE) return;
+    // Desktop Firefox oddly fires another focus event when the native color
+    // input closes rather than a blur event, so determine whether a value
+    // change has occurred and force a blur to have it persisted
+    const input = event.target as HTMLInputElement;
+    if (input.value !== this.formControl.value) {
+      input.blur();
+    }
+  }
+}

--- a/src/app/features/project/project-form-cfg.const.ts
+++ b/src/app/features/project/project-form-cfg.const.ts
@@ -57,10 +57,9 @@ export const CREATE_PROJECT_BASIC_CONFIG_FORM_CONFIG: ConfigFormSection<Project>
     },
     {
       key: 'theme.primary' as any,
-      type: 'input',
+      type: 'color',
       templateOptions: {
         label: T.F.PROJECT.FORM_THEME.L_THEME_COLOR,
-        type: 'color',
       },
     },
     {

--- a/src/app/features/tag/tag-form-cfg.const.ts
+++ b/src/app/features/tag/tag-form-cfg.const.ts
@@ -24,10 +24,9 @@ export const BASIC_TAG_CONFIG_FORM_CONFIG: ConfigFormSection<Tag> = {
     },
     {
       key: 'color',
-      type: 'input',
+      type: 'color',
       templateOptions: {
         label: T.F.TAG.FORM_BASIC.L_COLOR,
-        type: 'color',
       },
     },
   ],

--- a/src/app/features/work-context/work-context.const.ts
+++ b/src/app/features/work-context/work-context.const.ts
@@ -65,26 +65,23 @@ export const WORK_CONTEXT_THEME_CONFIG_FORM_CONFIG: ConfigFormSection<WorkContex
     items: [
       {
         key: 'primary',
-        type: 'input',
+        type: 'color',
         templateOptions: {
           label: T.F.PROJECT.FORM_THEME.L_COLOR_PRIMARY,
-          type: 'color',
         },
       },
       {
         key: 'accent',
-        type: 'input',
+        type: 'color',
         templateOptions: {
           label: T.F.PROJECT.FORM_THEME.L_COLOR_ACCENT,
-          type: 'color',
         },
       },
       {
         key: 'warn',
-        type: 'input',
+        type: 'color',
         templateOptions: {
           label: T.F.PROJECT.FORM_THEME.L_COLOR_WARN,
-          type: 'color',
         },
       },
       {

--- a/src/app/ui/formly-config.module.ts
+++ b/src/app/ui/formly-config.module.ts
@@ -22,6 +22,7 @@ import { FormlyMatSliderModule } from '@ngx-formly/material/slider';
 import { FormlyTagSelectionComponent } from './formly-tag-selection/formly-tag-selection.component';
 import { FormlyBtnComponent } from './formly-button/formly-btn.component';
 import { FormlyImageInputComponent } from './formly-image-input/formly-image-input.component';
+import { ColorInputComponent } from '../features/config/color-input/color-input.component';
 
 @NgModule({
   imports: [
@@ -63,6 +64,10 @@ import { FormlyImageInputComponent } from './formly-image-input/formly-image-inp
           component: IconInputComponent,
           extends: 'input',
           wrappers: ['form-field'],
+        },
+        {
+          name: 'color',
+          component: ColorInputComponent,
         },
         {
           name: 'project-select',

--- a/src/app/util/adjust-to-live-formly-form.ts
+++ b/src/app/util/adjust-to-live-formly-form.ts
@@ -15,7 +15,8 @@ export const adjustToLiveFormlyForm = (
       item.type === 'input' ||
       item.type === 'textarea' ||
       item.type === 'duration' ||
-      item.type === 'icon'
+      item.type === 'icon' ||
+      item.type === 'color'
     ) {
       return {
         ...item,


### PR DESCRIPTION
# Description

Hello there,

This is an attempt to improve the consistency of editing colour-related settings using the native colour picker across different browser environments. More specifically, aimed at addressing the quirkiness of the control provided by Firefox.

I started by reviewing how `<input type="color" />` behaved in isolation (i.e. vanilla HTML and JS). After binding event listeners to `focus` and `blur`, I noticed that Firefox would immediately trigger a `focus` and `blur` in quick succession upon opening the colour picker. Once the latter is dismissed, another `focus` would fire.

This could be contrasted with the behaviour in Chrome, where `focus` fires when the colour picker is opened, and `blur` fires when the colour picker is dismissed, as one might intuitively expect.

With this information in mind, I scrutinised the event firing behaviour of the existing Formly field type input in Firefox. I wasn't able to reproduce the `focus` event firing when the colour picker was dismissed, despite various attempts. This led me to wonder whether Formly was interfering in some way.

I eventually stumbled across this.

https://github.com/ngx-formly/ngx-formly/blob/4cc44d96e94350ef3b90ff0ae7be33a084ea2c3e/src/ui/material/form-field/src/form-field.wrapper.ts#L142

Formly's Material form field wrapper uses a focus monitoring service that appears to nullify that second `focus` event I wanted to make use of to provide compatibility.

This led me to defining a new and simple custom Formly field type that manually (and minimally) wraps the native colour picker control, so as to avoid that focus monitoring service altogether. In this control, I provide special handling for desktop Firefox only, which helps input value changes get picked up for persistence.

I've included some screenshots below of the native colour picker as it appears in Firefox for Ubuntu, Android and Windows. In Ubuntu, I noticed the colour picker wasn't a strict modal, so a user could still interact with the application underneath. In Android, there was no option to pick any colour than what was supplied via the preset swatches.

<div><img width="200" alt="ubuntu" src="https://github.com/user-attachments/assets/02963352-6b63-45a5-b97f-73fb7c238f9a" /></div>

<div><img width="200" alt="android" src="https://github.com/user-attachments/assets/b3c235fa-8d68-4fe5-81b9-563f232cb63b" /></div>

<div><img width="200" alt="windows" src="https://github.com/user-attachments/assets/e024762c-e71c-45ad-bf14-51eef1d59ca0" /></div>

There might be a better overall solution, but this one should work too, at least for now.

**EDIT:** I'm unsure whether that failing Lighthouse CI run is a legitimate issue with my changeset. If it is, please let me know how to get by it.

## Issues Resolved

#3931

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
