### PR TITLE
docs(ci): expand permissions for CI

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -3,7 +3,8 @@ name: PR Preview Deploy
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-
+    paths-ignore:
+      - 'docs/wiki/**'
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,5 +1,5 @@
 ---
-name: GitHub Wiki - Lint and (r)Sync
+name: Wiki Update
 
 'on':
   pull_request:
@@ -21,10 +21,12 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
+  actions: write
 
 jobs:
   lint:
-    name: Lint YAML and Markdown
+    name: Lint
     runs-on: ubuntu-latest
     env:
       GH_A9S: .github/annotations
@@ -65,7 +67,7 @@ jobs:
             scan "docs/wiki"
 
   sync:
-    name: Publish to GitHub Wiki
+    name: (r)Sync
     needs: lint
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This should minimize false warnings and allow for merges without
concern. Slight renaming of jobs should also help with review. Exclusion
of new GH Action for docs/wiki/** added too.
