### PR TITLE
Changed 'Due' to 'Schedule' in 'Add task' UI

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1253,7 +1253,7 @@
       "ADD_TASK_BAR": {
         "ADD_EXISTING_TASK": "Add existing task \"{{taskTitle}}\"",
         "CREATE_NEW_TAGS": "Create new tags",
-        "DUE_BUTTON": "Due",
+        "DUE_BUTTON": "Schedule",
         "ESTIMATE_BUTTON": "Estimate",
         "PLACEHOLDER_CREATE": "A task title #tag @16:00",
         "PLACEHOLDER_SEARCH": "Add existing task or issues...",


### PR DESCRIPTION
This change makes the function of the button accurate.   But because it's a change people will certainly notice, I made it a separate PR from other changes (if we need to discuss).

## Problem

SP currently doesn't support due dates.  It only supports scheduling dates.  As such, the affected button in the 'Add Tasks' UI was confusing and misleading.

## Solution: What PR does

Makes the button's purpose clear and accurate.