### PR TITLE
fix #5596

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.ts
+++ b/src/app/core-ui/main-header/main-header.component.ts
@@ -46,6 +46,7 @@ import { DateService } from '../../core/date/date.service';
 import { MsToMinuteClockStringPipe } from '../../ui/duration/ms-to-minute-clock-string.pipe';
 import { UserProfileButtonComponent } from '../../features/user-profile/user-profile-button/user-profile-button.component';
 import { FocusButtonComponent } from './focus-button/focus-button.component';
+import { UserProfileService } from '../../features/user-profile/user-profile.service';
 
 @Component({
   selector: 'main-header',
@@ -165,8 +166,12 @@ export class MainHeaderComponent implements OnDestroy {
     return this.globalConfigService.cfg()?.appFeatures.isSyncIconEnabled;
   });
 
+  private readonly _userProfileService = inject(UserProfileService);
   isUserProfilesEnabled = computed(() => {
-    return this.globalConfigService.cfg()?.appFeatures.isEnableUserProfiles;
+    return (
+      this.globalConfigService.cfg()?.appFeatures.isEnableUserProfiles &&
+      this._userProfileService.isInitialized()
+    );
   });
 
   private _subs: Subscription = new Subscription();

--- a/src/app/features/user-profile/user-profile.service.ts
+++ b/src/app/features/user-profile/user-profile.service.ts
@@ -21,6 +21,8 @@ export class UserProfileService {
   private readonly _injector = inject(Injector);
   private readonly _globalConfigService = inject(GlobalConfigService);
 
+  readonly isInitialized = signal(false);
+
   // Current profile metadata
   private readonly _metadata = signal<ProfileMetadata | null>(null);
   readonly metadata = this._metadata.asReadonly();
@@ -73,6 +75,8 @@ export class UserProfileService {
         );
         this.activeProfile.set(metadata.profiles[0]);
       }
+
+      this.isInitialized.set(true);
     } catch (error) {
       Log.err('UserProfileService: Failed to initialize', error);
       // create a default profile and continue
@@ -80,6 +84,7 @@ export class UserProfileService {
       this._metadata.set(defaultMetadata);
       this.profiles.set(defaultMetadata.profiles);
       this.activeProfile.set(defaultMetadata.profiles[0]);
+      this.isInitialized.set(true);
     }
   }
 
@@ -468,6 +473,7 @@ export class UserProfileService {
       this._metadata.set(metadata);
       this.profiles.set(metadata.profiles);
       this.activeProfile.set(metadata.profiles[0]);
+      this.isInitialized.set(true);
 
       Log.log('UserProfileService: Migration completed successfully');
     } catch (error) {


### PR DESCRIPTION
# Description

Fixed broken user profiles activation.

It seems there was a race condition and a unnecessary check, as well as a missing import.
Instead I added a signal to the UserProfileService if the subsystem was initialized successfully.

The user profiles could be activated and used reliable in my test scenario.

## Issues Resolved

Fix #5596

