### PR TITLE
fix(mobile-nav): check history.state for null before access the key

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -169,6 +169,9 @@ export const HANDLED_ERROR_PROP_STR = 'HANDLED_ERROR_PROP';
  * Constants representing history state keys.
  * Used in the `window.history.pushState/replaceState` methods when opening an overlay
  * that can later be closed by pressing the "back" button in the browser or mobile app.
+ *
+ * ATTENTION: `window.history.state` can be `null`.
+ * So you should access the value this way: `window.history.state?.[HISTORY_STATE.MOBILE_NAVIGATION]` (ensuring it's not null).
  */
 export const HISTORY_STATE = {
   MOBILE_NAVIGATION: 'mobileSideNav',

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -245,7 +245,8 @@ export class MagicSideNavComponent implements OnInit, OnDestroy, AfterViewInit {
   syncMobileNavHistory(isVisible: boolean): void {
     if (!this.isMobile()) return;
 
-    const hasState = window.history.state[HISTORY_STATE.MOBILE_NAVIGATION] !== undefined;
+    const historyState = window.history.state?.[HISTORY_STATE.MOBILE_NAVIGATION];
+    const hasState = historyState !== undefined;
 
     // Mobile menu is hidden and already no state in history - nothing to do
     if (!isVisible && !hasState) return;


### PR DESCRIPTION
# Description

Ensuring `window.history.state` is not `null` before accessing

## Issues Resolved

https://github.com/johannesjo/super-productivity/issues/5472
