### PR TITLE
Update README to require PUBLIC_URL for configuration

### DIFF
--- a/packages/super-sync-server/README.md
+++ b/packages/super-sync-server/README.md
@@ -78,7 +78,7 @@ All configuration is done via environment variables.
 | `PORT`         | `1900`                               | Server port                                                                    |
 | `DATABASE_URL` | -                                    | PostgreSQL connection string (e.g. `postgresql://user:pass@localhost:5432/db`) |
 | `JWT_SECRET`   | -                                    | **Required.** Secret for signing JWTs (min 32 chars)                           |
-| `PUBLIC_URL`   | -                                    | Public URL used for email links (e.g. `https://sync.example.com`)              |
+| `PUBLIC_URL`   | -                                    | **Required.** Public URL used for email links (e.g. `https://sync.example.com`)              |
 | `CORS_ORIGINS` | `https://app.super-productivity.com` | Allowed CORS origins                                                           |
 | `SMTP_HOST`    | -                                    | SMTP Server for emails                                                         |
 


### PR DESCRIPTION
## Problem

I tried to run this locally and I got an error when I didn't define this in the .env, but no error for not defining the SMTP server which definitely seems to be needed.

## Solution: What PR does

Mark PUBLIC_URL as required in the README.
