### PR TITLE
Update docker-compose image for Super Productivity app (johannesjo/super-productivity)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
 
   # Super Productivity app
   app:
-    image: super-productivity/super-productivity:latest
+    image: johannesjo/super-productivity:latest
     ports:
       - '8080:80'
     environment:


### PR DESCRIPTION
https://hub.docker.com/r/super-productivity/super-productivity doesn't exist. I assume it was renamed recently but the docker-compose wasn't upated.

## Problem

<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does

<!-- Describe your changes in detail -->
