### PR TITLE
allow disabling calendars for webapps

### DIFF
--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -37,7 +37,10 @@ import { getDbDateStr } from '../../util/get-db-date-str';
 import { selectCalendarProviders } from '../issue/store/issue-provider.selectors';
 import { IssueProviderCalendar } from '../issue/issue.model';
 import { CalendarProviderCfg } from '../issue/providers/calendar/calendar.model';
-import { CORS_SKIP_EXTRA_HEADERS } from '../../app.constants';
+import {
+  CORS_SKIP_EXTRA_HEADERS,
+  IS_WEB_EXTENSION_REQUIRED_FOR_JIRA,
+} from '../../app.constants';
 import { Log } from '../../core/log';
 import {
   getCalendarEventIdCandidates,
@@ -198,6 +201,10 @@ export class CalendarIntegrationService {
   ): Observable<CalendarIntegrationEvent[]> {
     // Log.log('REQUEST EVENTS', calProvider, start, end);
 
+    // allow calendars to be disabled for web apps if CORS will fail to prevent errors
+    if (calProvider.isDisabledForWebApp && IS_WEB_EXTENSION_REQUIRED_FOR_JIRA) {
+      return of([]);
+    }
     return this._http
       .get(calProvider.icalUrl, {
         responseType: 'text',

--- a/src/app/features/issue/providers/calendar/calendar.const.ts
+++ b/src/app/features/issue/providers/calendar/calendar.const.ts
@@ -12,6 +12,7 @@ export const DEFAULT_CALENDAR_CFG: CalendarProviderCfg = {
   isAutoImportForCurrentDay: false,
   checkUpdatesEvery: 2 * 60 * 60000,
   showBannerBeforeThreshold: 2 * 60 * 60000,
+  isDisabledForWebApp: false,
 };
 
 export const CALENDAR_FORM_CFG_NEW: ConfigFormSection<IssueProviderCalendar> = {
@@ -83,6 +84,16 @@ export const CALENDAR_FORM_CFG_NEW: ConfigFormSection<IssueProviderCalendar> = {
         // TODO translation
         // label: T.GCF.CALENDARS.CAL_PATH,
         label: 'Auto import events as tasks for current day',
+      },
+    },
+    {
+      type: 'checkbox',
+      key: 'isDisabledForWebApp',
+      templateOptions: {
+        type: 'url',
+        // TODO translation
+        // label: T.GCF.CALENDARS.CAL_PATH,
+        label: 'Disable when using web application',
       },
     },
     // {

--- a/src/app/features/issue/providers/calendar/calendar.model.ts
+++ b/src/app/features/issue/providers/calendar/calendar.model.ts
@@ -8,6 +8,7 @@ export interface CalendarProviderCfg extends BaseIssueProviderCfg {
   icon?: string;
   checkUpdatesEvery: number;
   showBannerBeforeThreshold: null | number;
+  isDisabledForWebApp: boolean;
 }
 
 export type LegacyCalendarProvider = Readonly<{


### PR DESCRIPTION
# Description

Allows disabling of calendars when using the web app. This prevents errors when using the web app to get calendars that cause CORS issues. It is necessary for users who use the desktop app with calendars, but use iOS and cannot have calendars on mobile.

## Issues Resolved

Not a direct fix, but a mitigation for issues like #4021 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
