### PR TITLE
feat: bump to electron 38 to fix Wayland GPU launch issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@angular-eslint/template-parser": "^20.5.0",
         "@angular/animations": "^20.3.7",
         "@angular/cdk": "^20.2.10",
-        "@angular/cli": "^20.3.10",
+        "@angular/cli": "^20.3.7",
         "@angular/common": "^20.3.7",
         "@angular/compiler": "^20.3.7",
         "@angular/compiler-cli": "^20.3.7",
@@ -1072,13 +1072,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.10.tgz",
-      "integrity": "sha512-2N2WF9lj+kr3uCG4+vFadYCL5hAT4dxMgzwScSdOqSd0O+GZD0CzKbDzlfvWIWC/ZealC5Sh4dFEQaRfmy72xA==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.7.tgz",
+      "integrity": "sha512-DUxcQBPKO69p56ZgIdVfxWyLiSjdcUoD6BH9/nWHp0QiqRAR6GcXP4SFax76JPl2WsiCp4hHZ233Hf69AP1xew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.10",
+        "@angular-devkit/core": "20.3.7",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "8.2.0",
@@ -1091,9 +1091,9 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.10.tgz",
-      "integrity": "sha512-COOT2eVebDwHhwENk12VR6m0wjL8D7p0dncEHF15zaBt1IXEnVhGESjSrs5klnPnt5T55qCBKyCTaeK7i/cS8Q==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.7.tgz",
+      "integrity": "sha512-psmcjwYcXve4sLrcdnARc15/Wfd3RpydbtLo9+mViNzk5HQ6L2eEztKl/2QVYMgzZVIa1GfhjwUllVCyLAv3sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1871,19 +1871,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.10.tgz",
-      "integrity": "sha512-CQzXScurBXSuMMn0jf6UYDItdggaM3bHYERKL4cUG1z5JqSozVFin1+TB1EjWYkddwdgC10R5xQurdMb+ahRNw==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.7.tgz",
+      "integrity": "sha512-hNurF7g/e9cDHFBRCKLPSmQJs0n28jZsC3sTl/XuWE8PYtv5egh2EuqrxdruYB5GdANpIqSQNgDGQJrKrk/XnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2003.10",
-        "@angular-devkit/core": "20.3.10",
-        "@angular-devkit/schematics": "20.3.10",
+        "@angular-devkit/architect": "0.2003.7",
+        "@angular-devkit/core": "20.3.7",
+        "@angular-devkit/schematics": "20.3.7",
         "@inquirer/prompts": "7.8.2",
         "@listr2/prompt-adapter-inquirer": "3.0.1",
         "@modelcontextprotocol/sdk": "1.17.3",
-        "@schematics/angular": "20.3.10",
+        "@schematics/angular": "20.3.7",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.35.0",
         "ini": "5.0.0",
@@ -1905,26 +1905,10 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@angular/cli/node_modules/@angular-devkit/architect": {
-      "version": "0.2003.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.10.tgz",
-      "integrity": "sha512-2SWetxJzS8gRX6OKQstkWx37VRvZVgcEBDLsDSaeTjpnwh81A+niZQjAVRdwL0NEt1Wixk/RxfeUuCmdyyHvhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "20.3.10",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.10.tgz",
-      "integrity": "sha512-COOT2eVebDwHhwENk12VR6m0wjL8D7p0dncEHF15zaBt1IXEnVhGESjSrs5klnPnt5T55qCBKyCTaeK7i/cS8Q==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.7.tgz",
+      "integrity": "sha512-psmcjwYcXve4sLrcdnARc15/Wfd3RpydbtLo9+mViNzk5HQ6L2eEztKl/2QVYMgzZVIa1GfhjwUllVCyLAv3sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8328,14 +8312,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.10.tgz",
-      "integrity": "sha512-F9ntS2CElpoWlENf4b03nwdTcN9Ri0Nb4SAE/pfRw3In09h2UHxYyf1ex9jqQt70xltDg4wvyuc3mMs+JlSx9A==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.7.tgz",
+      "integrity": "sha512-jR2LPJVGK6yzPTNXkGJZYtdeLGkNdqJhVow2E+ILt3pk/LZuT/iSdr9V4nArU9yysifGuJFTyZapVOYkEYaykg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.10",
-        "@angular-devkit/schematics": "20.3.10",
+        "@angular-devkit/core": "20.3.7",
+        "@angular-devkit/schematics": "20.3.7",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -8345,9 +8329,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.10.tgz",
-      "integrity": "sha512-COOT2eVebDwHhwENk12VR6m0wjL8D7p0dncEHF15zaBt1IXEnVhGESjSrs5klnPnt5T55qCBKyCTaeK7i/cS8Q==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.7.tgz",
+      "integrity": "sha512-psmcjwYcXve4sLrcdnARc15/Wfd3RpydbtLo9+mViNzk5HQ6L2eEztKl/2QVYMgzZVIa1GfhjwUllVCyLAv3sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@angular-eslint/template-parser": "^20.5.0",
     "@angular/animations": "^20.3.7",
     "@angular/cdk": "^20.2.10",
-    "@angular/cli": "^20.3.10",
+    "@angular/cli": "^20.3.7",
     "@angular/common": "^20.3.7",
     "@angular/compiler": "^20.3.7",
     "@angular/compiler-cli": "^20.3.7",


### PR DESCRIPTION
# Description

  - Bump the project from Electron 37.7.0 to 38.x (package + lockfile) so we pick up the upstream fix for the Wayland GPU sandbox regression (electron/electron#45862)

  ## Issues Resolved

  - Fixes the “GPU process exited unexpectedly / GpuControl.CreateCommandBuffer” crash tracked in #5252 (and duplicates like #5196) by moving to Electron 38, which incorporates the upstream Electron fix.

  ## Check List

  - [ ] New functionality includes testing.
  - [ ] New functionality has been documented in the README if applicable.

