### PR TITLE
Improve local file sync directory picker

### DIFF
--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -51,7 +51,7 @@ export interface ElectronAPI {
 
   checkDirExists(args: { dirPath: string }): Promise<true | Error>;
 
-  pickDirectory(): Promise<string | undefined>;
+  pickDirectory(options?: DirectoryDialogOptions): Promise<string | undefined>;
 
   // checkDirExists(dirPath: string): Promise<true | Error>;
 
@@ -151,4 +151,11 @@ export interface ElectronAPI {
     manifest: PluginManifest,
     request: PluginNodeScriptRequest,
   ): Promise<PluginNodeScriptResult>;
+}
+
+export interface DirectoryDialogOptions {
+  defaultPath?: string | null;
+  title?: string;
+  message?: string;
+  buttonLabel?: string;
 }

--- a/electron/local-file-sync.ts
+++ b/electron/local-file-sync.ts
@@ -2,8 +2,13 @@ import { IPC } from './shared-with-frontend/ipc-events.const';
 import { SyncGetRevResult } from '../src/app/imex/sync/sync.model';
 import { readdirSync, readFileSync, statSync, writeFileSync, unlinkSync } from 'fs';
 import { error, log } from 'electron-log/main';
-import { dialog, ipcMain } from 'electron';
+import { dialog, ipcMain, OpenDialogOptions } from 'electron';
 import { getWin } from './main-window';
+
+type DirectoryDialogOptions = Pick<
+  OpenDialogOptions,
+  'defaultPath' | 'title' | 'message' | 'buttonLabel'
+>;
 
 export const initLocalFileSyncAdapter = (): void => {
   ipcMain.handle(
@@ -136,16 +141,19 @@ export const initLocalFileSyncAdapter = (): void => {
     },
   );
 
-  ipcMain.handle(IPC.PICK_DIRECTORY, async (): Promise<string | undefined> => {
-    const { canceled, filePaths } = await dialog.showOpenDialog(getWin(), {
-      properties: ['openDirectory'],
-    });
-    if (canceled) {
-      return undefined;
-    } else {
+  ipcMain.handle(
+    IPC.PICK_DIRECTORY,
+    async (_ev, options?: DirectoryDialogOptions): Promise<string | undefined> => {
+      const { canceled, filePaths } = await dialog.showOpenDialog(getWin(), {
+        properties: ['openDirectory'],
+        ...options,
+      });
+      if (canceled) {
+        return undefined;
+      }
       return filePaths[0];
-    }
-  });
+    },
+  );
 };
 
 const getRev = (filePath: string): string => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer, IpcRendererEvent, webFrame, contextBridge } from 'electron';
-import { ElectronAPI } from './electronAPI.d';
+import { DirectoryDialogOptions, ElectronAPI } from './electronAPI.d';
 import { IPCEventValue } from './shared-with-frontend/ipc-events.const';
 import { LocalBackupMeta } from '../src/app/imex/local-backup/local-backup.model';
 import { SyncGetRevResult } from '../src/app/imex/sync/sync.model';
@@ -48,7 +48,8 @@ const ea: ElectronAPI = {
   checkDirExists: (dirPath) =>
     _invoke('CHECK_DIR_EXISTS', dirPath) as Promise<true | Error>,
 
-  pickDirectory: () => _invoke('PICK_DIRECTORY') as Promise<string | undefined>,
+  pickDirectory: (options?: DirectoryDialogOptions) =>
+    _invoke('PICK_DIRECTORY', options) as Promise<string | undefined>,
 
   // STANDARD
   // --------

--- a/src/app/pfapi/api/sync/providers/local-file-sync/local-file-sync-electron.ts
+++ b/src/app/pfapi/api/sync/providers/local-file-sync/local-file-sync-electron.ts
@@ -86,7 +86,10 @@ export class LocalFileSyncElectron extends LocalFileSyncBase {
     PFLog.normal(`${LocalFileSyncElectron.L}.pickDirectory()`);
 
     try {
-      const dir = await (window as any).ea.pickDirectory();
+      const privateCfg = await this.privateCfg.load();
+      const dir = await (window as any).ea.pickDirectory({
+        defaultPath: privateCfg?.syncFolderPath || undefined,
+      });
       if (dir) {
         await this.privateCfg.upsertPartial({ syncFolderPath: dir });
       }


### PR DESCRIPTION
## Summary
- allow the renderer process to pass directory-picker options through the preload bridge to the Electron main process
- preserve the previously selected local sync folder by passing it as the default path when reopening the picker

## Testing
- `npm run checkFile electron/local-file-sync.ts` *(fails: Angular CLI binary unavailable in the container environment)*
- `npm run checkFile electron/preload.ts` *(fails: Angular CLI binary unavailable in the container environment)*
- `npm run checkFile electron/electronAPI.d.ts` *(fails: Angular CLI binary unavailable in the container environment)*
- `npm run checkFile src/app/pfapi/api/sync/providers/local-file-sync/local-file-sync-electron.ts` *(fails: Angular CLI binary unavailable in the container environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691afb643dd883329d7ed02f8decbaab)