### PR TITLE
fix: Initialize isEmoji for icon-input component to avoid showing icon twice

### DIFF
--- a/src/app/features/config/icon-input/icon-input.component.ts
+++ b/src/app/features/config/icon-input/icon-input.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
 import { FieldType } from '@ngx-formly/material';
 import { MATERIAL_ICONS } from '../../../ui/material-icons.const';
 import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
@@ -29,7 +29,7 @@ import { isSingleEmoji } from '../../../util/extract-first-emoji';
     MatTooltip,
   ],
 })
-export class IconInputComponent extends FieldType<FormlyFieldConfig> {
+export class IconInputComponent extends FieldType<FormlyFieldConfig> implements OnInit {
   filteredIcons = signal<string[]>([]);
   isEmoji = signal(false);
 
@@ -40,8 +40,8 @@ export class IconInputComponent extends FieldType<FormlyFieldConfig> {
     return this.to.type || 'text';
   }
 
-  ngOnInit() {
-    this.isEmoji.set(containsEmoji(this.formControl.value))
+  ngOnInit(): void {
+    this.isEmoji.set(containsEmoji(this.formControl.value));
   }
 
   trackByIndex(i: number, p: any): number {


### PR DESCRIPTION
# Description

Apparently the emojis showing twice mentioned in #5242 happens because the preview for mat icons also shows up beside the icon input, even though its supposed to in case the input value is an emoji. This happens because the `onInputValueChange` method, which contains the code to set the signal `isEmoji` to true, does not run on the first time the input value is set through the `ngModel` directive :
```
<input
  [ngModel]="formControl.value"
  (ngModelChange)="onInputValueChange($event)"
  ...
```
  
So to solve this, I just use `ngOnInit` to set isEmoji to `containsEmoji(this.formControl.value)` 

## Issues Resolved

#5242