### PR TITLE
Consolidate Google Play release workflow into build-android

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -123,5 +123,5 @@ jobs:
           packageName: com.superproductivity.superproductivity
           releaseFiles: android/app/build/outputs/apk/play/release/*.apk
           track: internal
-          status: draft
+          status: completed
           inAppUpdatePriority: 2


### PR DESCRIPTION
## Problem

The Google Play release automation was split across two separate workflows:
- `auto-publish-google-play-on-release.yml` - triggered on GitHub releases
- `build-android.yml` - builds and publishes to internal track

This separation created unnecessary complexity and potential timing issues between the internal release and production promotion steps.

## Solution: What PR does

- Removes the dedicated `auto-publish-google-play-on-release.yml` workflow
- Consolidates the production promotion logic into `build-android.yml` 
- Changes internal track release status from `draft` to `completed`
- Adds conditional promotion step that runs only for version tags (e.g., `v1.0.0`) and excludes pre-releases (tags with `-` suffix)
- Streamlines the release process by handling both internal and production releases in a single workflow

This ensures that when a version tag is pushed, the build is completed and automatically promoted to production in the same workflow run, reducing complexity and improving reliability.

https://claude.ai/code/session_01N8ddANh4ejMn3kYLajkL5V