### PR TITLE
fix: Change accent color on Nord Snow Storm theme to fix contrast issues

### DIFF
--- a/src/assets/themes/nord-snow-storm.css
+++ b/src/assets/themes/nord-snow-storm.css
@@ -110,7 +110,7 @@ body:not(.isDarkTheme) {
 
   /* Dark accent for contrast on light background */
   --palette-accent-500: var(--nord0);
-  --c-accent: var(--nord4);
+  --c-accent: var(--nord10);
   --palette-accent-100: #9fa5b0;
   --palette-accent-200: #7f879a;
   --palette-accent-300: #5f6984;


### PR DESCRIPTION
# Description

Changed accent color to `--nord-10` (#5e81ac) to fix NordSnowStorm theme contrast issues reported on #5114

## Issues Resolved

#5114 
