### PR TITLE
'Fix: Remove trailing slashes from --user-data-dir CLI option path'

### DIFF
--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -86,7 +86,10 @@ export const startApp = (): void => {
     }
 
     if (val && val.includes('--user-data-dir=')) {
-      const customUserDir = val.replace('--user-data-dir=', '').trim();
+      const customUserDir = val
+        .replace('--user-data-dir=', '')
+        .trim()
+        .replace(/[\/\\]+$/, ''); // Remove trailing slashes
       log('Using custom directory for user data', customUserDir);
       app.setPath('userData', customUserDir);
       wasUserDataDirSet = true;


### PR DESCRIPTION
## Description
Fixes #5349

This PR resolves an issue where the `--user-data-dir` CLI option would not remove trailing slashes from the provided path, causing double slashes in file paths (e.g., `path/dir//file` instead of `path/dir/file`).

## Changes
- Modified `electron/start-app.ts` to strip trailing slashes from the custom user directory path
- Added regex pattern `/[\/\\]+$/` to handle both forward slashes and backslashes for cross-platform compatibility
- Added inline comment for clarity

## Testing
Before fix:
- Input: `--user-data-dir=/whatever/`
- Result: Path used as `/whatever/` → leads to `/whatever//file`

After fix:
- Input: `--user-data-dir=/whatever/`
- Result: Path normalized to `/whatever` → correct path `/whatever/file`

## Checklist
- [x] The issue is reproducible and has been verified
- [x] Fix handles both forward slashes (/) and backslashes (\)
- [x] Code follows the project's coding style
- [x] Comment added to explain the trailing slash removal