### PR TITLE
Increase ping interval and idle time in order to not waste CPU cycles.

### DIFF
--- a/electron/CONFIG.ts
+++ b/electron/CONFIG.ts
@@ -1,5 +1,5 @@
 export const CONFIG = {
   D_BUS_ID: 'com.super.productivity.service',
-  IDLE_PING_INTERVAL: 5000,
-  MIN_IDLE_TIME: 15000,
+  IDLE_PING_INTERVAL: 30000,
+  MIN_IDLE_TIME: 60000,
 };


### PR DESCRIPTION
If I understand the codebase correctly, this will do exactly as the title states, if not, please educate me :). Also is there a way to turn of idle checking when it is  also turned of in the settings?

## Problem

It should solve unneeded CPU cycles in the background.

## Solution: What PR does

Simply increase idle checking time, and the minimum amount to 60 seconds, as that's the minimum you can even configure in the app.
