### PR TITLE
fix(linear): show status name property

### DIFF
--- a/src/app/features/issue/providers/linear/linear-issue-content.const.ts
+++ b/src/app/features/issue/providers/linear/linear-issue-content.const.ts
@@ -16,9 +16,9 @@ export const LINEAR_ISSUE_CONTENT_CONFIG: IssueContentConfig<LinearIssue> = {
     },
     {
       label: T.F.ISSUE.ISSUE_CONTENT.STATUS,
-      value: 'state',
+      value: (issue: LinearIssue) => issue.state.name,
       type: IssueFieldType.TEXT,
-      isVisible: (issue: LinearIssue) => !!issue.state,
+      isVisible: (issue: LinearIssue) => !!issue.state.name,
     },
     {
       label: 'Priority',
@@ -44,12 +44,6 @@ export const LINEAR_ISSUE_CONTENT_CONFIG: IssueContentConfig<LinearIssue> = {
       value: 'description',
       type: IssueFieldType.MARKDOWN,
       isVisible: (issue: LinearIssue) => !!issue.description,
-    },
-    {
-      label: T.F.ISSUE.ISSUE_CONTENT.ATTACHMENTS,
-      value: 'attachments',
-      type: IssueFieldType.LINK,
-      isVisible: (issue: LinearIssue) => Boolean(issue.attachments?.length),
     },
   ],
   comments: {


### PR DESCRIPTION
# Description

Fixes an issue where the status property shows `[object Object]` on linear tickets

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
