### PR TITLE
docs(ci): Exclude docs/wiki/** from some actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,8 @@ name: Claude Code Review
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
+    paths-ignore:
+      - 'docs/wiki/**'
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master, release/*]
+    paths-ignore:
+      - 'docs/wiki/**'
+
   schedule:
     - cron: '0 3 * * 6'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,10 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/wiki/**'
 
 permissions:
   contents: read

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
       - main
+    paths-ignore:
+      - 'docs/wiki/**'
+
   workflow_dispatch:
     inputs: {}
   release:

--- a/.github/workflows/lint-and-test-pr.yml
+++ b/.github/workflows/lint-and-test-pr.yml
@@ -1,6 +1,9 @@
 name: 'Lint & Test PRs'
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/wiki/**'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Problem

The modified Actions in this PR showed up during the initial v0.1 PR and added noise to the process and added delays/waste to what would otherwise be a 10s workflow to copy markdown files.

## Solution: What PR does

Relevant actions had a path exclusion added. Some minor YML re-formatting needed to ensure validity.
