### PR TITLE
fix: Wrong Global Stylesheet Import

### DIFF
--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -1,4 +1,4 @@
-@use 'styles/globals' as *;
+@use '../../../../styles/_globals.scss' as *;
 
 // Folder expand/collapse icon animation
 .folder-icon {


### PR DESCRIPTION
# Description

The stylesheet for `NavItemComponent` has an incorrect import. Calling `@use 'styles/globals' as *;` will try to import a stylesheet named `globals` relative to the `nav-item` directory. This file doesn't exist.

I've changed the statement to import from the global stylesheet at `src/styles`.

## Issues Resolved

N/A

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
