### PR TITLE
fix: prevent window controls overlap in header #6365

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.scss
+++ b/src/app/core-ui/main-header/main-header.component.scss
@@ -30,6 +30,13 @@
   // Fallback calc ensures 140px when env vars unavailable
   // Only on non-Mac: macOS window controls are on the left, no right padding needed
   padding-right: calc(100vw - env(titlebar-area-width, calc(100vw - 140px)));
+
+  // Prevent header content from overflowing into the window controls area
+  // when the window is resized to a narrow width (fixes #6365).
+  // Uses clip instead of hidden to avoid affecting vertical overflow (dropdowns).
+  .wrapper {
+    overflow-x: clip;
+  }
 }
 
 :host-context(.isMac.isElectron),
@@ -131,6 +138,7 @@ button.isActive2 {
   display: flex;
   align-items: center;
   gap: var(--header-nav-button-gap);
+  min-width: 0;
 
   :host-context([dir='rtl']) & {
     margin-left: 0;


### PR DESCRIPTION
## Problem

When the window is resized to a narrow width on Windows (Electron with custom title bar), the header flex items overflow into the area reserved for native window controls (minimize/maximize/close), causing visual overlap.

## Solution

Two targeted CSS changes in `main-header.component.scss`:

1. **`overflow-x: clip` on `.wrapper`** within the non-Mac Electron context — clips flex items that overflow the wrapper's boundary, preventing them from bleeding into the `padding-right` area reserved for window controls. Uses `clip` instead of `hidden` to avoid affecting vertical overflow (mobile dropdown menus).

2. **`min-width: 0` on `.action-nav-right`** — allows the flex layout to shrink the navigation section below its intrinsic content width, giving the page title more room to truncate gracefully before the clip takes effect.

Closes #6365