### PR TITLE
fix(i18n): misspelled translation for 'NO_PLANNED_TASKS' in Polish

### DIFF
--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2079,7 +2079,7 @@
     "MOVE_DONE_TO_ARCHIVE": "Przenieś gotowe do archiwum",
     "NO_DONE_TASKS": "Obecnie nie ma żadnych wykonanych zadań",
     "NO_PLANNED_TASK_ALL_DONE": "wszystkie zadania zakończone",
-    "NO_PLANNED_TASKS": "Nie zaplaniwano zadań",
+    "NO_PLANNED_TASKS": "Nie zaplanowano zadań",
     "READY_TO_WORK": "Gotowy do Pracy!",
     "RESET_BREAK_TIMER": "Zresetuj bez czasu przerwy",
     "TIME_ESTIMATED": "Zaplanowany Czas:",


### PR DESCRIPTION
Zaplaniwano is an incorrect word. The correct word is zaplanowano.