### PR TITLE
fix(ci): pin pr-preview-deploy workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,78 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    env:
+      UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
+      UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      # work around for npm installs from git+https://github.com/johannesjo/J2M.git
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+
+      - name: Install npm Packages
+        run: npm ci
+
+      - name: Generate environment file
+        run: npm run env
+
+      - name: Build Frontend for Web
+        run: npm run buildFrontend:prodWeb
+
+      - name: Deploy to Cloudflare Pages
+        id: cloudflare-deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist/browser --project-name=super-productivity-preview --branch=${{ github.head_ref }}
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v4
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- pr-preview-comment -->'
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- pr-preview-comment -->
+            ## Preview Deployment
+
+            | Status | URL |
+            |--------|-----|
+            | Deployed | ${{ steps.cloudflare-deploy.outputs.deployment-url }} |
+
+            **Branch:** `${{ github.head_ref }}`
+            **Commit:** ${{ github.sha }}
+
+            ---
+            <sub>Deployed with Cloudflare Pages</sub>


### PR DESCRIPTION
- Update peter-evans/find-comment to v4.0.0 (pinned SHA)
- Update peter-evans/create-or-update-comment to v5.0.0 (pinned SHA)

Fixes GitHub Actions failure where v4 tag pointed to unavailable commit. Uses commit SHAs instead of version tags for supply chain security.

## Problem

<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does

<!-- Describe your changes in detail -->
