### PR TITLE
Allow to drag subtasks on tags item in sidebar

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -581,8 +581,8 @@ export class MagicSideNavComponent implements OnInit, OnDestroy, AfterViewInit {
   private _handlePointerUp(event: MouseEvent | TouchEvent): void {
     const draggedTask = this._externalDragService.activeTask();
 
-    // exclude subtasks and recurring tasks
-    if (!draggedTask || draggedTask.parentId || draggedTask.repeatCfgId) {
+    // exclude recurring tasks
+    if (!draggedTask || draggedTask.repeatCfgId) {
       return;
     }
 
@@ -600,6 +600,12 @@ export class MagicSideNavComponent implements OnInit, OnDestroy, AfterViewInit {
 
     if (navItemElement.hasAttribute('data-project-id')) {
       // Task is dropped on a project
+
+      // Exclude subtasks dragged on projects
+      if (draggedTask.parentId) {
+        return;
+      }
+
       const projectId = navItemElement.getAttribute('data-project-id');
       Log.debug('Task dropped on Project', { draggedTask, projectId });
 


### PR DESCRIPTION
## Problem

Dragging subtasks over sidebar items currently has no effect.

## Solution: What PR does

This PR is the first step toward enabling a complete drag-and-drop experience.
Its scope is intentionally limited to one case: allowing subtasks to be dropped onto tag items.

Future PRs will cover the remaining scenarios:
- Subtasks dragged over project items (the user should be warned that this action will move the parent task and all of its subtasks to the new project)
- Recurring tasks (drag-and-drop behavior should match the existing task context menu actions)
