### PR TITLE
fix: trello can't be used (#6331)

### DIFF
--- a/src/app/features/issue/providers/trello/trello-api.service.spec.ts
+++ b/src/app/features/issue/providers/trello/trello-api.service.spec.ts
@@ -205,17 +205,15 @@ describe('TrelloApiService', () => {
   });
 
   describe('HTTP parameters', () => {
-    // it('should include api key in query parameters', (done) => {
-    //   service.testConnection$(mockCfg).subscribe(() => {
-    //     done();
-    //   });
+    it('should include api key in query parameters', (done) => {
+      service.testConnection$(mockCfg).subscribe(() => {
+        done();
+      });
 
-    //   const req = httpMock.expectOne((request) => request.url.includes('/boards/'));
-    //   expect(req.request.urlWithParams).toContain('key=test-api-key');
-    //   expect(req.request.headers.has('Authorization')).toBe(true);
-    //   expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
-    //   req.flush({ id: mockCfg.boardId });
-    // });
+      const req = httpMock.expectOne((request) => request.url.includes('/boards/'));
+      expect(req.request.urlWithParams).toContain('key=test-api-key');
+      req.flush({ id: mockCfg.boardId });
+    });
 
     it('should properly encode search terms', (done) => {
       service.issuePicker$('test & special', mockCfg).subscribe(() => {
@@ -225,7 +223,6 @@ describe('TrelloApiService', () => {
       const req = httpMock.expectOne((request) => request.url.includes('/search'));
       expect(req.request.urlWithParams).toContain('query=test');
       expect(req.request.urlWithParams).toContain('%26');
-      // expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
       req.flush({ cards: [] });
     });
   });

--- a/src/app/features/issue/providers/trello/trello-api.service.ts
+++ b/src/app/features/issue/providers/trello/trello-api.service.ts
@@ -1,10 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import {
-  HttpClient,
-  HttpErrorResponse,
-  HttpParams,
-  // HttpHeaders,
-} from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { TrelloCfg } from './trello.model';
@@ -168,7 +163,6 @@ export class TrelloApiService {
     );
   }
 
-  // todo: investigate this
   private _request$<T>(
     path: string,
     cfg: TrelloCfg,
@@ -176,11 +170,9 @@ export class TrelloApiService {
   ): Observable<T> {
     this._checkSettings(cfg);
     const httpParams = this._createParams(cfg, params);
-    // const headers = new HttpHeaders().set('Authorization', `Bearer ${cfg.token}`);
     return this._http
       .get<T>(`${BASE_URL}${path}`, {
         params: httpParams,
-        // headers,
       })
       .pipe(catchError((err) => this._handleError$(err)));
   }


### PR DESCRIPTION
## Problem
Trello can't be connected due to potential changes in API (Thanks @dukeofharen for pinpointing the exact issue!)

## Solution: 

Comments out the header. Tested with issue search, boards querying with a valid Trello ID and it seems working from my side. Fixes #6331.
