### PR TITLE
fix: exclude backlog subtasks in boards when backlogs are excluded

### DIFF
--- a/src/app/features/boards/board-panel/board-panel.component.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.ts
@@ -347,6 +347,6 @@ export class BoardPanelComponent {
   }
 
   _isTaskInBacklog(task: Readonly<TaskCopy>): boolean {
-    return this.allBacklogTaskIds().has(task.id);
+    return this.allBacklogTaskIds().has(task.parentId || task.id);
   }
 }


### PR DESCRIPTION
# Description

exclude backlog subtasks in boards when backlogs are excluded

## Issues Resolved

#5354

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
