### PR TITLE
test(sync): increase wait buffer for TODAY_TAG repair effect

### DIFF
--- a/e2e/tests/sync/supersync-lww-conflict.spec.ts
+++ b/e2e/tests/sync/supersync-lww-conflict.spec.ts
@@ -1469,10 +1469,12 @@ test.describe('@supersync SuperSync LWW Conflict Resolution', () => {
       await clientA.sync.syncAndWait();
       console.log('[TodayDeleteRace] Client A synced, LWW applied');
 
-      // Wait for post-sync cooldown (2s) to ensure repair effect runs if needed.
+      // Wait for post-sync cooldown (2s) plus buffer for repair effect to run.
       // The meta-reducer should add task to TODAY_TAG.taskIds immediately, but
       // the repair effect provides a safety net with a 2-second delay.
-      await clientA.page.waitForTimeout(2500);
+      // Extra buffer (1.5s) ensures effect has time to dispatch and render
+      // even under CI resource contention.
+      await clientA.page.waitForTimeout(3500);
       console.log('[TodayDeleteRace] Post-sync cooldown complete');
 
       // 8. CRITICAL ASSERTION: Task should appear in TODAY view on Client A


### PR DESCRIPTION
Increased post-sync cooldown wait from 2.5s to 3.5s in the "LWW: Recreated task with dueDay=today appears in TODAY view" test.

The previous 2.5s wait only provided 500ms buffer after the 2s POST_SYNC_COOLDOWN_MS period ended. Under CI resource contention, this wasn't always enough time for the repair effect to dispatch its action and for the UI to render.

The new 3.5s wait provides 1.5s buffer, which should be sufficient even under heavy CI load.

## Problem

<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does

<!-- Describe your changes in detail -->
