### PR TITLE
fix(lighthouse): increase font budget for Material Symbols upgrade

### DIFF
--- a/tools/lighthouse/.lighthouserc.json
+++ b/tools/lighthouse/.lighthouserc.json
@@ -23,7 +23,7 @@
         "interactive": ["warn", { "maxNumericValue": 5000 }],
         "resource-summary.script.count": ["warn", { "maxNumericValue": 140 }],
         "resource-summary.total.count": ["warn", { "maxNumericValue": 150 }],
-        "resource-summary.font.size": ["warn", { "maxNumericValue": 260000 }]
+        "resource-summary.font.size": ["warn", { "maxNumericValue": 520000 }]
       }
     },
     "upload": {

--- a/tools/lighthouse/budget.json
+++ b/tools/lighthouse/budget.json
@@ -16,7 +16,7 @@
       },
       {
         "resourceType": "font",
-        "budget": 260
+        "budget": 520
       },
       {
         "resourceType": "total",


### PR DESCRIPTION
The font budget was set to 260KB before the Material Icons to Material
Symbols upgrade. Material Symbols font is ~456KB, causing Lighthouse CI
to fail. Increase budget to 520KB to accommodate the larger font with
headroom for future updates.