### PR TITLE
fix(note-fullscreen-dialog): change max-height to ensure the note takes the full mobile screen

### DIFF
--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -75,7 +75,7 @@ body.isDarkTheme {
   @include media-queries.mq(xs, max) {
     max-width: 96vw !important;
     max-height: calc(
-      95vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)
+      100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)
     ) !important;
   }
 }


### PR DESCRIPTION
## Problem
The note fullscreen dialog leaves out some space at the bottom in mobile screens due to max-height being set to 95vh.
<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does
Change the max-height hardcoded value of 95vh to 100vh in `.cdk-overlay-pane.mat-mdc-dialog-panel`
<!-- Describe your changes in detail -->

### Before
<img width="353" height="706" alt="image" src="https://github.com/user-attachments/assets/c5d70b6c-4c78-4f0f-b0f3-babaf57b14bc" />


### After
<img width="378" height="708" alt="image" src="https://github.com/user-attachments/assets/8ac8077f-6733-4827-91a9-33a7961437e5" />
