### PR TITLE
refactor: migrate to control flow syntax

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -12,7 +12,6 @@ import {
   signal,
   AfterViewInit,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { NavigationStart, Router, RouterModule } from '@angular/router';
 import { NavItemComponent } from './nav-item/nav-item.component';
 import { NavListTreeComponent } from './nav-list/nav-list-tree.component';
@@ -42,7 +41,6 @@ const FOCUS_DELAY_MS = 10;
   selector: 'magic-side-nav',
   standalone: true,
   imports: [
-    CommonModule,
     RouterModule,
     NavItemComponent,
     NavListTreeComponent,

--- a/src/app/core-ui/magic-side-nav/nav-mat-menu/nav-mat-menu.component.ts
+++ b/src/app/core-ui/magic-side-nav/nav-mat-menu/nav-mat-menu.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIcon } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
@@ -10,14 +9,7 @@ import { NavItemComponent } from '../nav-item/nav-item.component';
 @Component({
   selector: 'nav-mat-menu',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatMenuModule,
-    MatIcon,
-    RouterModule,
-    TranslatePipe,
-    NavItemComponent,
-  ],
+  imports: [MatMenuModule, MatIcon, RouterModule, TranslatePipe, NavItemComponent],
   templateUrl: './nav-mat-menu.component.html',
   styleUrl: './nav-mat-menu.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/core-ui/main-header/mobile-side-panel-menu/mobile-side-panel-menu.component.ts
+++ b/src/app/core-ui/main-header/mobile-side-panel-menu/mobile-side-panel-menu.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -29,7 +28,6 @@ import { BreakpointObserver } from '@angular/cdk/layout';
   selector: 'mobile-side-panel-menu',
   standalone: true,
   imports: [
-    CommonModule,
     MatIconModule,
     MatButtonModule,
     MatTooltipModule,

--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.ts
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, inject, output } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -26,7 +25,6 @@ import { WorkContextService } from '../../features/work-context/work-context.ser
   selector: 'mobile-bottom-nav',
   standalone: true,
   imports: [
-    CommonModule,
     RouterModule,
     MatIconModule,
     MatButtonModule,

--- a/src/app/core/share/dialog-share/dialog-share.component.ts
+++ b/src/app/core/share/dialog-share/dialog-share.component.ts
@@ -5,7 +5,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
 import { ShareService } from '../share.service';
 import { ShareDialogOptions, ShareResult, ShareTarget } from '../share.model';
 import { ShareFormatter } from '../share-formatter';
@@ -23,7 +22,6 @@ interface ShareTargetButton {
   styleUrls: ['./dialog-share.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    CommonModule,
     MatDialogModule,
     MatButtonModule,
     MatIconModule,

--- a/src/app/features/focus-mode/task-tracking-info/task-tracking-info.component.ts
+++ b/src/app/features/focus-mode/task-tracking-info/task-tracking-info.component.ts
@@ -6,7 +6,6 @@ import {
   input,
 } from '@angular/core';
 import { expandAnimation } from '../../../ui/animations/expand.ani';
-import { CommonModule } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatIcon } from '@angular/material/icon';
@@ -19,7 +18,7 @@ import { TaskService } from '../../tasks/task.service';
 @Component({
   selector: 'task-tracking-info',
   standalone: true,
-  imports: [CommonModule, MatIcon, MatTooltipModule, MsToStringPipe],
+  imports: [MatIcon, MatTooltipModule, MsToStringPipe],
   template: `
     @if (currentTask() && (showTitle() || currentTaskTimeToday() > 0)) {
       <div

--- a/src/app/features/issue/issue-content/issue-content-custom/caldav-time/caldav-time.component.ts
+++ b/src/app/features/issue/issue-content/issue-content-custom/caldav-time/caldav-time.component.ts
@@ -5,7 +5,7 @@ import {
   inject,
   input,
 } from '@angular/core';
-import { CommonModule, DatePipe } from '@angular/common';
+import { DatePipe } from '@angular/common';
 import { TaskCopy } from '../../../../tasks/task.model';
 import { IssueData } from '../../../issue.model';
 import { IssueFieldConfig } from '../../issue-content.model';
@@ -14,7 +14,7 @@ import { IssueFieldConfig } from '../../issue-content.model';
   selector: 'caldav-time',
   templateUrl: './caldav-time.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule],
+  imports: [],
 })
 export class CaldavTimeComponent {
   private _datePipe = inject(DatePipe);

--- a/src/app/features/issue/issue-content/issue-content-custom/jira-link/jira-link.component.ts
+++ b/src/app/features/issue/issue-content/issue-content-custom/jira-link/jira-link.component.ts
@@ -7,7 +7,6 @@ import {
   signal,
   effect,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { JiraCommonInterfacesService } from '../../../providers/jira/jira-common-interfaces.service';
 import { TaskCopy } from '../../../../tasks/task.model';
 import { IssueData } from '../../../issue.model';
@@ -18,7 +17,7 @@ import { IssueFieldConfig } from '../../issue-content.model';
   templateUrl: './jira-link.component.html',
   styleUrls: ['./jira-link.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule],
+  imports: [],
 })
 export class JiraLinkComponent {
   private _jiraCommonInterfacesService = inject(JiraCommonInterfacesService, {

--- a/src/app/features/issue/issue-header/issue-header.component.ts
+++ b/src/app/features/issue/issue-header/issue-header.component.ts
@@ -2,14 +2,13 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { TaskWithSubTasks } from '../../tasks/task.model';
 import { ISSUE_PROVIDER_HUMANIZED, ISSUE_PROVIDER_ICON_MAP } from '../issue.const';
 import { MatIcon } from '@angular/material/icon';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'issue-header',
   templateUrl: './issue-header.component.html',
   styleUrls: ['./issue-header.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatIcon],
+  imports: [MatIcon],
 })
 export class IssueHeaderComponent {
   task = input.required<TaskWithSubTasks>();

--- a/src/app/features/metric/dialog-productivity-breakdown/dialog-productivity-breakdown.component.html
+++ b/src/app/features/metric/dialog-productivity-breakdown/dialog-productivity-breakdown.component.html
@@ -1,7 +1,7 @@
 <h2 mat-dialog-title>{{ titleKey | translate }}</h2>
 
 <div mat-dialog-content>
-  <ng-container *ngIf="breakdown$ | async as breakdown; else noData">
+  @if (breakdown$ | async; as breakdown) {
     @if (chartData$ | async; as chartData) {
       <div class="chart-section">
         <lazy-chart
@@ -28,32 +28,32 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let item of breakdown">
-          <td>{{ item.day }}</td>
-          <td>{{ item.score ?? '-' }}</td>
-          <td>{{ item.impactRating ?? '-' }}</td>
-          <td>
-            @if (item.energyCheckin === 1) {
-              😫
-            } @else if (item.energyCheckin === 2) {
-              😐
-            } @else if (item.energyCheckin === 3) {
-              😊
-            } @else {
-              -
-            }
-          </td>
-          <td>{{ item.focusedMinutes | number: '1.0-1' }}</td>
-          <td>{{ item.totalWorkMinutes | number: '1.0-1' }}</td>
-        </tr>
+        @for (item of breakdown; track item) {
+          <tr>
+            <td>{{ item.day }}</td>
+            <td>{{ item.score ?? '-' }}</td>
+            <td>{{ item.impactRating ?? '-' }}</td>
+            <td>
+              @if (item.energyCheckin === 1) {
+                😫
+              } @else if (item.energyCheckin === 2) {
+                😐
+              } @else if (item.energyCheckin === 3) {
+                😊
+              } @else {
+                -
+              }
+            </td>
+            <td>{{ item.focusedMinutes | number: '1.0-1' }}</td>
+            <td>{{ item.totalWorkMinutes | number: '1.0-1' }}</td>
+          </tr>
+        }
       </tbody>
     </table>
-  </ng-container>
+  } @else {
+    <div class="no-data">No productivity data available for the selected range.</div>
+  }
 </div>
-
-<ng-template #noData>
-  <div class="no-data">No productivity data available for the selected range.</div>
-</ng-template>
 
 <div
   mat-dialog-actions

--- a/src/app/features/metric/impact-stars/impact-stars.component.html
+++ b/src/app/features/metric/impact-stars/impact-stars.component.html
@@ -8,21 +8,22 @@
   tabindex="0"
 >
   <!-- 1..maxStars -->
-  <button
-    *ngFor="let idx of stars(); trackBy: track"
-    type="button"
-    class="impact-stars__star"
-    role="radio"
-    [attr.aria-checked]="value() === idx"
-    [attr.aria-label]="idx + ' ' + starLabel(idx)"
-    [disabled]="disabled"
-    (click)="handleClick(idx)"
-    (mouseenter)="preview(idx)"
-    (mouseleave)="preview(null)"
-  >
-    <!-- Material icons -->
-    <mat-icon>
-      {{ isActive(idx) ? activeIcon : inactiveIcon }}
-    </mat-icon>
-  </button>
+  @for (idx of stars(); track track($index, idx)) {
+    <button
+      type="button"
+      class="impact-stars__star"
+      role="radio"
+      [attr.aria-checked]="value() === idx"
+      [attr.aria-label]="idx + ' ' + starLabel(idx)"
+      [disabled]="disabled"
+      (click)="handleClick(idx)"
+      (mouseenter)="preview(idx)"
+      (mouseleave)="preview(null)"
+    >
+      <!-- Material icons -->
+      <mat-icon>
+        {{ isActive(idx) ? activeIcon : inactiveIcon }}
+      </mat-icon>
+    </button>
+  }
 </div>

--- a/src/app/features/metric/impact-stars/impact-stars.component.ts
+++ b/src/app/features/metric/impact-stars/impact-stars.component.ts
@@ -9,14 +9,13 @@ import {
   computed,
   effect,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   standalone: true,
   selector: 'impact-stars',
-  imports: [CommonModule, MatIconModule],
+  imports: [MatIconModule],
   templateUrl: './impact-stars.component.html',
   styleUrls: ['./impact-stars.component.scss'],
   providers: [

--- a/src/app/features/metric/lazy-chart/lazy-chart.component.ts
+++ b/src/app/features/metric/lazy-chart/lazy-chart.component.ts
@@ -20,7 +20,6 @@ import type {
   Chart as ChartJS,
   ChartConfiguration,
 } from 'chart.js';
-import { CommonModule } from '@angular/common';
 import { ChartLazyLoaderService } from '../chart-lazy-loader.service';
 import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -104,7 +103,7 @@ interface ChartClickEvent {
     `,
   ],
   standalone: true,
-  imports: [CommonModule, MatIconButton, MatTooltip, MatIcon, TranslatePipe],
+  imports: [MatIconButton, MatTooltip, MatIcon, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LazyChartComponent implements OnInit, OnDestroy {

--- a/src/app/features/quick-history/quick-history.component.html
+++ b/src/app/features/quick-history/quick-history.component.html
@@ -1,144 +1,151 @@
 <h1>{{ T.F.QUICK_HISTORY.PAGE_TITLE | translate }}</h1>
 
-<div
-  *ngIf="worklogService.quickHistoryWeeks$ | async as weeks; else spinner"
-  [@fadeInSlow]
->
-  <div
-    class="no-data"
-    *ngIf="weeks?.length === 0"
-  >
-    {{ T.F.QUICK_HISTORY.NO_DATA | translate }}
-  </div>
-
-  <div *ngFor="let week of weeks; let j = index">
-    <h2>
-      {{
-        T.F.QUICK_HISTORY.WEEK_TITLE
-          | translate: { nr: week.weekNr, timeSpent: (week.timeSpent | msToString) }
-      }}
-    </h2>
-
-    <div class="days">
-      <div
-        *ngFor="
-          let day of week?.ent | keyvalue: sortDays;
-          trackBy: trackByDay;
-          let i = index
-        "
-        class="day"
-      >
-        <div class="material-table">
-          <div
-            (click)="visibility[i + j * 100] = !visibility[i + j * 100]"
-            class="caption"
-            mat-ripple
-          >
-            <div>
-              <span
-                *ngIf="visibility[i + j * 100]"
-                [@fade]
-                >{{ T.F.WORKLOG.WEEK.TITLE | translate }}</span
-              >
-            </div>
-            <div class="center-box">
-              <div class="title">
-                <h3 class="mat-h3">{{ day.value.dayStr }}</h3>
+@if (worklogService.quickHistoryWeeks$ | async; as weeks) {
+  <div [@fadeInSlow]>
+    @if (weeks?.length === 0) {
+      <div class="no-data">
+        {{ T.F.QUICK_HISTORY.NO_DATA | translate }}
+      </div>
+    }
+    @for (week of weeks; track week; let j = $index) {
+      <div>
+        <h2>
+          {{
+            T.F.QUICK_HISTORY.WEEK_TITLE
+              | translate: { nr: week.weekNr, timeSpent: (week.timeSpent | msToString) }
+          }}
+        </h2>
+        <div class="days">
+          @for (
+            day of week?.ent | keyvalue: sortDays;
+            track trackByDay(i, day);
+            let i = $index
+          ) {
+            <div class="day">
+              <div class="material-table">
                 <div
-                  *ngIf="!visibility[i + j * 100]"
-                  [@expandFade]
-                  class="icon-indicator-bar"
+                  (click)="visibility[i + j * 100] = !visibility[i + j * 100]"
+                  class="caption"
+                  mat-ripple
                 >
-                  <strong>∑ {{ day.value.timeSpent | msToClockString }}</strong>
-                  &nbsp;
-                  <mat-icon>list</mat-icon>
-                  <strong>{{ day.value.logEntries.length }}</strong>
-                  <em *ngIf="day.value.workStart"
-                    ><span class="spacer"></span
-                    >{{ day.value.workStart | momentFormat: 'HH:mm' }} -
-                    {{ day.value.workEnd | momentFormat: 'HH:mm' }}</em
-                  >
-
-                  <div class="simple-counter-items">
-                    <div
-                      *ngFor="
-                        let sc of simpleCounterService.enabledSimpleCounters$ | async
-                      "
-                      class="simple-counter-item"
-                    >
-                      <mat-icon inline="true">{{ sc.icon }}</mat-icon>
-                      @if (sc.type === 'StopWatch') {
-                        <div class="count">
-                          {{
-                            sc.countOnDay[day.value.dateStr] || 0 | msToMinuteClockString
-                          }}
-                        </div>
-                      } @else {
-                        <div class="count">
-                          {{ sc.countOnDay[day.value.dateStr] || 0 }}
+                  <div>
+                    @if (visibility[i + j * 100]) {
+                      <span [@fade]>{{ T.F.WORKLOG.WEEK.TITLE | translate }}</span>
+                    }
+                  </div>
+                  <div class="center-box">
+                    <div class="title">
+                      <h3 class="mat-h3">{{ day.value.dayStr }}</h3>
+                      @if (!visibility[i + j * 100]) {
+                        <div
+                          [@expandFade]
+                          class="icon-indicator-bar"
+                        >
+                          <strong>∑ {{ day.value.timeSpent | msToClockString }}</strong>
+                          &nbsp;
+                          <mat-icon>list</mat-icon>
+                          <strong>{{ day.value.logEntries.length }}</strong>
+                          @if (day.value.workStart) {
+                            <em
+                              ><span class="spacer"></span
+                              >{{ day.value.workStart | momentFormat: 'HH:mm' }} -
+                              {{ day.value.workEnd | momentFormat: 'HH:mm' }}</em
+                            >
+                          }
+                          <div class="simple-counter-items">
+                            @for (
+                              sc of simpleCounterService.enabledSimpleCounters$ | async;
+                              track sc
+                            ) {
+                              <div class="simple-counter-item">
+                                <mat-icon inline="true">{{ sc.icon }}</mat-icon>
+                                @if (sc.type === 'StopWatch') {
+                                  <div class="count">
+                                    {{
+                                      sc.countOnDay[day.value.dateStr] || 0
+                                        | msToMinuteClockString
+                                    }}
+                                  </div>
+                                } @else {
+                                  <div class="count">
+                                    {{ sc.countOnDay[day.value.dateStr] || 0 }}
+                                  </div>
+                                }
+                              </div>
+                            }
+                          </div>
                         </div>
                       }
                     </div>
                   </div>
+                  <div class="with-icon">
+                    @if (visibility[i + j * 100]) {
+                      <mat-icon [@fade]>timer </mat-icon>
+                    }
+                  </div>
                 </div>
+                @if (visibility[i + j * 100]) {
+                  <table
+                    [@expandFade]
+                    class="task-summary-table"
+                  >
+                    @for (
+                      logEntry of filterWorklogDataForDay(day.value.logEntries);
+                      track trackByLogEntry($index, logEntry)
+                    ) {
+                      <tr>
+                        <td
+                          [class.isSubTask]="logEntry.task.parentId"
+                          class="title"
+                          colspan
+                        >
+                          <span class="task-title">{{ logEntry.task.title }}</span>
+                        </td>
+                        <td class="worked">
+                          @if (
+                            logEntry.task.subTaskIds &&
+                            logEntry.task.subTaskIds.length > 0
+                          ) {
+                            <span
+                              >∑
+                              {{
+                                logEntry.task.timeSpentOnDay[day.value.dateStr]
+                                  | msToClockString
+                              }}</span
+                            >
+                          }
+                          @if (
+                            !logEntry.task.subTaskIds || !logEntry.task.subTaskIds.length
+                          ) {
+                            <inline-input
+                              (changed)="
+                                updateTimeSpentTodayForTask(
+                                  logEntry.task,
+                                  day.value.dateStr,
+                                  $event
+                                )
+                              "
+                              [displayValue]="
+                                logEntry.task.timeSpentOnDay[day.value.dateStr]
+                                  | msToClockString
+                              "
+                              [type]="'duration'"
+                              [value]="logEntry.task.timeSpentOnDay[day.value.dateStr]"
+                            >
+                            </inline-input>
+                          }
+                        </td>
+                      </tr>
+                    }
+                  </table>
+                }
               </div>
             </div>
-            <div class="with-icon">
-              <mat-icon
-                *ngIf="visibility[i + j * 100]"
-                [@fade]
-                >timer
-              </mat-icon>
-            </div>
-          </div>
-
-          <table
-            *ngIf="visibility[i + j * 100]"
-            [@expandFade]
-            class="task-summary-table"
-          >
-            <tr
-              *ngFor="
-                let logEntry of filterWorklogDataForDay(day.value.logEntries);
-                trackBy: trackByLogEntry
-              "
-            >
-              <td
-                [class.isSubTask]="logEntry.task.parentId"
-                class="title"
-                colspan
-              >
-                <span class="task-title">{{ logEntry.task.title }}</span>
-              </td>
-              <td class="worked">
-                <span
-                  *ngIf="logEntry.task.subTaskIds && logEntry.task.subTaskIds.length > 0"
-                  >∑
-                  {{
-                    logEntry.task.timeSpentOnDay[day.value.dateStr] | msToClockString
-                  }}</span
-                >
-                <inline-input
-                  (changed)="
-                    updateTimeSpentTodayForTask(logEntry.task, day.value.dateStr, $event)
-                  "
-                  *ngIf="!logEntry.task.subTaskIds || !logEntry.task.subTaskIds.length"
-                  [displayValue]="
-                    logEntry.task.timeSpentOnDay[day.value.dateStr] | msToClockString
-                  "
-                  [type]="'duration'"
-                  [value]="logEntry.task.timeSpentOnDay[day.value.dateStr]"
-                >
-                </inline-input>
-              </td>
-            </tr>
-          </table>
+          }
         </div>
       </div>
-    </div>
+    }
   </div>
-</div>
-
-<ng-template #spinner>
+} @else {
   <full-page-spinner></full-page-spinner>
-</ng-template>
+}

--- a/src/app/features/quick-history/quick-history.component.ts
+++ b/src/app/features/quick-history/quick-history.component.ts
@@ -7,7 +7,7 @@ import { TaskService } from '../tasks/task.service';
 import { Task } from '../tasks/task.model';
 import { WorklogDataForDay, WorklogDay } from '../worklog/worklog.model';
 import { T } from 'src/app/t.const';
-import { AsyncPipe, KeyValue, KeyValuePipe, NgForOf, NgIf } from '@angular/common';
+import { AsyncPipe, KeyValue, KeyValuePipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MsToStringPipe } from '../../ui/duration/ms-to-string.pipe';
 import { MsToClockStringPipe } from '../../ui/duration/ms-to-clock-string.pipe';
@@ -27,8 +27,6 @@ import { FullPageSpinnerComponent } from '../../ui/full-page-spinner/full-page-s
     TranslatePipe,
     AsyncPipe,
     MsToStringPipe,
-    NgForOf,
-    NgIf,
     MsToClockStringPipe,
     MomentFormatPipe,
     MsToMinuteClockStringPipe,

--- a/src/app/features/task-view-customizer/task-view-customizer-panel/task-view-customizer-panel.component.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer-panel/task-view-customizer-panel.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, ViewChild } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
@@ -22,7 +21,6 @@ import { T } from 'src/app/t.const';
   standalone: true,
   exportAs: 'customizerMenu',
   imports: [
-    CommonModule,
     FormsModule,
     MatFormFieldModule,
     MatSelectModule,

--- a/src/app/features/worklog/worklog-week/worklog-week.component.html
+++ b/src/app/features/worklog/worklog-week/worklog-week.component.html
@@ -3,153 +3,153 @@
 @if (worklogService.currentWeek$ | async; as currentWeek) {
   <div>
     <div class="days">
-      <div
-        *ngFor="
-          let day of currentWeek?.ent | keyvalue: sortDays;
-          trackBy: trackByDay;
-          let i = index
-        "
-        class="day"
-      >
-        <div class="material-table">
-          <div
-            (click)="visibility[i] = !visibility[i]"
-            class="caption"
-            mat-ripple
-          >
-            <div>
-              @if (visibility[i]) {
-                <span [@fade]>{{ T.F.WORKLOG.WEEK.TITLE | translate }}</span>
-              }
-            </div>
-            <div class="center-box">
-              <div class="title">
-                <h3 class="mat-h3">{{ day.value.dayStr }} {{ day.key }}.</h3>
-                @if (!visibility[i]) {
-                  <div
-                    [@expandFade]
-                    class="icon-indicator-bar"
-                  >
-                    <strong>∑ {{ day.value.timeSpent | msToClockString }}</strong>
-                    &nbsp;
-                    <mat-icon>list</mat-icon>
-                    <strong>{{ day.value.logEntries.length }}</strong>
-
-                    @if (day.value.workStart) {
-                      <em
-                        ><span class="spacer"></span
-                        >{{ day.value.workStart | momentFormat: 'HH:mm' }} -
-                        {{ day.value.workEnd | momentFormat: 'HH:mm' }}</em
-                      >
-                    }
-                    <div class="simple-counter-items">
-                      @if (focusSummaryFor(day.value.dateStr); as focusSummary) {
-                        <div
-                          class="simple-counter-item focus-summary-item"
-                          [attr.title]="T.F.WORKLOG.WEEK.FOCUS_SUMMARY | translate"
+      @for (
+        day of currentWeek!.ent | keyvalue: sortDays;
+        track trackByDay(i, day);
+        let i = $index
+      ) {
+        <div class="day">
+          <div class="material-table">
+            <div
+              (click)="visibility[i] = !visibility[i]"
+              class="caption"
+              mat-ripple
+            >
+              <div>
+                @if (visibility[i]) {
+                  <span [@fade]>{{ T.F.WORKLOG.WEEK.TITLE | translate }}</span>
+                }
+              </div>
+              <div class="center-box">
+                <div class="title">
+                  <h3 class="mat-h3">{{ day.value.dayStr }} {{ day.key }}.</h3>
+                  @if (!visibility[i]) {
+                    <div
+                      [@expandFade]
+                      class="icon-indicator-bar"
+                    >
+                      <strong>∑ {{ day.value.timeSpent | msToClockString }}</strong>
+                      &nbsp;
+                      <mat-icon>list</mat-icon>
+                      <strong>{{ day.value.logEntries.length }}</strong>
+                      @if (day.value.workStart) {
+                        <em
+                          ><span class="spacer"></span
+                          >{{ day.value.workStart | momentFormat: 'HH:mm' }} -
+                          {{ day.value.workEnd | momentFormat: 'HH:mm' }}</em
                         >
-                          <mat-icon inline="true">center_focus_strong</mat-icon>
-                          <div class="count">
-                            {{ focusSummary.count }} /
-                            {{ focusSummary.total | msToMinuteClockString }}
+                      }
+                      <div class="simple-counter-items">
+                        @if (focusSummaryFor(day.value.dateStr); as focusSummary) {
+                          <div
+                            class="simple-counter-item focus-summary-item"
+                            [attr.title]="T.F.WORKLOG.WEEK.FOCUS_SUMMARY | translate"
+                          >
+                            <mat-icon inline="true">center_focus_strong</mat-icon>
+                            <div class="count">
+                              {{ focusSummary.count }} /
+                              {{ focusSummary.total | msToMinuteClockString }}
+                            </div>
                           </div>
-                        </div>
-                      }
-                      @for (
-                        sc of simpleCounterService.enabledSimpleCounters$ | async;
-                        track sc
-                      ) {
-                        <div class="simple-counter-item">
-                          <mat-icon inline="true">{{ sc.icon }}</mat-icon>
-                          @if (sc.type === 'StopWatch') {
-                            <div class="count">
-                              {{
-                                sc.countOnDay[day.value.dateStr] || 0
-                                  | msToMinuteClockString
-                              }}
-                            </div>
-                          } @else {
-                            <div class="count">
-                              {{ sc.countOnDay[day.value.dateStr] || 0 }}
-                            </div>
-                          }
-                        </div>
-                      }
+                        }
+                        @for (
+                          sc of simpleCounterService.enabledSimpleCounters$ | async;
+                          track sc
+                        ) {
+                          <div class="simple-counter-item">
+                            <mat-icon inline="true">{{ sc.icon }}</mat-icon>
+                            @if (sc.type === 'StopWatch') {
+                              <div class="count">
+                                {{
+                                  sc.countOnDay[day.value.dateStr] || 0
+                                    | msToMinuteClockString
+                                }}
+                              </div>
+                            } @else {
+                              <div class="count">
+                                {{ sc.countOnDay[day.value.dateStr] || 0 }}
+                              </div>
+                            }
+                          </div>
+                        }
+                      </div>
                     </div>
-                  </div>
+                  }
+                </div>
+              </div>
+              <div class="with-icon">
+                @if (visibility[i]) {
+                  <mat-icon [@fade]>timer </mat-icon>
                 }
               </div>
             </div>
-            <div class="with-icon">
-              @if (visibility[i]) {
-                <mat-icon [@fade]>timer </mat-icon>
-              }
-            </div>
+            @if (visibility[i]) {
+              <table
+                [@expandFade]
+                class="task-summary-table"
+              >
+                @for (
+                  logEntry of day.value.logEntries;
+                  track trackByLogEntry($index, logEntry)
+                ) {
+                  <tr>
+                    <td
+                      [class.isSubTask]="logEntry.task.parentId"
+                      class="title"
+                      colspan
+                    >
+                      <span class="task-title">{{ logEntry.task.title }}</span>
+                    </td>
+                    <td class="worked">
+                      @if (
+                        logEntry.task.subTaskIds && logEntry.task.subTaskIds.length > 0
+                      ) {
+                        <span
+                          >∑
+                          {{
+                            logEntry.task.timeSpentOnDay[day.value.dateStr]
+                              | msToClockString
+                          }}</span
+                        >
+                      }
+                      @if (
+                        !logEntry.task.subTaskIds || !logEntry.task.subTaskIds.length
+                      ) {
+                        <inline-input
+                          (changed)="
+                            updateTimeSpentTodayForTask(
+                              logEntry.task,
+                              day.value.dateStr,
+                              $event
+                            )
+                          "
+                          [displayValue]="
+                            logEntry.task.timeSpentOnDay[day.value.dateStr]
+                              | msToClockString
+                          "
+                          [type]="'duration'"
+                          [value]="logEntry.task.timeSpentOnDay[day.value.dateStr]"
+                        >
+                        </inline-input>
+                      }
+                    </td>
+                  </tr>
+                }
+              </table>
+            }
+            <!--        <div class="simple-counter-items">-->
+            <!--          <div *ngFor="let sc of simpleCounterService.enabledSimpleCounters$|async"-->
+            <!--               class="simple-counter-item">-->
+            <!--            <mat-icon>{{sc.icon}}</mat-icon>-->
+            <!--            <div class="count"-->
+            <!--                 *ngIf="sc.type==='ClickCounter'">{{sc.countOnDay[day.value.dateStr]}}</div>-->
+            <!--            <div class="count"-->
+            <!--                 *ngIf="sc.type==='StopWatch'">{{sc.countOnDay[day.value.dateStr]|msToMinuteClockString}}</div>-->
+            <!--          </div>-->
+            <!--        </div>-->
           </div>
-          @if (visibility[i]) {
-            <table
-              [@expandFade]
-              class="task-summary-table"
-            >
-              @for (
-                logEntry of day.value.logEntries;
-                track trackByLogEntry($index, logEntry)
-              ) {
-                <tr>
-                  <td
-                    [class.isSubTask]="logEntry.task.parentId"
-                    class="title"
-                    colspan
-                  >
-                    <span class="task-title">{{ logEntry.task.title }}</span>
-                  </td>
-                  <td class="worked">
-                    @if (
-                      logEntry.task.subTaskIds && logEntry.task.subTaskIds.length > 0
-                    ) {
-                      <span
-                        >∑
-                        {{
-                          logEntry.task.timeSpentOnDay[day.value.dateStr]
-                            | msToClockString
-                        }}</span
-                      >
-                    }
-                    @if (!logEntry.task.subTaskIds || !logEntry.task.subTaskIds.length) {
-                      <inline-input
-                        (changed)="
-                          updateTimeSpentTodayForTask(
-                            logEntry.task,
-                            day.value.dateStr,
-                            $event
-                          )
-                        "
-                        [displayValue]="
-                          logEntry.task.timeSpentOnDay[day.value.dateStr]
-                            | msToClockString
-                        "
-                        [type]="'duration'"
-                        [value]="logEntry.task.timeSpentOnDay[day.value.dateStr]"
-                      >
-                      </inline-input>
-                    }
-                  </td>
-                </tr>
-              }
-            </table>
-          }
-          <!--        <div class="simple-counter-items">-->
-          <!--          <div *ngFor="let sc of simpleCounterService.enabledSimpleCounters$|async"-->
-          <!--               class="simple-counter-item">-->
-          <!--            <mat-icon>{{sc.icon}}</mat-icon>-->
-          <!--            <div class="count"-->
-          <!--                 *ngIf="sc.type==='ClickCounter'">{{sc.countOnDay[day.value.dateStr]}}</div>-->
-          <!--            <div class="count"-->
-          <!--                 *ngIf="sc.type==='StopWatch'">{{sc.countOnDay[day.value.dateStr]|msToMinuteClockString}}</div>-->
-          <!--          </div>-->
-          <!--        </div>-->
         </div>
-      </div>
+      }
     </div>
     <div style="text-align: center; margin-top: 12px">
       <button

--- a/src/app/features/worklog/worklog-week/worklog-week.component.ts
+++ b/src/app/features/worklog/worklog-week/worklog-week.component.ts
@@ -12,7 +12,7 @@ import { TaskService } from '../../tasks/task.service';
 import { T } from '../../../t.const';
 import { SimpleCounterService } from '../../simple-counter/simple-counter.service';
 import { DateAdapter, MatRipple } from '@angular/material/core';
-import { AsyncPipe, KeyValuePipe, NgFor } from '@angular/common';
+import { AsyncPipe, KeyValue, KeyValuePipe } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { InlineInputComponent } from '../../../ui/inline-input/inline-input.component';
 import { MatButton } from '@angular/material/button';
@@ -29,7 +29,6 @@ import { MetricService } from '../../metric/metric.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [expandAnimation, expandFadeAnimation, fadeAnimation],
   imports: [
-    NgFor,
     MatRipple,
     MatIcon,
     InlineInputComponent,
@@ -54,8 +53,8 @@ export class WorklogWeekComponent {
   T: typeof T = T;
   keys: (o: Record<string, unknown>) => string[] = Object.keys;
 
-  sortDays(a: any, b: any): number {
-    return a.key - b.key;
+  sortDays<T extends KeyValue<string, V>, V = unknown>(a: T, b: T): number {
+    return b.key < a.key ? 1 : -1;
   }
 
   async exportData(): Promise<void> {
@@ -90,7 +89,7 @@ export class WorklogWeekComponent {
     this.worklogService.refreshWorklog();
   }
 
-  trackByDay(i: number, day: any): string {
+  trackByDay<T extends KeyValue<string, V>, V = unknown>(i: number, day: T): string {
     return day.key;
   }
 

--- a/src/app/features/worklog/worklog.component.html
+++ b/src/app/features/worklog/worklog.component.html
@@ -1,242 +1,257 @@
-<ng-template #spinner>
-  <full-page-spinner></full-page-spinner>
-</ng-template>
-
-<div
-  *ngIf="worklogService.worklogData$ | async as wData; else spinner"
-  [@fadeInSlow]
->
-  <h1 class="mat-headline-5 total-time">
-    {{ T.F.WORKLOG.CMP.TOTAL_TIME | translate }} <br /><strong>{{
-      wData.totalTimeSpent | msToString
-    }}</strong>
-  </h1>
-
-  <div class="years">
-    <div
-      *ngFor="let year of wData.worklog | keyvalue: sortWorklogItems; trackBy: trackByKey"
-      class="year"
-    >
-      <h1
-        [innerHtml]="year.key"
-        class="year-title mat-headline-5"
-      ></h1>
-      <div class="year-time-spent">
-        {{ T.F.WORKLOG.CMP.MONTH_WORKED | translate }}
-        <strong>{{ year.value.monthWorked }}</strong
-        ><br />
-        {{ T.F.WORKLOG.CMP.DAYS_WORKED | translate }}
-        <strong>{{ year.value.daysWorked }}</strong
-        ><br />
-        {{ T.F.WORKLOG.CMP.TOTAL_TIME | translate }}
-        <strong [innerHtml]="year.value.timeSpent | msToString"></strong>
-      </div>
-
-      <div class="months">
-        <div
-          *ngFor="
-            let month of year.value.ent | keyvalue: sortWorklogItems;
-            trackBy: trackByKey
-          "
-          class="month"
-        >
-          <h2 class="month-title mat-headline-5">
-            <span [innerHtml]="month.key | numberToMonth"></span>
-
-            <button
-              (click)="exportData(month.value, year.key, month.key)"
-              aria-label="export data"
-              class="mat-elevation-z1"
-              color="primary"
-              mat-mini-fab
-            >
-              <mat-icon>call_made</mat-icon>
-            </button>
-          </h2>
-
-          <div class="month-time-spent">
+@if (worklogService.worklogData$ | async; as wData) {
+  <div [@fadeInSlow]>
+    <h1 class="mat-headline-5 total-time">
+      {{ T.F.WORKLOG.CMP.TOTAL_TIME | translate }} <br /><strong>{{
+        wData.totalTimeSpent | msToString
+      }}</strong>
+    </h1>
+    <div class="years">
+      @for (
+        year of wData.worklog | keyvalue: sortWorklogItems;
+        track trackByKey($index, year)
+      ) {
+        <div class="year">
+          <h1
+            [innerHtml]="year.key"
+            class="year-title mat-headline-5"
+          ></h1>
+          <div class="year-time-spent">
+            {{ T.F.WORKLOG.CMP.MONTH_WORKED | translate }}
+            <strong>{{ year.value.monthWorked }}</strong
+            ><br />
             {{ T.F.WORKLOG.CMP.DAYS_WORKED | translate }}
-            <strong>{{ month.value.daysWorked }}</strong
+            <strong>{{ year.value.daysWorked }}</strong
             ><br />
             {{ T.F.WORKLOG.CMP.TOTAL_TIME | translate }}
-            <strong [innerHtml]="month.value.timeSpent | msToString"></strong>
+            <strong [innerHtml]="year.value.timeSpent | msToString"></strong>
           </div>
-
-          <div class="weeks">
-            <div
-              *ngFor="let week of month.value.weeks; trackBy: trackByForWeek"
-              class="week"
-            >
-              <div class="week-header">
-                <div class="wrap">
-                  <h3 class="week-title mat-h4">
-                    {{ T.F.WORKLOG.CMP.WEEK_NR | translate: { nr: week.weekNr } }}
-                  </h3>
-                  <div>{{ week.timeSpent | msToString }}</div>
-                </div>
-                <button
-                  (click)="exportData(month.value, year.key, month.key, week.weekNr)"
-                  [matTooltip]="
-                    week.start +
-                    '.-' +
-                    week.end +
-                    '. Days: ' +
-                    week.daysWorked +
-                    ', Time: ' +
-                    (week.timeSpent | msToString)
-                  "
-                  aria-label="export data"
-                  class="mat-elevation-z1"
-                  color=""
-                  mat-mini-fab
-                >
-                  <mat-icon>call_made</mat-icon>
-                </button>
-              </div>
-
-              <div class="week-table-wrapper">
-                <table class="week-table">
-                  <tr>
-                    <th></th>
-                    <td>{{ T.F.WORKLOG.CMP.TASKS | translate }}</td>
-                    <td>{{ T.F.WORKLOG.CMP.WORKED | translate }}</td>
-                    <th></th>
-                  </tr>
-                  <ng-container
-                    *ngFor="
-                      let worklogForDay of week.ent | keyvalue: sortWorklogItemsReverse;
-                      trackBy: trackByKey
-                    "
-                    class="day"
+          <div class="months">
+            @for (
+              month of year.value.ent | keyvalue: sortWorklogItems;
+              track trackByKey($index, month)
+            ) {
+              <div class="month">
+                <h2 class="month-title mat-headline-5">
+                  <span [innerHtml]="month.key | numberToMonth"></span>
+                  <button
+                    (click)="exportData(month.value, year.key, month.key)"
+                    aria-label="export data"
+                    class="mat-elevation-z1"
+                    color="primary"
+                    mat-mini-fab
                   >
-                    <tr
-                      (click)="
-                        expanded[worklogForDay.value.dateStr] =
-                          !expanded[worklogForDay.value.dateStr]
-                      "
-                      [class.isExpanded]="expanded[worklogForDay.value.dateStr]"
-                      class="week-row"
-                    >
-                      <td>{{ worklogForDay.value.dayStr }} {{ worklogForDay.key }}.</td>
-                      <td>{{ worklogForDay.value.logEntries.length }}</td>
-                      <td>{{ worklogForDay.value.timeSpent | msToClockString }}</td>
-                      <td>
-                        <mat-icon *ngIf="!expanded[worklogForDay.value.dateStr]"
-                          >list
-                        </mat-icon>
-                        <mat-icon *ngIf="expanded[worklogForDay.value.dateStr]"
-                          >close
-                        </mat-icon>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td colspan="4">
-                        <div
-                          *ngIf="expanded[worklogForDay.value.dateStr]"
-                          [@expandFade]
-                          class="summary-table-wrapper material-table"
-                        >
-                          <table class="task-summary-table">
-                            <tr
-                              *ngFor="
-                                let logEntry of worklogForDay.value.logEntries;
-                                trackBy: trackByForLogEntry
-                              "
-                              [id]="'t-' + logEntry.task.id"
-                              tabindex="0"
-                            >
-                              <td
-                                [class.isSubTask]="logEntry.task.parentId"
-                                class="title"
-                              >
-                                <div
-                                  *ngIf="workContextService.isToday"
-                                  class="project-color"
-                                  [title]="
-                                    allProjectsColorAndTitle[logEntry.task.projectId]
-                                      ?.title
-                                  "
-                                  [style.background]="
-                                    allProjectsColorAndTitle[logEntry.task.projectId]
-                                      ?.color
-                                  "
-                                ></div>
-                                <mat-icon
-                                  *ngIf="logEntry.task.repeatCfgId"
-                                  [title]="T.F.WORKLOG.CMP.REPEATING_TASK | translate"
-                                  class="repeat-task-icon"
-                                  >repeat
-                                </mat-icon>
-                                <span class="task-title">{{ logEntry.task.title }}</span>
-                              </td>
-                              <td class="worked">
-                                <span
-                                  *ngIf="
-                                    logEntry.task.subTaskIds &&
-                                    logEntry.task.subTaskIds.length > 0
-                                  "
-                                  >∑
-                                  {{
-                                    logEntry.task.timeSpentOnDay[
-                                      worklogForDay.value.dateStr
-                                    ] | msToClockString
-                                  }}</span
-                                >
-                                <inline-input
-                                  (changed)="
-                                    updateTimeSpentTodayForTask(
-                                      logEntry.task,
-                                      worklogForDay.value.dateStr,
-                                      $event
-                                    )
-                                  "
-                                  *ngIf="
-                                    !logEntry.task.subTaskIds ||
-                                    !logEntry.task.subTaskIds.length
-                                  "
-                                  [displayValue]="
-                                    logEntry.task.timeSpentOnDay[
-                                      worklogForDay.value.dateStr
-                                    ] | msToClockString
-                                  "
-                                  [type]="'duration'"
-                                  [value]="
-                                    logEntry.task.timeSpentOnDay[
-                                      worklogForDay.value.dateStr
-                                    ]
-                                  "
-                                >
-                                </inline-input>
-                              </td>
-                              <td class="actions">
-                                <button
-                                  (click)="restoreTask(logEntry.task)"
-                                  *ngIf="
-                                    !logEntry.task?.parentId && !logEntry.isNoRestore
-                                  "
-                                  [title]="
-                                    T.F.WORKLOG.CMP.RESTORE_TASK_FROM_ARCHIVE | translate
-                                  "
-                                  aria-label="restore"
-                                  color=""
-                                  mat-icon-button
-                                >
-                                  <mat-icon>settings_backup_restore</mat-icon>
-                                </button>
-                              </td>
-                            </tr>
-                          </table>
+                    <mat-icon>call_made</mat-icon>
+                  </button>
+                </h2>
+                <div class="month-time-spent">
+                  {{ T.F.WORKLOG.CMP.DAYS_WORKED | translate }}
+                  <strong>{{ month.value.daysWorked }}</strong
+                  ><br />
+                  {{ T.F.WORKLOG.CMP.TOTAL_TIME | translate }}
+                  <strong [innerHtml]="month.value.timeSpent | msToString"></strong>
+                </div>
+                <div class="weeks">
+                  @for (week of month.value.weeks; track trackByForWeek($index, week)) {
+                    <div class="week">
+                      <div class="week-header">
+                        <div class="wrap">
+                          <h3 class="week-title mat-h4">
+                            {{ T.F.WORKLOG.CMP.WEEK_NR | translate: { nr: week.weekNr } }}
+                          </h3>
+                          <div>{{ week.timeSpent | msToString }}</div>
                         </div>
-                      </td>
-                    </tr>
-                  </ng-container>
-                </table>
+                        <button
+                          (click)="
+                            exportData(month.value, year.key, month.key, week.weekNr)
+                          "
+                          [matTooltip]="
+                            week.start +
+                            '.-' +
+                            week.end +
+                            '. Days: ' +
+                            week.daysWorked +
+                            ', Time: ' +
+                            (week.timeSpent | msToString)
+                          "
+                          aria-label="export data"
+                          class="mat-elevation-z1"
+                          color=""
+                          mat-mini-fab
+                        >
+                          <mat-icon>call_made</mat-icon>
+                        </button>
+                      </div>
+                      <div class="week-table-wrapper">
+                        <table class="week-table">
+                          <tr>
+                            <th></th>
+                            <td>{{ T.F.WORKLOG.CMP.TASKS | translate }}</td>
+                            <td>{{ T.F.WORKLOG.CMP.WORKED | translate }}</td>
+                            <th></th>
+                          </tr>
+                          @for (
+                            worklogForDay of week.ent | keyvalue: sortWorklogItemsReverse;
+                            track trackByKey($index, worklogForDay)
+                          ) {
+                            <ng-container class="day">
+                              <tr
+                                (click)="
+                                  expanded[worklogForDay.value.dateStr] =
+                                    !expanded[worklogForDay.value.dateStr]
+                                "
+                                [class.isExpanded]="expanded[worklogForDay.value.dateStr]"
+                                class="week-row"
+                              >
+                                <td>
+                                  {{ worklogForDay.value.dayStr }}
+                                  {{ worklogForDay.key }}.
+                                </td>
+                                <td>{{ worklogForDay.value.logEntries.length }}</td>
+                                <td>
+                                  {{ worklogForDay.value.timeSpent | msToClockString }}
+                                </td>
+                                <td>
+                                  @if (!expanded[worklogForDay.value.dateStr]) {
+                                    <mat-icon>list </mat-icon>
+                                  }
+                                  @if (expanded[worklogForDay.value.dateStr]) {
+                                    <mat-icon>close </mat-icon>
+                                  }
+                                </td>
+                              </tr>
+                              <tr>
+                                <td colspan="4">
+                                  @if (expanded[worklogForDay.value.dateStr]) {
+                                    <div
+                                      [@expandFade]
+                                      class="summary-table-wrapper material-table"
+                                    >
+                                      <table class="task-summary-table">
+                                        @for (
+                                          logEntry of worklogForDay.value.logEntries;
+                                          track trackByForLogEntry($index, logEntry)
+                                        ) {
+                                          <tr
+                                            [id]="'t-' + logEntry.task.id"
+                                            tabindex="0"
+                                          >
+                                            <td
+                                              [class.isSubTask]="logEntry.task.parentId"
+                                              class="title"
+                                            >
+                                              @if (workContextService.isToday) {
+                                                <div
+                                                  class="project-color"
+                                                  [title]="
+                                                    allProjectsColorAndTitle[
+                                                      logEntry.task.projectId
+                                                    ]?.title
+                                                  "
+                                                  [style.background]="
+                                                    allProjectsColorAndTitle[
+                                                      logEntry.task.projectId
+                                                    ]?.color
+                                                  "
+                                                ></div>
+                                              }
+                                              @if (logEntry.task.repeatCfgId) {
+                                                <mat-icon
+                                                  [title]="
+                                                    T.F.WORKLOG.CMP.REPEATING_TASK
+                                                      | translate
+                                                  "
+                                                  class="repeat-task-icon"
+                                                  >repeat
+                                                </mat-icon>
+                                              }
+                                              <span class="task-title">{{
+                                                logEntry.task.title
+                                              }}</span>
+                                            </td>
+                                            <td class="worked">
+                                              @if (
+                                                logEntry.task.subTaskIds &&
+                                                logEntry.task.subTaskIds.length > 0
+                                              ) {
+                                                <span
+                                                  >∑
+                                                  {{
+                                                    logEntry.task.timeSpentOnDay[
+                                                      worklogForDay.value.dateStr
+                                                    ] | msToClockString
+                                                  }}</span
+                                                >
+                                              }
+                                              @if (
+                                                !logEntry.task.subTaskIds ||
+                                                !logEntry.task.subTaskIds.length
+                                              ) {
+                                                <inline-input
+                                                  (changed)="
+                                                    updateTimeSpentTodayForTask(
+                                                      logEntry.task,
+                                                      worklogForDay.value.dateStr,
+                                                      $event
+                                                    )
+                                                  "
+                                                  [displayValue]="
+                                                    logEntry.task.timeSpentOnDay[
+                                                      worklogForDay.value.dateStr
+                                                    ] | msToClockString
+                                                  "
+                                                  [type]="'duration'"
+                                                  [value]="
+                                                    logEntry.task.timeSpentOnDay[
+                                                      worklogForDay.value.dateStr
+                                                    ]
+                                                  "
+                                                >
+                                                </inline-input>
+                                              }
+                                            </td>
+                                            <td class="actions">
+                                              @if (
+                                                !logEntry.task?.parentId &&
+                                                !logEntry.isNoRestore
+                                              ) {
+                                                <button
+                                                  (click)="restoreTask(logEntry.task)"
+                                                  [title]="
+                                                    T.F.WORKLOG.CMP
+                                                      .RESTORE_TASK_FROM_ARCHIVE
+                                                      | translate
+                                                  "
+                                                  aria-label="restore"
+                                                  color=""
+                                                  mat-icon-button
+                                                >
+                                                  <mat-icon
+                                                    >settings_backup_restore</mat-icon
+                                                  >
+                                                </button>
+                                              }
+                                            </td>
+                                          </tr>
+                                        }
+                                      </table>
+                                    </div>
+                                  }
+                                </td>
+                              </tr>
+                            </ng-container>
+                          }
+                        </table>
+                      </div>
+                    </div>
+                  }
+                </div>
               </div>
-            </div>
+            }
           </div>
         </div>
-      </div>
+      }
     </div>
   </div>
-</div>
+} @else {
+  <full-page-spinner></full-page-spinner>
+}

--- a/src/app/features/worklog/worklog.component.ts
+++ b/src/app/features/worklog/worklog.component.ts
@@ -25,7 +25,7 @@ import { Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { selectAllProjectColorsAndTitles } from '../project/store/project.selectors';
 import { FullPageSpinnerComponent } from '../../ui/full-page-spinner/full-page-spinner.component';
-import { AsyncPipe, KeyValuePipe, NgFor, NgIf } from '@angular/common';
+import { AsyncPipe, KeyValue, KeyValuePipe } from '@angular/common';
 import { MatIconButton, MatMiniFabButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -51,8 +51,6 @@ import { Log } from '../../core/log';
   ],
   imports: [
     FullPageSpinnerComponent,
-    NgIf,
-    NgFor,
     MatMiniFabButton,
     MatIcon,
     MatTooltip,
@@ -101,14 +99,14 @@ export class WorklogComponent implements AfterViewInit, OnDestroy {
 
   exportData(
     monthData: WorklogMonth,
-    year: number,
+    year: string | number,
     month: string | number,
     week?: number,
   ): void {
     const { rangeStart, rangeEnd } =
       typeof week === 'number'
-        ? getDateRangeForWeek(year, week, +month)
-        : getDateRangeForMonth(year, +month);
+        ? getDateRangeForWeek(+year, week, +month)
+        : getDateRangeForMonth(+year, +month);
 
     this._matDialog.open(DialogWorklogExportComponent, {
       restoreFocus: true,
@@ -149,15 +147,32 @@ export class WorklogComponent implements AfterViewInit, OnDestroy {
       });
   }
 
-  sortWorklogItems(a: { key: number }, b: { key: number }): number {
-    return b.key - a.key;
+  sortWorklogItems<
+    T extends KeyValue<K, V>,
+    K extends string | number = string,
+    V = unknown,
+  >(a: T, b: T): number {
+    if (typeof a.key === 'number' && typeof b.key === 'number') {
+      return b.key - a.key;
+    }
+    return b.key < a.key ? 1 : -1;
   }
 
-  sortWorklogItemsReverse(a: { key: number }, b: { key: number }): number {
-    return a.key - b.key;
+  sortWorklogItemsReverse<
+    T extends KeyValue<K, V>,
+    K extends string | number = string,
+    V = unknown,
+  >(a: T, b: T): number {
+    if (typeof a.key === 'number' && typeof b.key === 'number') {
+      return a.key - b.key;
+    }
+    return a.key < b.key ? 1 : -1;
   }
 
-  trackByKey(i: number, val: { key: number; val: unknown }): number {
+  trackByKey<T extends KeyValue<K, V>, K extends string | number = string, V = unknown>(
+    i: number,
+    val: T,
+  ): K {
     return val.key;
   }
 

--- a/src/app/imex/dialog-confirm-url-import/dialog-confirm-url-import.component.ts
+++ b/src/app/imex/dialog-confirm-url-import/dialog-confirm-url-import.component.ts
@@ -1,7 +1,6 @@
 import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
-import { CommonModule } from '@angular/common'; // For *ngIf, etc.
 import { TranslateModule } from '@ngx-translate/core'; // For translate pipe
 import { T } from '../../t.const';
 import { Log } from '../../core/log';
@@ -16,7 +15,6 @@ export interface DialogConfirmUrlImportData {
   styleUrls: ['./dialog-confirm-url-import.component.scss'],
   standalone: true,
   imports: [
-    CommonModule,
     MatDialogModule,
     MatButtonModule,
     TranslateModule, // Add TranslateModule for the pipe

--- a/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.html
+++ b/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.html
@@ -12,9 +12,11 @@
       required
       #urlCtrl="ngModel"
     />
-    <mat-error *ngIf="urlCtrl.invalid && (urlCtrl.dirty || urlCtrl.touched)">
-      {{ T.FILE_IMEX.S_ERR_INVALID_URL | translate }}
-    </mat-error>
+    @if (urlCtrl.invalid && (urlCtrl.dirty || urlCtrl.touched)) {
+      <mat-error>
+        {{ T.FILE_IMEX.S_ERR_INVALID_URL | translate }}
+      </mat-error>
+    }
   </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions align="end">

--- a/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.ts
+++ b/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.ts
@@ -7,7 +7,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog'; // Import MatDialogModule
 import { T } from '../../t.const';
 import { TranslatePipe } from '@ngx-translate/core';
-import { NgIf } from '@angular/common'; // For potential translations
 import { Log } from '../../core/log';
 
 @Component({
@@ -23,7 +22,6 @@ import { Log } from '../../core/log';
     MatDialogModule, // Ensure MatDialogModule is imported here for standalone
     // CommonModule will be automatically available for standalone components for ngIf, ngFor, etc.
     TranslatePipe, // If you use it in the template, import it
-    NgIf,
   ],
 })
 export class DialogImportFromUrlComponent {

--- a/src/app/imex/sync/sync-safety-backups/sync-safety-backups.component.ts
+++ b/src/app/imex/sync/sync-safety-backups/sync-safety-backups.component.ts
@@ -14,7 +14,6 @@ import { SnackService } from '../../../core/snack/snack.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { T } from '../../../t.const';
-import { CommonModule } from '@angular/common';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { SyncLog } from '../../../core/log';
 
@@ -23,7 +22,7 @@ import { SyncLog } from '../../../core/log';
   templateUrl: './sync-safety-backups.component.html',
   styleUrls: ['./sync-safety-backups.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatIcon, MatButton, MatTooltip, TranslatePipe],
+  imports: [MatIcon, MatButton, MatTooltip, TranslatePipe],
 })
 export class SyncSafetyBackupsComponent implements OnInit, OnDestroy {
   private _syncSafetyBackupService = inject(SyncSafetyBackupService);

--- a/src/app/pages/search-page/search-page.component.html
+++ b/src/app/pages/search-page/search-page.component.html
@@ -11,14 +11,15 @@
         [formControl]="searchForm"
         [placeholder]="T.F.SEARCH_BAR.PLACEHOLDER | translate"
       />
-      <button
-        mat-icon-button
-        matSuffix
-        (click)="clearSearch()"
-        *ngIf="searchForm.value"
-      >
-        <mat-icon>clear</mat-icon>
-      </button>
+      @if (searchForm.value) {
+        <button
+          mat-icon-button
+          matSuffix
+          (click)="clearSearch()"
+        >
+          <mat-icon>clear</mat-icon>
+        </button>
+      }
     </mat-form-field>
   </div>
 

--- a/src/app/pages/search-page/search-page.component.ts
+++ b/src/app/pages/search-page/search-page.component.ts
@@ -19,7 +19,7 @@ import { TagService } from '../../features/tag/tag.service';
 import { Task } from '../../features/tasks/task.model';
 import { SearchItem } from './search-page.model';
 import { NavigateToTaskService } from '../../core-ui/navigate-to-task/navigate-to-task.service';
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconButton } from '@angular/material/button';
 import { MatInput } from '@angular/material/input';
@@ -39,7 +39,6 @@ const MAX_RESULTS = 50;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncPipe,
-    NgIf,
     MatIcon,
     ReactiveFormsModule,
     MatIconButton,

--- a/src/app/plugins/ui/plugin-config-dialog/plugin-config-dialog.component.ts
+++ b/src/app/plugins/ui/plugin-config-dialog/plugin-config-dialog.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import {
   MAT_DIALOG_DATA,
   MatDialogActions,
@@ -116,7 +115,6 @@ interface PluginConfigData {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    CommonModule,
     MatButton,
     MatIcon,
     MatDialogActions,

--- a/src/app/plugins/ui/plugin-dialog/plugin-dialog.component.ts
+++ b/src/app/plugins/ui/plugin-dialog/plugin-dialog.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -69,14 +68,7 @@ import { PluginLog } from '../../../core/log';
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    CommonModule,
-    MatButton,
-    MatIcon,
-    MatDialogActions,
-    MatDialogContent,
-    MatDialogTitle,
-  ],
+  imports: [MatButton, MatIcon, MatDialogActions, MatDialogContent, MatDialogTitle],
 })
 export class PluginDialogComponent {
   private readonly _dialogRef = inject(MatDialogRef<PluginDialogComponent>);

--- a/src/app/plugins/ui/plugin-header-btns.component.ts
+++ b/src/app/plugins/ui/plugin-header-btns.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -20,7 +19,7 @@ import { PluginBridgeService } from '../plugin-bridge.service';
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatIconButton, MatIcon, MatTooltip],
+  imports: [MatIconButton, MatIcon, MatTooltip],
 })
 export class PluginHeaderBtnsComponent {
   private readonly _pluginBridge = inject(PluginBridgeService);

--- a/src/app/plugins/ui/plugin-icon/plugin-icon.component.ts
+++ b/src/app/plugins/ui/plugin-icon/plugin-icon.component.ts
@@ -8,7 +8,6 @@ import {
 import { DomSanitizer } from '@angular/platform-browser';
 import { PluginService } from '../../plugin.service';
 import { MatIcon } from '@angular/material/icon';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'plugin-icon',
@@ -51,7 +50,7 @@ import { CommonModule } from '@angular/common';
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatIcon],
+  imports: [MatIcon],
 })
 export class PluginIconComponent {
   private readonly _sanitizer = inject(DomSanitizer);

--- a/src/app/plugins/ui/plugin-index/plugin-index.component.ts
+++ b/src/app/plugins/ui/plugin-index/plugin-index.component.ts
@@ -22,7 +22,6 @@ import {
   handlePluginMessage,
   cleanupPluginIframeUrl,
 } from '../../util/plugin-iframe.util';
-import { CommonModule } from '@angular/common';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
@@ -43,7 +42,6 @@ import { PluginLog } from '../../../core/log';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
-    CommonModule,
     MatButton,
     MatIcon,
     MatProgressSpinner,

--- a/src/app/plugins/ui/plugin-management/plugin-management.component.ts
+++ b/src/app/plugins/ui/plugin-management/plugin-management.component.ts
@@ -11,7 +11,6 @@ import { PluginMetaPersistenceService } from '../../plugin-meta-persistence.serv
 import { PluginCacheService } from '../../plugin-cache.service';
 import { PluginConfigService } from '../../plugin-config.service';
 import { MAX_PLUGIN_ZIP_SIZE } from '../../plugin.const';
-import { CommonModule } from '@angular/common';
 import {
   MatCard,
   MatCardActions,
@@ -40,7 +39,6 @@ import { PluginLog } from '../../../core/log';
   styleUrls: ['./plugin-management.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    CommonModule,
     MatCard,
     MatCardActions,
     MatCardHeader,

--- a/src/app/plugins/ui/plugin-menu.component.ts
+++ b/src/app/plugins/ui/plugin-menu.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { PluginBridgeService } from '../plugin-bridge.service';
 import { MatMenuItem } from '@angular/material/menu';
 import { PluginIconComponent } from './plugin-icon/plugin-icon.component';
@@ -48,7 +47,7 @@ import { NavigationEnd, Router } from '@angular/router';
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatMenuItem, PluginIconComponent],
+  imports: [MatMenuItem, PluginIconComponent],
 })
 export class PluginMenuComponent {
   private readonly _pluginBridge = inject(PluginBridgeService);

--- a/src/app/plugins/ui/plugin-panel-container/plugin-panel-container.component.ts
+++ b/src/app/plugins/ui/plugin-panel-container/plugin-panel-container.component.ts
@@ -11,7 +11,6 @@ import { filter } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { selectActivePluginId } from '../../../core-ui/layout/store/layout.reducer';
 import { PluginIndexComponent } from '../plugin-index/plugin-index.component';
-import { CommonModule } from '@angular/common';
 import { PluginLog } from '../../../core/log';
 
 /**
@@ -21,7 +20,7 @@ import { PluginLog } from '../../../core/log';
 @Component({
   selector: 'plugin-panel-container',
   standalone: true,
-  imports: [CommonModule, PluginIndexComponent],
+  imports: [PluginIndexComponent],
   template: `
     @if (activePluginId()) {
       <plugin-index

--- a/src/app/plugins/ui/plugin-side-panel-btns.component.ts
+++ b/src/app/plugins/ui/plugin-side-panel-btns.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { PluginBridgeService } from '../plugin-bridge.service';
 import { PluginSidePanelBtnCfg } from '../plugin-api.model';
-import { CommonModule } from '@angular/common';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatIconButton } from '@angular/material/button';
 import { PluginIconComponent } from './plugin-icon/plugin-icon.component';
@@ -24,7 +23,7 @@ import { PluginLog } from '../../core/log';
 @Component({
   selector: 'plugin-side-panel-btns',
   standalone: true,
-  imports: [CommonModule, MatTooltip, MatIconButton, PluginIconComponent],
+  imports: [MatTooltip, MatIconButton, PluginIconComponent],
   template: `
     @for (button of sidePanelButtons(); track button.pluginId) {
       <button

--- a/src/app/ui/dialog-unsplash-picker/dialog-unsplash-picker.component.html
+++ b/src/app/ui/dialog-unsplash-picker/dialog-unsplash-picker.component.html
@@ -16,46 +16,47 @@
     />
   </mat-form-field>
 
-  <div
-    class="loading-container"
-    *ngIf="isLoading()"
-  >
-    <mat-spinner diameter="40"></mat-spinner>
-  </div>
-
-  <div
-    class="image-grid"
-    *ngIf="!isLoading()"
-  >
-    <div
-      class="image-item"
-      *ngFor="let photo of photos()"
-      (click)="selectPhoto(photo)"
-    >
-      <img
-        [src]="getPhotoThumb(photo)"
-        [alt]="photo.alt_description || photo.description || 'Unsplash photo'"
-      />
-      <div class="photographer">
-        {{ T.DIALOG_UNSPLASH_PICKER.BY | translate }}
-        <a
-          *ngIf="photo.user.links?.html"
-          [href]="getPhotographerUrl(photo)"
-          target="_blank"
-          (click)="$event.stopPropagation()"
-          style="color: inherit"
-        >
-          {{ photo.user.name }}
-        </a>
-        <span *ngIf="!photo.user.links?.html">{{ photo.user.name }}</span>
-      </div>
+  @if (isLoading()) {
+    <div class="loading-container">
+      <mat-spinner diameter="40"></mat-spinner>
     </div>
-  </div>
+  }
 
-  <div
-    class="no-results"
-    *ngIf="showNoResults()"
-  >
-    {{ T.DIALOG_UNSPLASH_PICKER.NO_RESULTS | translate }}
-  </div>
+  @if (!isLoading()) {
+    <div class="image-grid">
+      @for (photo of photos(); track photo) {
+        <div
+          class="image-item"
+          (click)="selectPhoto(photo)"
+        >
+          <img
+            [src]="getPhotoThumb(photo)"
+            [alt]="photo.alt_description || photo.description || 'Unsplash photo'"
+          />
+          <div class="photographer">
+            {{ T.DIALOG_UNSPLASH_PICKER.BY | translate }}
+            @if (photo.user.links?.html) {
+              <a
+                [href]="getPhotographerUrl(photo)"
+                target="_blank"
+                (click)="$event.stopPropagation()"
+                style="color: inherit"
+              >
+                {{ photo.user.name }}
+              </a>
+            }
+            @if (!photo.user.links?.html) {
+              <span>{{ photo.user.name }}</span>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  }
+
+  @if (showNoResults()) {
+    <div class="no-results">
+      {{ T.DIALOG_UNSPLASH_PICKER.NO_RESULTS | translate }}
+    </div>
+  }
 </mat-dialog-content>

--- a/src/app/ui/dialog-unsplash-picker/dialog-unsplash-picker.component.ts
+++ b/src/app/ui/dialog-unsplash-picker/dialog-unsplash-picker.component.ts
@@ -11,7 +11,6 @@ import { MatDialogContent, MatDialogRef, MatDialogTitle } from '@angular/materia
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
-import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap, takeUntil } from 'rxjs/operators';
@@ -24,7 +23,6 @@ import { T } from '../../t.const';
   selector: 'dialog-unsplash-picker',
   standalone: true,
   imports: [
-    CommonModule,
     FormsModule,
     MatDialogContent,
     MatDialogTitle,

--- a/src/app/ui/formly-image-input/formly-image-input.component.html
+++ b/src/app/ui/formly-image-input/formly-image-input.component.html
@@ -8,15 +8,16 @@
     matInput
     placeholder="https://... or file://..."
   />
-  <button
-    mat-stroked-button
-    type="button"
-    (click)="openUnsplashPicker()"
-    [disabled]="props.readonly || !isUnsplashAvailable"
-    class="unsplash-button"
-    *ngIf="isUnsplashAvailable"
-  >
-    <mat-icon>image</mat-icon>
-    Load from Unsplash
-  </button>
+  @if (isUnsplashAvailable) {
+    <button
+      mat-stroked-button
+      type="button"
+      (click)="openUnsplashPicker()"
+      [disabled]="props.readonly || !isUnsplashAvailable"
+      class="unsplash-button"
+    >
+      <mat-icon>image</mat-icon>
+      Load from Unsplash
+    </button>
+  }
 </div>

--- a/src/app/ui/formly-image-input/formly-image-input.component.ts
+++ b/src/app/ui/formly-image-input/formly-image-input.component.ts
@@ -6,22 +6,13 @@ import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
 import { DialogUnsplashPickerComponent } from '../dialog-unsplash-picker/dialog-unsplash-picker.component';
 import { UnsplashService } from '../../core/unsplash/unsplash.service';
 
 @Component({
   selector: 'formly-image-input',
   standalone: true,
-  imports: [
-    CommonModule,
-    FormsModule,
-    ReactiveFormsModule,
-    FormlyModule,
-    MatInput,
-    MatButton,
-    MatIcon,
-  ],
+  imports: [FormsModule, ReactiveFormsModule, FormlyModule, MatInput, MatButton, MatIcon],
   templateUrl: './formly-image-input.component.html',
   styleUrls: ['./formly-image-input.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/ui/mentions/mention-list.component.ts
+++ b/src/app/ui/mentions/mention-list.component.ts
@@ -40,22 +40,23 @@ import { Log } from '../../core/log';
       [class.mention-menu]="!styleOff"
       [class.mention-dropdown]="!styleOff && dropUp"
     >
-      <li
-        *ngFor="let item of items; let i = index"
-        [class.active]="activeIndex == i"
-        [class.mention-active]="!styleOff && activeIndex == i"
-      >
-        <a
-          class="dropdown-item"
-          [class.mention-item]="!styleOff"
-          (mousedown)="activeIndex = i; itemClick.emit(); $event.preventDefault()"
+      @for (item of items; track item; let i = $index) {
+        <li
+          [class.active]="activeIndex == i"
+          [class.mention-active]="!styleOff && activeIndex == i"
         >
-          <ng-template
-            [ngTemplateOutlet]="itemTemplate"
-            [ngTemplateOutletContext]="{ item: item }"
-          ></ng-template>
-        </a>
-      </li>
+          <a
+            class="dropdown-item"
+            [class.mention-item]="!styleOff"
+            (mousedown)="activeIndex = i; itemClick.emit(); $event.preventDefault()"
+          >
+            <ng-template
+              [ngTemplateOutlet]="itemTemplate"
+              [ngTemplateOutletContext]="{ item: item }"
+            ></ng-template>
+          </a>
+        </li>
+      }
     </ul>
   `,
   standalone: true,


### PR DESCRIPTION
# Description

This PR updates Angular templates across the project to use the new Angular control flow syntax (`@if`, `@for`, `@switch`, etc.) introduced in Angular v17, replacing the legacy structural directives (`*ngIf`, `*ngFor`, `*ngSwitch`).

## Issues Resolved

Migrating to the modern Control Flow syntax:
- Improves template performance and reduces generated code size.
- Provides cleaner and more maintainable template logic.
- Aligns with the latest Angular best practices and future-proof features.

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
