### PR TITLE
docs(ci): prevent sync job from running on PR

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -21,8 +21,6 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: write
-  actions: write
 
 jobs:
   lint:
@@ -68,6 +66,7 @@ jobs:
 
   sync:
     name: (r)Sync
+    if: github.event_name == 'push'
     needs: lint
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
The workflow fails during the "sync" job on a pull request because of
repo-specific settings that are not set. These can be a security problem
to enable and are not needed for this workflow. Since accepting a PR
will cause a merge (and therefore a push by the author) this push will
then trigger the sync job with the correct authorization and will
therefore succeed as observed during my initial testing.

The only actions needed for the PR itself is linting.
