### PR TITLE
allow click on buttons under hidden .current-task-title

### DIFF
--- a/src/app/core-ui/main-header/play-button/play-button.component.ts
+++ b/src/app/core-ui/main-header/play-button/play-button.component.ts
@@ -290,8 +290,8 @@ import { distinctUntilChanged, observeOn } from 'rxjs/operators';
           padding-right: 0;
         }
 
-        :host:hover & {
-          opacity: 0;
+        ::ng-deep .action-nav:hover & {
+          visibility: hidden;
         }
       }
     `,


### PR DESCRIPTION
# Description

When time tracking is active, the name of the running task is shown left next to the play button in the main button bar, covering the buttons "Add new Task", "Sync!" and "Profile". Although the task name is hidden and the buttons become visible on hover, they are not clickable.

Attached the hover to the nav bar and changed to visibility: hidden for the task label instead of setting opacity: 0

## Issues Resolved

Fixes #5696
Fixes #5595 (I think, there is some room for interpretation from the description of the issue...)

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
