### PR TITLE
refactor: replace `any` types with proper type annotations across 6 files

### DIFF
--- a/src/app/features/config/store/global-config.effects.ts
+++ b/src/app/features/config/store/global-config.effects.ts
@@ -12,7 +12,10 @@ import { loadAllData } from '../../../root-store/meta/load-all-data.action';
 import { DEFAULT_GLOBAL_CONFIG } from '../default-global-config.const';
 import { KeyboardConfig } from '../keyboard-config.model';
 import { updateGlobalConfigSection } from './global-config.actions';
-import { selectLocalizationConfig } from './global-config.reducer';
+import {
+  selectConfigFeatureState,
+  selectLocalizationConfig,
+} from './global-config.reducer';
 import { AppFeaturesConfig, MiscConfig } from '../global-config.model';
 import { UserProfileService } from '../../user-profile/user-profile.service';
 
@@ -22,7 +25,7 @@ export class GlobalConfigEffects {
   private _languageService = inject(LanguageService);
   private _dateService = inject(DateService);
   private _snackService = inject(SnackService);
-  private _store = inject<Store<any>>(Store);
+  private _store = inject(Store);
   private _userProfileService = inject(UserProfileService);
 
   snackUpdate$ = createEffect(
@@ -96,7 +99,7 @@ export class GlobalConfigEffects {
     { dispatch: false },
   );
 
-  setStartOfNextDayDiffOnChange: any = createEffect(
+  setStartOfNextDayDiffOnChange = createEffect(
     () =>
       this._actions$.pipe(
         ofType(updateGlobalConfigSection),
@@ -106,13 +109,15 @@ export class GlobalConfigEffects {
             sectionCfg && typeof (sectionCfg as MiscConfig).startOfNextDay === 'number',
         ),
         tap(({ sectionKey, sectionCfg }) => {
-          this._dateService.setStartOfNextDayDiff((sectionCfg as any)['startOfNextDay']);
+          this._dateService.setStartOfNextDayDiff(
+            (sectionCfg as MiscConfig).startOfNextDay,
+          );
         }),
       ),
     { dispatch: false },
   );
 
-  setStartOfNextDayDiffOnLoad: any = createEffect(
+  setStartOfNextDayDiffOnLoad = createEffect(
     () =>
       this._actions$.pipe(
         ofType(loadAllData),
@@ -125,13 +130,13 @@ export class GlobalConfigEffects {
     { dispatch: false },
   );
 
-  notifyElectronAboutCfgChange: any =
+  notifyElectronAboutCfgChange =
     IS_ELECTRON &&
     createEffect(
       () =>
         this._actions$.pipe(
           ofType(updateGlobalConfigSection),
-          withLatestFrom(this._store.select('globalConfig')),
+          withLatestFrom(this._store.select(selectConfigFeatureState)),
           tap(([action, globalConfig]) => {
             // Send the entire settings object to electron for overlay initialization
             window.ea.sendSettingsUpdate(globalConfig);
@@ -140,7 +145,7 @@ export class GlobalConfigEffects {
       { dispatch: false },
     );
 
-  notifyElectronAboutCfgChangeInitially: any =
+  notifyElectronAboutCfgChangeInitially =
     IS_ELECTRON &&
     createEffect(
       () =>
@@ -156,7 +161,7 @@ export class GlobalConfigEffects {
     );
 
   // Handle user profiles being enabled/disabled
-  handleUserProfilesToggle: any = createEffect(
+  handleUserProfilesToggle = createEffect(
     () =>
       this._actions$.pipe(
         ofType(updateGlobalConfigSection),

--- a/src/app/features/tag/store/tag.effects.ts
+++ b/src/app/features/tag/store/tag.effects.ts
@@ -37,7 +37,7 @@ import { alertDialog, confirmDialog } from '../../../util/native-dialogs';
 @Injectable()
 export class TagEffects {
   private _actions$ = inject(LOCAL_ACTIONS);
-  private _store$ = inject<Store<any>>(Store);
+  private _store$ = inject(Store);
   private _snackService = inject(SnackService);
   private _tagService = inject(TagService);
   private _workContextService = inject(WorkContextService);
@@ -45,7 +45,7 @@ export class TagEffects {
   private _translateService = inject(TranslateService);
   private _plannerService = inject(PlannerService);
 
-  snackUpdateBaseSettings$: any = createEffect(
+  snackUpdateBaseSettings$ = createEffect(
     () =>
       this._actions$.pipe(
         ofType(updateTag),
@@ -61,7 +61,7 @@ export class TagEffects {
     { dispatch: false },
   );
 
-  snackPlanForToday$: any = createEffect(
+  snackPlanForToday$ = createEffect(
     () =>
       this._actions$.pipe(
         ofType(TaskSharedActions.planTasksForToday),
@@ -98,7 +98,7 @@ export class TagEffects {
     () =>
       this._actions$.pipe(
         ofType(deleteTag, deleteTags),
-        map((a: any) => (a.ids ? a.ids : [a.id])),
+        map((a) => ('ids' in a ? a.ids : [a.id])),
         tap(async (tagIdsToRemove: string[]) => {
           if (
             tagIdsToRemove.includes(
@@ -161,7 +161,7 @@ export class TagEffects {
    * - The current guards provide sufficient protection
    * - This is a "cleanup" effect that corrects inconsistencies, not a primary data flow
    */
-  preventParentAndSubTaskInTodayList$: any = createEffect(() =>
+  preventParentAndSubTaskInTodayList$ = createEffect(() =>
     this._store$.select(selectTodayTaskIds).pipe(
       filter((v) => v.length > 0),
       skipDuringSyncWindow(),

--- a/src/app/features/tasks/filter-done-tasks.pipe.spec.ts
+++ b/src/app/features/tasks/filter-done-tasks.pipe.spec.ts
@@ -20,7 +20,7 @@ describe('filterDoneTasks()', () => {
       true,
       false,
     );
-    expect(r).toEqual([{ isDone: false }]);
+    expect(r).toEqual([jasmine.objectContaining({ isDone: false })]);
   });
 
   it('should filter all but current', () => {
@@ -30,7 +30,7 @@ describe('filterDoneTasks()', () => {
       false,
       true,
     );
-    expect(r).toEqual([{ id: 'CURRENT' }]);
+    expect(r).toEqual([jasmine.objectContaining({ id: 'CURRENT' })]);
   });
 
   it('should not filter', () => {
@@ -40,6 +40,10 @@ describe('filterDoneTasks()', () => {
       false,
       false,
     );
-    expect(r).toEqual([{ isDone: true }, { isDone: false }, { isDone: true }]);
+    expect(r).toEqual([
+      jasmine.objectContaining({ isDone: true }),
+      jasmine.objectContaining({ isDone: false }),
+      jasmine.objectContaining({ isDone: true }),
+    ]);
   });
 });

--- a/src/app/features/tasks/filter-done-tasks.pipe.ts
+++ b/src/app/features/tasks/filter-done-tasks.pipe.ts
@@ -6,7 +6,7 @@ export const filterDoneTasks = (
   currentTaskId: string | null,
   isFilterDone: boolean,
   isFilterAll: boolean,
-): any => {
+): TaskWithSubTasks[] => {
   return isFilterDone
     ? tasks.filter((task) => !task.isDone)
     : isFilterAll
@@ -18,5 +18,12 @@ export const filterDoneTasks = (
 
 @Pipe({ name: 'filterDoneTasks' })
 export class FilterDoneTasksPipe implements PipeTransform {
-  transform: (value: any, ...args: any[]) => any = filterDoneTasks;
+  transform(
+    tasks: TaskWithSubTasks[],
+    currentTaskId: string | null,
+    isFilterDone: boolean,
+    isFilterAll: boolean,
+  ): TaskWithSubTasks[] {
+    return filterDoneTasks(tasks, currentTaskId, isFilterDone, isFilterAll);
+  }
 }

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -7,6 +7,7 @@ import { ShortSyntaxConfig } from '../config/global-config.model';
 import { isImageUrlSimple } from '../../util/is-image-url';
 import { TaskAttachment } from './task-attachment/task-attachment.model';
 import { nanoid } from 'nanoid';
+import type { Chrono, ParsingContext, ParsingResult } from 'chrono-node';
 type ProjectChanges = {
   title?: string;
   projectId?: string;
@@ -36,10 +37,10 @@ const CH_TAG = '#';
 const CH_DUE = '@';
 const ALL_SPECIAL = `(\\${CH_PRO}|\\${CH_TAG}|\\${CH_DUE})`;
 
-let customDateParserPromise: Promise<any> | null = null;
-let customDateParserCache: any = null;
+let customDateParserPromise: Promise<Chrono> | null = null;
+let customDateParserCache: Chrono | null = null;
 
-const loadCustomDateParser = (): Promise<any> => {
+const loadCustomDateParser = (): Promise<Chrono> => {
   if (customDateParserCache) {
     return Promise.resolve(customDateParserCache);
   }
@@ -47,7 +48,7 @@ const loadCustomDateParser = (): Promise<any> => {
     customDateParserPromise = import('chrono-node').then(({ casual }) => {
       const parser = casual.clone();
       parser.refiners.push({
-        refine: (context: unknown, results: any[]) => {
+        refine: (context: ParsingContext, results: ParsingResult[]) => {
           results.forEach((result) => {
             const { refDate, text, start } = result;
             const regex = / [5-9][0-9]$/;
@@ -125,7 +126,7 @@ export const shortSyntax = async (
   if (!task.title) {
     return;
   }
-  if (typeof (task.title as any) !== 'string') {
+  if (typeof task.title !== 'string') {
     throw new Error('No str');
   }
 

--- a/src/app/op-log/validation/is-related-model-data-valid.ts
+++ b/src/app/op-log/validation/is-related-model-data-valid.ts
@@ -98,7 +98,7 @@ export const isRelatedModelDataValid = (d: AppDataComplete): boolean => {
 
 export const getLastValidityError = (): string | undefined => lastValidityError;
 
-const _validityError = (errTxt: string, additionalInfo?: any): void => {
+const _validityError = (errTxt: string, additionalInfo?: unknown): void => {
   if (additionalInfo) {
     OpLog.log('Validity Error Info: ', additionalInfo);
     if (environment.production) {

--- a/src/app/ui/marked-options-factory.ts
+++ b/src/app/ui/marked-options-factory.ts
@@ -1,5 +1,5 @@
 import { MarkedOptions, MarkedRenderer } from 'ngx-markdown';
-import { Hooks } from 'marked';
+import { Hooks, Token } from 'marked';
 
 /**
  * Parses image sizing syntax from title attribute.
@@ -64,7 +64,7 @@ export const markedOptionsFactory = (): MarkedOptions => {
     text: string;
     task: boolean;
     checked?: boolean;
-    tokens: any[];
+    tokens: Token[];
   }) {
     // In marked v17, task list items need to manually prepend the checkbox
     // Use parse() to handle both block tokens (paragraph in loose lists) and inline tokens
@@ -94,7 +94,7 @@ export const markedOptionsFactory = (): MarkedOptions => {
   }: {
     href: string;
     title?: string | null;
-    tokens: any[];
+    tokens: Token[];
   }) {
     const text = tokens ? this.parser.parseInline(tokens) : '';
     return `<a target="_blank" href="${href}" title="${title || ''}">${text}</a>`;
@@ -127,7 +127,7 @@ export const markedOptionsFactory = (): MarkedOptions => {
   };
 
   // In marked v17, paragraph renderer receives tokens that need to be parsed
-  renderer.paragraph = function ({ tokens }: { tokens: any[] }) {
+  renderer.paragraph = function ({ tokens }: { tokens: Token[] }) {
     const text = tokens ? this.parser.parseInline(tokens) : '';
     const split = text.split('\n');
     return split.reduce((acc, p, i) => {


### PR DESCRIPTION
- is-related-model-data-valid.ts: `any` → `unknown` for logging parameter
- global-config.effects.ts: remove 7 `any` annotations, use typed selectors
  and `MiscConfig` cast instead of `as any` property access
- tag.effects.ts: remove 5 `any` annotations, use `in` operator for
  union type narrowing on deleteTag/deleteTags action
- filter-done-tasks.pipe.ts: add `TaskWithSubTasks[]` return type, replace
  untyped `transform` assignment with explicit method signature
- short-syntax.ts: use chrono-node's `Chrono`, `ParsingContext`, and
  `ParsingResult` types instead of `any`, remove unnecessary `as any` cast
- marked-options-factory.ts: use marked's `Token` type for renderer tokens

https://claude.ai/code/session_01XNDmLyMKgwQMnAZurTniir