### PR TITLE
fix(backup): make migration and import errors explicit

### DIFF
--- a/src/app/op-log/persistence/archive-migration.service.ts
+++ b/src/app/op-log/persistence/archive-migration.service.ts
@@ -49,21 +49,41 @@ export class ArchiveMigrationService {
     }
 
     // Load archives from legacy database
-    const [legacyYoung, legacyOld] = await Promise.all([
-      this._legacyPfDb.loadArchiveYoung(),
-      this._legacyPfDb.loadArchiveOld(),
-    ]);
+    let legacyYoung: ArchiveModel;
+    let legacyOld: ArchiveModel;
+    try {
+      [legacyYoung, legacyOld] = await Promise.all([
+        this._legacyPfDb.loadArchiveYoung(),
+        this._legacyPfDb.loadArchiveOld(),
+      ]);
+    } catch (e) {
+      Log.err(
+        'ArchiveMigrationService: Failed to load archives from legacy database:',
+        e,
+      );
+      throw e;
+    }
 
     // Migrate archiveYoung if it has data and doesn't exist in SUP_OPS
     if (!hasYoung && this._hasArchiveData(legacyYoung)) {
-      Log.log('ArchiveMigrationService: Migrating archiveYoung to SUP_OPS');
-      await this._archiveStore.saveArchiveYoung(legacyYoung);
+      try {
+        Log.log('ArchiveMigrationService: Migrating archiveYoung to SUP_OPS');
+        await this._archiveStore.saveArchiveYoung(legacyYoung);
+      } catch (e) {
+        Log.err('ArchiveMigrationService: Failed to save archiveYoung to SUP_OPS:', e);
+        throw e;
+      }
     }
 
     // Migrate archiveOld if it has data and doesn't exist in SUP_OPS
     if (!hasOld && this._hasArchiveData(legacyOld)) {
-      Log.log('ArchiveMigrationService: Migrating archiveOld to SUP_OPS');
-      await this._archiveStore.saveArchiveOld(legacyOld);
+      try {
+        Log.log('ArchiveMigrationService: Migrating archiveOld to SUP_OPS');
+        await this._archiveStore.saveArchiveOld(legacyOld);
+      } catch (e) {
+        Log.err('ArchiveMigrationService: Failed to save archiveOld to SUP_OPS:', e);
+        throw e;
+      }
     }
 
     Log.log('ArchiveMigrationService: Archive migration complete');


### PR DESCRIPTION
## Summary

- Backup imports from different versions failed with a generic "Data validation failed" message — no way to tell what went wrong
- Now throws `DataValidationFailedError` so the snackbar shows actual validation paths (e.g. `.task.ids`, `.project.entities`)
- Adds verbose logging across the import/migration pipeline: format detection, validation details, repair step names
- Wraps archive migration and each data-repair step in error-aware logging so failures point to the exact step and entity

## Test plan

- [x] All 6893 unit tests pass (both TZ configs)
- [x] 5 new tests for error paths (backup service + archive migration)
- [x] Lint + prettier clean