### PR TITLE
Always use project URL from issue ID

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
@@ -191,7 +191,7 @@ export class GitlabApiService {
   }> {
     return this._sendRawRequest$(
       {
-        url: `${this._issueApiLink(cfg)}/time_stats`,
+        url: `${this._issueApiLink(cfg, issueId)}/time_stats`,
       },
       cfg,
     ).pipe(map((res) => (res as any).body));
@@ -325,8 +325,8 @@ export class GitlabApiService {
 
   private _issueApiLink(cfg: GitlabCfg, issueId: string): string {
     IssueLog.log(issueId);
-    const {project, projectIssueId } = getPartsFromGitlabIssueId(issueId);
-    return `${this._projectApiLink(cfg,project)}/issues/${projectIssueId}`;
+    const { project, projectIssueId } = getPartsFromGitlabIssueId(issueId);
+    return `${this._projectApiLink(cfg, project)}/issues/${projectIssueId}`;
   }
 
   private _projectApiLink(cfg: GitlabCfg, project: string): string {
@@ -347,6 +347,6 @@ export class GitlabApiService {
   }
 
   private _apiLink(cfg: GitlabCfg): string {
-    return this._projectApiLink(cfg.project)
+    return this._projectApiLink(cfg, cfg.project);
   }
 }


### PR DESCRIPTION
With this change the correct project URL for an issue is always used. This allows to set `..` as "user name/project" and use the global search in selfhosted gitlab instances. This will enable the user to find and use issues from different projects.