### PR TITLE
fix: backlog subtasks are not removed when removing a project

### DIFF
--- a/src/app/features/project/project.service.ts
+++ b/src/app/features/project/project.service.ts
@@ -193,15 +193,18 @@ export class ProjectService {
       .pipe(take(1))
       .toPromise();
     const subTaskIdsForProject: string[] = [];
-    project.taskIds.forEach((id) => {
+    const allParentTaskIds = [
+      ...project.taskIds,
+      ...project.backlogTaskIds,
+    ];
+    allParentTaskIds.forEach((id) => {
       const task = getTaskById(id, taskState);
       if (task.projectId && task.subTaskIds.length > 0) {
         subTaskIdsForProject.push(...task.subTaskIds);
       }
     });
     const allTaskIds = [
-      ...project.taskIds,
-      ...project.backlogTaskIds,
+      ...allParentTaskIds,
       ...subTaskIdsForProject,
     ];
     this._store$.dispatch(TaskSharedActions.deleteProject({ project, allTaskIds }));


### PR DESCRIPTION
# Description

fix: backlog subtasks are not removed when removing a project

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
