### PR TITLE
feat(shortSyntax): add support for time unit clusters (#2983)

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1144,4 +1144,34 @@ describe('shortSyntax', () => {
       expect(taskChanges?.timeEstimate).toEqual(minuteEstimate * 60 * 1000);
     });
   });
+
+  describe('time unit clusters', () => {
+    const testCases: [string, number | undefined, number | undefined][] = [
+      ['1h 30m', 90, undefined],
+      ['1d2h5m', 1565, undefined],
+      ['1h 30m /', undefined, 90],
+      ['1d2h5m/', undefined, 1565],
+      ['1h 30m / 1d 12h', 2160, 90],
+      ['1.25h / 0.5d 1h 4m', 784, 75],
+      ['1d2h5m/3d', 4320, 1565],
+    ];
+
+    for (const [title, timeEstimateMins, timeSpentMins] of testCases) {
+      const timeEstimate = typeof timeEstimateMins === 'number' ? timeEstimateMins * 60 * 1000 : undefined;
+      const timeSpentOnDay = typeof timeSpentMins === 'number' ? timeSpentMins * 60 * 1000 : undefined;
+      it(`should parse ${timeEstimate === undefined
+        ? 'no time estimate'
+        : 'time estimate of ' + timeEstimate} and ${timeSpentOnDay === undefined
+          ? 'no time spent on day'
+          : 'time spent on day of ' + timeSpentOnDay} from "${title}"`, () => {
+        const task = {
+          ...TASK,
+          title,
+        };
+        const result = shortSyntax(task, CONFIG, [], []);
+        expect(result?.taskChanges.timeEstimate).toBe(timeEstimate);
+        expect(result?.taskChanges.timeSpentOnDay?.[getDbDateStr()]).toBe(timeSpentOnDay);
+      });
+    }
+  });
 });

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -19,10 +19,12 @@ type DueChanges = {
 };
 
 const CH_TSP = '/';
+// Due how this expression capture clusters of duration units, be mindful of
+// match boundary whitespace during processing
 export const SHORT_SYNTAX_TIME_REG_EX = new RegExp(
-  String.raw`(?:\s|^)t?(\d+(?:\.\d+)?[mhd])(?:\s*` +
+  String.raw`(?:\s|^)t?((?:\d+(?:\.\d+)?[mhd]\s*)+)(?:\s*` +
     `\\${CH_TSP}` +
-    String.raw`(:?\s*(\d+(?:\.\d+)?[mhd]))?)?(?=\s|$)`,
+    String.raw`((?:\s*\d+(?:\.\d+)?[mhd])+)?)?(?=\s|$)`,
   'i',
 );
 
@@ -395,11 +397,11 @@ const parseTimeSpentChanges = (task: Partial<TaskCopy>): Partial<Task> => {
     ...(typeof timeSpent === 'string' && {
       timeSpentOnDay: {
         ...task.timeSpentOnDay,
-        [getDbDateStr()]: stringToMs(timeSpent),
+        [getDbDateStr()]: timeSpent.split(/\s+/g).reduce((ms, s) => ms + stringToMs(s), 0),
       },
     }),
     ...(typeof timeEstimate === 'string' && {
-      timeEstimate: stringToMs(timeEstimate),
+      timeEstimate: timeEstimate.split(/\s+/g).reduce((ms, s) => ms + stringToMs(s), 0),
     }),
     title: task.title.replace(matchSpan, '').trim(),
   };


### PR DESCRIPTION
# Description

Hello there,

This changeset extends short syntax to recognise time unit clusters when specified in task input.

For cases where the same unit is specified multiple times, I thought it was reasonable to gracefully handle them by simply summing them all up (e.g. `1h 2h 10m 20m = 3h 30m`), rather than add intrusive user validation errors.

![](https://github.com/user-attachments/assets/9af70b39-dd60-4ee4-a48c-cd2c6ecbd970)

## Issues Resolved

- #2983

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
