### PR TITLE
local file sync select folder

### DIFF
--- a/electron/local-file-sync.ts
+++ b/electron/local-file-sync.ts
@@ -138,7 +138,14 @@ export const initLocalFileSyncAdapter = (): void => {
 
   ipcMain.handle(IPC.PICK_DIRECTORY, async (): Promise<string | undefined> => {
     const { canceled, filePaths } = await dialog.showOpenDialog(getWin(), {
-      properties: ['openDirectory'],
+      title: 'Select sync folder',
+      buttonLabel: 'Select Folder',
+      properties: [
+        'openDirectory',
+        'createDirectory',
+        'promptToCreate',
+        'dontAddToRecent',
+      ],
     });
     if (canceled) {
       return undefined;


### PR DESCRIPTION
# Description

More explicitly configures directory selection when picking a path for the local file sync provider

## Issues Resolved

addresses discussion in #5149 (but likely not the original issue) 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
