### PR TITLE
fix(ci): use macos-15 runner for iOS build to fix Xcode compatibility

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ios-app-store-release:
-    runs-on: macos-26
+    runs-on: macos-15
     env:
       UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}


### PR DESCRIPTION
macos-26 runner defaults to Xcode 26.2 (Swift 6.2.3) which is
incompatible with Capacitor 7. Capacitor 8 is required for Xcode 26
support. Switch to macos-15 as an interim fix until Capacitor 8
migration is completed.

https://claude.ai/code/session_01A9RKZFkpVxqWXTdoyH5sZA