### PR TITLE
feat(addTaskBar): add time spent short syntax for new tasks (#5269)

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -16,6 +16,7 @@ describe('AddTaskBarParserService', () => {
       'updateProjectId',
       'updateTagIds',
       'updateNewTagTitles',
+      'updateSpent',
       'updateEstimate',
       'updateDate',
       'isAutoDetected',
@@ -88,6 +89,7 @@ describe('AddTaskBarParserService', () => {
       // Reset all spy calls before each test
       mockStateService.updateCleanText.calls.reset();
       mockStateService.updateDate.calls.reset();
+      mockStateService.updateSpent.calls.reset();
       mockStateService.updateEstimate.calls.reset();
       mockStateService.updateTagIds.calls.reset();
       mockStateService.updateNewTagTitles.calls.reset();
@@ -117,6 +119,7 @@ describe('AddTaskBarParserService', () => {
           newTagTitles: [],
           date: null,
           time: null,
+          spent: null,
           estimate: null,
           cleanText: null,
         };
@@ -150,6 +153,7 @@ describe('AddTaskBarParserService', () => {
           newTagTitles: [],
           date: currentDate,
           time: currentTime,
+          spent: null,
           estimate: null,
           cleanText: null,
         };
@@ -180,6 +184,7 @@ describe('AddTaskBarParserService', () => {
           newTagTitles: [],
           date: currentDate,
           time: null,
+          spent: null,
           estimate: null,
           cleanText: null,
         };
@@ -275,6 +280,30 @@ describe('AddTaskBarParserService', () => {
         );
 
         expect(mockStateService.updateEstimate).toHaveBeenCalledWith(null);
+      });
+
+      it('should call updateSpent when parsing text', () => {
+        service.parseAndUpdateText(
+          'Task with potential time spent',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+        );
+
+        expect(mockStateService.updateSpent).toHaveBeenCalled();
+      });
+
+      it('should handle null time spent', () => {
+        service.parseAndUpdateText(
+          'Simple task',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+        );
+
+        expect(mockStateService.updateSpent).toHaveBeenCalledWith(null);
       });
     });
 
@@ -439,6 +468,9 @@ describe('AddTaskBarParserService', () => {
           { input: 'Task t1.5h', expected: 'Task' },
           { input: 'Task 45d', expected: 'Task' },
           { input: 'Task t30m other text', expected: 'Task other text' },
+          { input: 'Task 1h/', expected: 'Task' },
+          { input: 'Task 1h/ between', expected: 'Task between' },
+          { input: '1h/ Task', expected: 'Task' },
         ];
 
         testCases.forEach(({ input, expected }) => {
@@ -552,6 +584,7 @@ describe('AddTaskBarParserService', () => {
         newTagTitles: [],
         date: dateStr,
         time: timeStr,
+        spent: null,
         estimate: null,
         cleanText: null,
       };
@@ -582,6 +615,7 @@ describe('AddTaskBarParserService', () => {
         newTagTitles: [],
         date: null,
         time: null,
+        spent: null,
         estimate: null,
         cleanText: null,
       };
@@ -614,6 +648,7 @@ describe('AddTaskBarParserService', () => {
         newTagTitles: [],
         date: null,
         time: null,
+        spent: null,
         estimate: null,
         cleanText: null,
       };
@@ -644,6 +679,7 @@ describe('AddTaskBarParserService', () => {
         newTagTitles: [],
         date: null,
         time: null,
+        spent: null,
         estimate: null,
         cleanText: null,
       };
@@ -673,6 +709,7 @@ describe('AddTaskBarParserService', () => {
         newTagTitles: [],
         date: null,
         time: null,
+        spent: null,
         estimate: null,
         cleanText: null,
       };

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -3,6 +3,7 @@ import { Tag } from '../../tag/tag.model';
 import { AddTaskBarState, INITIAL_ADD_TASK_BAR_STATE } from './add-task-bar.const';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { SS } from '../../../core/persistence/storage-keys.const';
+import { TimeSpentOnDay } from '../task.model';
 
 @Injectable()
 export class AddTaskBarStateService {
@@ -37,6 +38,10 @@ export class AddTaskBarStateService {
 
   updateTime(time: string | null): void {
     this._taskInputState.update((state) => ({ ...state, time }));
+  }
+
+  updateSpent(spent: TimeSpentOnDay | null): void {
+    this._taskInputState.update((state) => ({ ...state, spent }));
   }
 
   updateEstimate(estimate: number | null): void {

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -433,6 +433,10 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
       timeEstimate: state.estimate || 0,
     };
 
+    if (state.spent) {
+      taskData.timeSpentOnDay = state.spent;
+    }
+
     if (state.date) {
       // Parse date components to create date in local timezone
       // This avoids timezone issues when parsing date strings like "2024-01-15"

--- a/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
@@ -1,10 +1,12 @@
 import { INBOX_PROJECT } from '../../project/project.const';
+import { TimeSpentOnDay } from '../task.model';
 
 export interface AddTaskBarState {
   projectId: string;
   tagIds: string[];
   date: string | null;
   time: string | null;
+  spent: TimeSpentOnDay | null;
   estimate: number | null;
   newTagTitles: string[];
   cleanText: string | null;
@@ -26,6 +28,7 @@ export const INITIAL_ADD_TASK_BAR_STATE: AddTaskBarState = {
   tagIds: [],
   date: null,
   time: null,
+  spent: null,
   estimate: null,
   newTagTitles: [],
   cleanText: null,

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -242,6 +242,25 @@ describe('shortSyntax', () => {
       const r = shortSyntax(t, { ...CONFIG, isEnableDue: false });
       expect(r).toEqual(undefined);
     });
+
+    it('with time spent only', () => {
+      const t = {
+        ...TASK,
+        title: 'Task description 30m/',
+      };
+      const r = shortSyntax(t, CONFIG);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: undefined,
+        taskChanges: {
+          title: 'Task description',
+          timeSpentOnDay: {
+            [getDbDateStr()]: 1800000,
+          },
+        },
+      });
+    });
   });
 
   describe('should recognize short syntax for date', () => {


### PR DESCRIPTION
# Description

Hello there,

This changeset adds short syntax support for recording time spent when creating a new task.

For example,

- `10m` is a ten minute time estimate.
- `10m/` is ten minutes spent.
- `10m/20m` is a twenty minute time estimate with already ten minutes spent on the day the task was created.

I tried my best to hunt down potentially affected areas and to make appropriate adjustments, but I mightn't have caught them all.

I'll also leave some additional remarks inline with the code changes.

![](https://github.com/user-attachments/assets/c4c3ebff-8140-422b-95b0-1ee6c4bf9343)

## Issues Resolved

Resolves #5269

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
