### PR TITLE
fix(test): adjust derivation of days for repeat task fixture

### DIFF
--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
@@ -31,17 +31,21 @@ describe('TaskRepeatCfgService', () => {
   let taskService: jasmine.SpyObj<TaskService>;
   let dispatchSpy: jasmine.Spy;
 
+  const formatIsoDate = (d: Date): string =>
+    `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+
   const mockTaskRepeatCfg: TaskRepeatCfg = {
     ...DEFAULT_TASK_REPEAT_CFG,
     id: 'test-cfg-id',
     title: 'Test Repeat Task',
     projectId: 'test-project',
     repeatCycle: 'DAILY',
-    startDate: new Date().toISOString().split('T')[0], // Use today's date
-    // eslint-disable-next-line no-mixed-operators
-    lastTaskCreationDay: new Date(Date.now() - 24 * 60 * 60 * 1000)
-      .toISOString()
-      .split('T')[0], // Yesterday
+    startDate: formatIsoDate(new Date()), // Today
+    lastTaskCreationDay: (() => {
+      const prevNow = new Date();
+      prevNow.setDate(prevNow.getDate() - 1);
+      return formatIsoDate(prevNow);
+    })(), // Yesterday
     repeatEvery: 1,
     defaultEstimate: 3600000,
     notes: 'Test notes',


### PR DESCRIPTION
# Description

Hello there,

I looked into the intermittently failing "Lint & Test PRs" check and came across what I think is a genuine flaw in a common fixture used for testing `TaskRepeatCfgService`.

Examples of failed check runs include:

- https://github.com/johannesjo/super-productivity/actions/runs/19008270363/job/54285401822?pr=5403
- https://github.com/johannesjo/super-productivity/actions/runs/19008249780/job/54285348565?pr=5370

The problem is the use of `toISOString` for the purpose of establishing today's or yesterday's date.

A short walkthrough example to explain:

- Consider the script `npm run test:tz:la`, which should apply a time zone offset of `UTC-8` at this time of writing.
- If I run this before 16:00 my time (`UTC+8`), say at 12:00, a sixteen hour difference means the current time would be 20:00 the *previous day* at in the time zone forced for the test run.
- Due to the use of `toISOString`, the common fixture's "today" is shifted forward a day, as adding 8 hours to get to `UTC+0` becomes the next day.
- Each test that derives its own "today" reference is doing so correctly as far as I can see (i.e. they simply invoke `new Date()`), however this mismatches the common fixture's reference today date, which then presumably goes on to mess with the assertions.
- If instead I had run the script _after_ 16:00 my time, the tests pass without issue.

There's one other unaccounted for failure that appears to affect `taskSharedSchedulingMetaReducer`. That's probably something worth investigating further to stop the ongoing false positive checks.

## Issues Resolved

N/A

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
