### PR TITLE
fix(magic-side-nav): restore vertical scrolling by removing drag region

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.scss
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.scss
@@ -80,7 +80,7 @@
   z-index: 1002;
   overflow-y: auto;
   overflow-x: hidden;
-  -webkit-app-region: drag;
+  -webkit-app-region: no-drag;
 
   // Slight elevation and clear background for overlay/mobile mode is defined in the mobile block below
 


### PR DESCRIPTION
## Problem
The vertical scrollbar in the left sidebar cannot be interacted with using the mouse pointer. When attempting to click and drag the scrollbar, the application window resizes (shrinks) and moves along with the mouse cursor instead of scrolling the sidebar content. Currently, the only way to scroll this panel is by using the mouse wheel.
The `-webkit-app-region: drag` on the `.nav-sidebar` causes such an issue in Electron.

This seems to occur only when the custom title bar setting is on.

Fixes #6330
<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does
Change `-webkit-app-region: drag` to `-webkit-app-region: no-drag`

<!-- Describe your changes in detail -->
