### PR TITLE
prevent inline-input element from collapsing due to empty value

### DIFF
--- a/src/app/ui/inline-input/inline-input.component.scss
+++ b/src/app/ui/inline-input/inline-input.component.scss
@@ -18,6 +18,12 @@
   }
 }
 
+:host-context(.summary-point) {
+  .inline-input-wrapper {
+    min-width: 35px;
+  }
+}
+
 .inline-input-wrapper {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
# Description

The input-wrapper-width collapsed to 0 due to the empty value; Because of that the hover rule which reveals the hidden inline input field did not apply.
Fixed by setting a min-width to the wrapper element in the summary-point context.

## Issues Resolved

closes #5393
