### PR TITLE
Improve local file sync directory picker

### DIFF
--- a/electron/directory-dialog-options.ts
+++ b/electron/directory-dialog-options.ts
@@ -1,0 +1,6 @@
+import type { OpenDialogOptions } from 'electron';
+
+export type DirectoryDialogOptions = Pick<
+  OpenDialogOptions,
+  'defaultPath' | 'title' | 'message' | 'buttonLabel'
+>;

--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -14,6 +14,7 @@ import {
   PluginNodeScriptResult,
   PluginManifest,
 } from '../packages/plugin-api/src/types';
+import type { DirectoryDialogOptions } from './directory-dialog-options';
 
 export interface ElectronAPI {
   on(
@@ -153,9 +154,4 @@ export interface ElectronAPI {
   ): Promise<PluginNodeScriptResult>;
 }
 
-export interface DirectoryDialogOptions {
-  defaultPath?: string | null;
-  title?: string;
-  message?: string;
-  buttonLabel?: string;
-}
+export type { DirectoryDialogOptions } from './directory-dialog-options';

--- a/electron/local-file-sync.ts
+++ b/electron/local-file-sync.ts
@@ -2,13 +2,9 @@ import { IPC } from './shared-with-frontend/ipc-events.const';
 import { SyncGetRevResult } from '../src/app/imex/sync/sync.model';
 import { readdirSync, readFileSync, statSync, writeFileSync, unlinkSync } from 'fs';
 import { error, log } from 'electron-log/main';
-import { dialog, ipcMain, OpenDialogOptions } from 'electron';
+import { dialog, ipcMain } from 'electron';
 import { getWin } from './main-window';
-
-type DirectoryDialogOptions = Pick<
-  OpenDialogOptions,
-  'defaultPath' | 'title' | 'message' | 'buttonLabel'
->;
+import type { DirectoryDialogOptions } from './directory-dialog-options';
 
 export const initLocalFileSyncAdapter = (): void => {
   ipcMain.handle(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer, IpcRendererEvent, webFrame, contextBridge } from 'electron';
-import { DirectoryDialogOptions, ElectronAPI } from './electronAPI.d';
+import type { ElectronAPI } from './electronAPI.d';
+import type { DirectoryDialogOptions } from './directory-dialog-options';
 import { IPCEventValue } from './shared-with-frontend/ipc-events.const';
 import { LocalBackupMeta } from '../src/app/imex/local-backup/local-backup.model';
 import { SyncGetRevResult } from '../src/app/imex/sync/sync.model';


### PR DESCRIPTION
## Summary
- allow the renderer process to pass directory-picker options through the preload bridge to the Electron main process
- preserve the previously selected local sync folder by passing it as the default path when reopening the picker
- share the `DirectoryDialogOptions` type between the Electron main process and preload bridge to avoid divergence during future merges

## Testing
- `npm run checkFile electron/directory-dialog-options.ts` *(fails: Angular CLI binary unavailable in the container environment)*
- `npm run checkFile electron/local-file-sync.ts` *(fails: Angular CLI binary unavailable in the container environment)*
- `npm run checkFile electron/preload.ts` *(fails: Angular CLI binary unavailable in the container environment)*
- `npm run checkFile electron/electronAPI.d.ts` *(fails: Angular CLI binary unavailable in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b08a5eb708332b440de1e1765d585)