### PR TITLE
fix(schedule): maintain visibility during task overlap on schedule (#5887)

### DIFF
--- a/e2e/tests/schedule/schedule-overlap.spec.ts
+++ b/e2e/tests/schedule/schedule-overlap.spec.ts
@@ -1,0 +1,56 @@
+import { test } from '../../fixtures/test.fixture';
+
+test.describe('Schedule overlap', () => {
+  test('should display multiple tasks starting the same time', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    // Navigate to schedule view
+    await page.getByRole('menuitem', { name: 'Schedule' }).click();
+    // Dismiss the scheduling information dialog
+    await page.locator('button', { hasText: /Cancel/ }).click();
+
+    const addTask = async (taskDescription: string): Promise<void> => {
+      // Last day is far enough into the future to avoid any created tasks
+      // spawning reminder popups to interrupt the test
+      const lastDayColumn = page.locator('schedule [data-day]').last();
+      // Tasks appearing in columns are expected to always allow for a small
+      // margin to the rightmost column edge for additional tasks to be created
+      // around the same start time
+      await lastDayColumn.click({
+        position: {
+          x: await lastDayColumn.evaluate((el) => el.clientWidth - 5),
+          y: await lastDayColumn.evaluate((el) => el.clientHeight / 2),
+        },
+      });
+
+      const newTaskInput = page.getByRole('combobox', { name: 'Schedule task...' });
+      await newTaskInput.fill(taskDescription);
+      await newTaskInput.press('Enter');
+    };
+
+    await addTask('task1');
+    await addTask('task2');
+    await addTask('task3');
+
+    const checkTaskAccessible = async (taskDescription: string): Promise<void> => {
+      await page
+        .locator('schedule-event')
+        .filter({ hasText: taskDescription })
+        // Regardless of how the elements representing tasks overlap, the top
+        // left corner should always be visible to click on
+        .click({ position: { x: 0, y: 0 } });
+      // Clicking on the task should bring up its details panel
+      await page
+        .locator('task-detail-panel')
+        .filter({ hasText: taskDescription })
+        .isVisible();
+    };
+
+    await checkTaskAccessible('task1');
+    await checkTaskAccessible('task2');
+    await checkTaskAccessible('task3');
+  });
+});

--- a/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts
@@ -93,8 +93,6 @@ describe('mapScheduleDaysToScheduleEvents()', () => {
           style: 'grid-column: 2;  grid-row: 61 / span 12',
           timeLeftInHours: 1,
           type: 'Task',
-          isCloseToOthers: false,
-          isCloseToOthersFirst: false,
         },
         {
           data: {
@@ -111,8 +109,6 @@ describe('mapScheduleDaysToScheduleEvents()', () => {
           style: 'grid-column: 2;  grid-row: 73 / span 6',
           timeLeftInHours: 0.5,
           type: 'Task',
-          isCloseToOthers: false,
-          isCloseToOthersFirst: false,
         },
       ],
     } as any);

--- a/src/app/features/schedule/schedule-day-panel/schedule-day-panel.component.ts
+++ b/src/app/features/schedule/schedule-day-panel/schedule-day-panel.component.ts
@@ -678,8 +678,6 @@ export class ScheduleDayPanelComponent implements AfterViewInit, OnDestroy {
       style: '',
       startHours: 0,
       timeLeftInHours: timeInHours,
-      isCloseToOthersFirst: false,
-      isCloseToOthers: false,
       data: task,
     };
   }

--- a/src/app/features/schedule/schedule-event/schedule-event.component.scss
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.scss
@@ -26,11 +26,6 @@
   z-index: 2;
   user-select: none;
 
-  // Bring hovered events above others
-  &:hover {
-    z-index: 10;
-  }
-
   // has to be for after elements
   overflow: visible !important;
   min-width: 0;
@@ -100,9 +95,9 @@
     content: '';
     position: absolute;
     top: 0;
-    bottom: calc(-1 * (var(--margin-bottom) + 1px));
+    bottom: 0;
     left: 0;
-    right: calc(-1 * (var(--margin-right) + 4px));
+    right: 0;
     z-index: 3;
     display: block;
   }

--- a/src/app/features/schedule/schedule-week/schedule-week.component.html
+++ b/src/app/features/schedule/schedule-week/schedule-week.component.html
@@ -166,6 +166,7 @@
       [style]="dragPreviewStyle()!"
       [class.isShiftInsertPreview]="dragPreviewContext()?.kind === 'shift-task'"
       [class.isScheduleForDay]="isShiftNoScheduleMode()"
+      [isDragPreview]="true"
     >
       @if (dragPreviewLabel()) {
         <div class="drag-preview-time-badge">

--- a/src/app/features/schedule/schedule.model.ts
+++ b/src/app/features/schedule/schedule.model.ts
@@ -9,10 +9,9 @@ export interface ScheduleEvent {
   style: string;
   startHours: number;
   timeLeftInHours: number;
-  isCloseToOthersFirst: boolean;
-  isCloseToOthers: boolean;
   dayOfMonth?: number;
   data?: SVE['data'];
+  overlap?: { count: number; offset: number };
 }
 
 export interface ScheduleDay {


### PR DESCRIPTION
Hello there,

This changeset provides an (somewhat opinionated) approach to maintain the visibility of any overlapping tasks that appear in the Schedule view.

If I had to summarise broadly, the gist of this approach is based on keeping track of when tasks are "active" and assigning them into a "slot" (day column offset) all the while ensuring that the exact start and end of each task is visually discernable. I'll add some comments inline to help with review.

I've also added an additional E2E regression test case to ensure user access to overlapping tasks in the Schedule view is maintained.

![1](https://github.com/user-attachments/assets/d0e0f287-5bd4-400e-8d93-a35a0d2b9a92)

Addresses:
- https://github.com/super-productivity/super-productivity/issues/5887

(I noticed there's no longer a pull request template since I last contributed. I guess it's been removed?)