### PR TITLE
fix: allow bare hostnames in Jira host URL validation

### DIFF
--- a/src/app/features/issue/providers/jira/jira-cfg-form.const.spec.ts
+++ b/src/app/features/issue/providers/jira/jira-cfg-form.const.spec.ts
@@ -1,0 +1,64 @@
+import { JIRA_CONFIG_FORM_SECTION } from './jira-cfg-form.const';
+
+describe('Jira config form URL pattern', () => {
+  let urlPattern: RegExp;
+
+  beforeAll(() => {
+    const hostField = JIRA_CONFIG_FORM_SECTION.items!.find((item) => item.key === 'host');
+    const pattern = hostField?.templateOptions?.pattern as RegExp;
+    expect(pattern).toBeDefined();
+    urlPattern = pattern;
+  });
+
+  describe('should accept valid Jira host URLs', () => {
+    const validUrls = [
+      // Bare hostnames (#4731)
+      'jira',
+      'http://jira',
+      'https://jira',
+      'http://jira:1234',
+      'http://jira:8080/rest',
+      'http://server-name:8080',
+      'bamboo',
+
+      // Localhost
+      'localhost',
+      'http://localhost',
+      'https://localhost',
+      'http://localhost:8080',
+      'http://localhost:8080/some/path',
+
+      // FQDN
+      'jira.example.com',
+      'http://jira.example.com',
+      'https://jira.example.com',
+      'https://jira.example.com:443',
+      'https://jira.example.com/rest/api',
+      'https://jira.example.com:8080/rest/api',
+
+      // Subdomains
+      'https://my.company.atlassian.net',
+      'https://deep.sub.domain.example.com',
+
+      // IP-like patterns
+      'http://192.168.1.1',
+      'http://192.168.1.1:8080',
+    ];
+
+    validUrls.forEach((url) => {
+      it(`should accept: "${url}"`, () => {
+        expect(urlPattern.test(url)).toBe(true);
+      });
+    });
+  });
+
+  describe('should reject invalid Jira host URLs', () => {
+    const invalidUrls = ['', 'http://', 'http:// spaces', 'http://jira server'];
+
+    invalidUrls.forEach((url) => {
+      it(`should reject: "${url}"`, () => {
+        expect(urlPattern.test(url)).toBe(false);
+      });
+    });
+  });
+});

--- a/src/app/features/issue/providers/jira/jira-cfg-form.const.ts
+++ b/src/app/features/issue/providers/jira/jira-cfg-form.const.ts
@@ -78,8 +78,7 @@ export const JIRA_CONFIG_FORM_SECTION: ConfigFormSection<IssueProviderJira> = {
       templateOptions: {
         type: 'url',
 
-        pattern:
-          /^(http(s)?:\/\/)?(localhost|[\w.\-]+(?:\.[\w\.\-]+)+)(:\d+)?(\/[^\s]*)?$/i,
+        pattern: /^(http(s)?:\/\/)?(localhost|[\w\-]+(?:\.[\w\-]+)*)(:\d+)?(\/[^\s]*)?$/i,
         required: true,
         label: T.F.JIRA.FORM_CRED.HOST,
       },


### PR DESCRIPTION
## Summary

Fixes #4731.

The Jira host URL validation pattern requires at least one dot-separated segment after the hostname (e.g., `.com`, `.org`), which rejects valid internal hostnames like `http://jira:1234` or `http://bamboo:8080`.

**Two changes to the regex:**

1. Change the quantifier on the dot-separated segment group from `+` (one or more) to `*` (zero or more), allowing bare hostnames while still accepting all previously valid URLs.

2. Remove `.` from hostname label character classes (`[\w.\-]+` → `[\w\-]+`) to eliminate overlapping repetition that could cause exponential backtracking on adversarial input. Dots now only appear as the explicit separator `\.` between labels.

### Before
| URL | Result |
|-----|--------|
| `http://jira:1234` | Rejected |
| `http://server-name:8080` | Rejected |
| `https://company.atlassian.net` | Accepted |

### After
| URL | Result |
|-----|--------|
| `http://jira:1234` | Accepted |
| `http://server-name:8080` | Accepted |
| `https://company.atlassian.net` | Accepted |

## Test plan
- [x] Verified regex against test matrix of bare hostnames, dotted hostnames, and invalid inputs
- [x] Added 26 unit tests for the URL pattern (`jira-cfg-form.const.spec.ts`)
- [x] Full test suite passes (7,303 tests, both TZ variants)
- [x] Production build succeeds
- [x] Lint passes