### PR TITLE
fix(inline-markdown): update placeholder and modelCopy to use empty s…

### DIFF
--- a/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
@@ -547,7 +547,7 @@ describe('InlineMarkdownComponent', () => {
 
     it('should not emit if model is undefined', () => {
       // Arrange
-      component.model = undefined;
+      component.model = '';
       fixture.detectChanges();
 
       const wrapper1 = document.createElement('li');

--- a/src/app/ui/inline-markdown/inline-markdown.component.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.ts
@@ -45,7 +45,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
   readonly isShowControls = input<boolean>(false);
   readonly isShowChecklistToggle = input<boolean>(false);
   readonly isDefaultText = input<boolean>(false);
-  readonly placeholderTxt = input<string | undefined>(undefined);
+  readonly placeholderTxt = input<string>('');
 
   readonly changed = output<string>();
   readonly focused = output<Event>();
@@ -58,7 +58,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
   isHideOverflow = signal(false);
   isChecklistMode = signal(false);
   isShowEdit = signal(false);
-  modelCopy = signal<string | undefined>(undefined);
+  modelCopy = signal<string>('');
 
   isMarkdownFormattingEnabled = computed(() => {
     const tasks = this._globalConfigService.tasks();
@@ -82,9 +82,9 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
 
   // TODO: Skipped for migration because:
   //  Accessor inputs cannot be migrated as they are too complex.
-  @Input() set model(v: string | undefined) {
-    this._model = v;
-    this.modelCopy.set(v);
+  @Input() set model(v: string) {
+    this._model = v || '';
+    this.modelCopy.set(v || '');
 
     if (!this.isShowEdit()) {
       window.setTimeout(() => {


### PR DESCRIPTION
…tring instead of `undefined` string

## Problem
When I (user) clear task's description, I see placeholder `undefined`:
<img width="305" height="141" alt="image" src="https://github.com/user-attachments/assets/2d1c34a5-2b46-4b6b-ba42-8d2c034e459c" />

It's quite simple, I would even tell tiny bug. But I use the app every day and it's quite annoing to met it every time when I write the description.

## Solution: What PR does

PR fixes the bug described above :)