### PR TITLE
fix(worklog): revise comparators for key-value pipe (#5465)

### DIFF
--- a/src/app/features/worklog/worklog.component.spec.ts
+++ b/src/app/features/worklog/worklog.component.spec.ts
@@ -1,0 +1,149 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+
+import { TranslateModule } from '@ngx-translate/core';
+import { provideMockStore } from '@ngrx/store/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { Worklog } from './worklog.model';
+import { WorklogComponent } from './worklog.component';
+import { WorklogService } from './worklog.service';
+import { WorkContextService } from '../work-context/work-context.service';
+import { TaskArchiveService } from '../time-tracking/task-archive.service';
+import { TaskService } from '../tasks/task.service';
+import { Task } from '../tasks/task.model';
+import { PfapiService } from '../../pfapi/pfapi.service';
+import { selectAllProjectColorsAndTitles } from '../project/store/project.selectors';
+import { mapArchiveToWorklog } from './util/map-archive-to-worklog';
+
+describe('WorklogComponent', () => {
+  let fixture: ComponentFixture<WorklogComponent>;
+
+  const worklogData$ = new BehaviorSubject({
+    worklog: {} as Worklog,
+    totalTimeSpent: 0,
+  });
+
+  const createTaskForDate = (dateStr: string, timeSpent = 60000): Task => ({
+    attachments: [],
+    created: new Date(dateStr).getTime(),
+    id: dateStr,
+    isDone: false,
+    projectId: 'project',
+    subTaskIds: [],
+    tagIds: [],
+    timeEstimate: 0,
+    timeSpent,
+    timeSpentOnDay: { [dateStr]: timeSpent },
+    title: dateStr,
+  });
+
+  beforeEach(async () => {
+    const activatedRouteSpy = jasmine.createSpyObj<ActivatedRoute>('ActivatedRoute', [], {
+      queryParams: of(),
+    });
+    const worklogServiceSpy = jasmine.createSpyObj<WorklogService>('WorklogService', [], {
+      worklogData$,
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), WorklogComponent],
+      providers: [
+        provideMockStore({
+          selectors: [
+            {
+              selector: selectAllProjectColorsAndTitles,
+              value: [],
+            },
+          ],
+        }),
+        provideMockActions(of()),
+        provideNoopAnimations(),
+        { provide: ActivatedRoute, useValue: activatedRouteSpy },
+        { provide: PfapiService, useValue: {} },
+        { provide: TaskArchiveService, useValue: {} },
+        { provide: TaskService, useValue: {} },
+        { provide: WorkContextService, useValue: {} },
+        { provide: WorklogService, useValue: worklogServiceSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WorklogComponent);
+    fixture.detectChanges();
+  });
+
+  it('arranges month data in reverse chronological order from top to bottom', () => {
+    const tasks = [
+      createTaskForDate('2025-01-01'),
+      createTaskForDate('2025-02-01'),
+      createTaskForDate('2025-03-01'),
+      createTaskForDate('2025-10-01'),
+      createTaskForDate('2025-11-01'),
+      createTaskForDate('2025-12-01'),
+    ];
+
+    worklogData$.next(
+      mapArchiveToWorklog(
+        {
+          ids: tasks.map((task) => task.id),
+          entities: tasks.reduce(
+            (entities, task) => ({ ...entities, [task.id]: task }),
+            {},
+          ),
+        },
+        [],
+        { workStart: {}, workEnd: {} },
+        1,
+        'en-US',
+      ),
+    );
+    fixture.detectChanges();
+
+    const monthTitles = fixture.debugElement
+      .queryAll(By.css('.month-title > span'))
+      .map((de) => de.nativeElement.textContent.trim());
+
+    expect(monthTitles).toEqual([
+      'December',
+      'November',
+      'October',
+      'March',
+      'February',
+      'January',
+    ]);
+  });
+
+  it('arranges day data in chronological order from top to bottom', () => {
+    const tasks = [
+      createTaskForDate('2025-01-01'),
+      createTaskForDate('2025-01-02'),
+      createTaskForDate('2025-01-03'),
+    ];
+
+    worklogData$.next(
+      mapArchiveToWorklog(
+        {
+          ids: tasks.map((task) => task.id),
+          entities: tasks.reduce(
+            (entities, task) => ({ ...entities, [task.id]: task }),
+            {},
+          ),
+        },
+        [],
+        { workStart: {}, workEnd: {} },
+        1,
+        'en-US',
+      ),
+    );
+    fixture.detectChanges();
+
+    const dayLabels = fixture.debugElement
+      .queryAll(By.css('.week-row td:first-child'))
+      .map((de) => de.nativeElement.textContent.trim());
+
+    expect(dayLabels).toEqual(['Wed 1.', 'Thu 2.', 'Fri 3.']);
+  });
+});

--- a/src/app/features/worklog/worklog.component.ts
+++ b/src/app/features/worklog/worklog.component.ts
@@ -147,27 +147,11 @@ export class WorklogComponent implements AfterViewInit, OnDestroy {
       });
   }
 
-  sortWorklogItems<
-    T extends KeyValue<K, V>,
-    K extends string | number = string,
-    V = unknown,
-  >(a: T, b: T): number {
-    if (typeof a.key === 'number' && typeof b.key === 'number') {
-      return b.key - a.key;
-    }
-    return b.key < a.key ? 1 : -1;
-  }
+  sortWorklogItems = <T extends KeyValue<string, unknown>>(a: T, b: T): number =>
+    +b.key - +a.key;
 
-  sortWorklogItemsReverse<
-    T extends KeyValue<K, V>,
-    K extends string | number = string,
-    V = unknown,
-  >(a: T, b: T): number {
-    if (typeof a.key === 'number' && typeof b.key === 'number') {
-      return a.key - b.key;
-    }
-    return a.key < b.key ? 1 : -1;
-  }
+  sortWorklogItemsReverse = <T extends KeyValue<string, unknown>>(a: T, b: T): number =>
+    -this.sortWorklogItems(a, b);
 
   trackByKey<T extends KeyValue<K, V>, K extends string | number = string, V = unknown>(
     i: number,


### PR DESCRIPTION
# Description

Hello there,

This changeset should address the undesirable ordering of worklog data that was recently reported by some users.

The cause appears to be a regression introduced by the following pull request:

- #5396

Specifically, the (rather obfuscated IMHO) changes to `sortWorklogItems` and `sortWorklogItemsReverse`, used by the Worklog view to display data.

For how these comparators are actually being used in the template, the `key` (of `KeyValuePair<K, V>`) should always be a `string`. As such, that refactored attempt would be using the lexicographic comparison, not the numeric one, which produces the unintuitive ordering seen.

Also worth pointing out that while the prior comparator implementations do work, they do so in a perhaps unexpected manner. That is, the subtraction operator on incoming `string` values (incorrectly typed as `number`) causes an implicit conversion of the operands to `number` values.

https://github.com/johannesjo/super-productivity/blob/5e43c022d62e0e203d12e753f5202a73c8b2c49f/src/app/features/worklog/worklog.component.ts#L152-L158

I've also added tests for the worklog component to cover this ordering behaviour to hopefully prevent future refactor regressions.

## Issues Resolved

- #5465

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
