### PR TITLE
fix: handle async voice loading in voice reminder settings (#6437)

### DIFF
--- a/src/app/features/config/form-cfgs/voice-reminder-form.const.ts
+++ b/src/app/features/config/form-cfgs/voice-reminder-form.const.ts
@@ -65,16 +65,24 @@ export const VOICE_REMINDER_FORM: ConfigFormSection<DominaModeConfig> = {
       },
       hooks: {
         onInit: (field) => {
-          let voices: SpeechSynthesisVoice[] = getAvailableVoices() || [];
-          voices = getAvailableVoices();
-          //Log.log(voices);
+          const populateVoices = (): void => {
+            const voices = getAvailableVoices();
+            if (field.templateOptions) {
+              field.templateOptions.options = voices.map((voice) => ({
+                label: voice.name,
+                value: voice.voiceURI,
+              }));
+            }
+          };
 
-          if (field.templateOptions) {
-            field.templateOptions.options = voices.map((voiceName) => ({
-              label: voiceName.name,
-              value: voiceName.voiceURI,
-            }));
-          }
+          populateVoices();
+
+          // On some platforms (e.g. Linux/Chromium), voices load asynchronously
+          // and getVoices() returns [] on first call. Listen for voiceschanged
+          // to populate the dropdown when voices become available.
+          window.speechSynthesis?.addEventListener('voiceschanged', populateVoices, {
+            once: true,
+          });
         },
       },
     },


### PR DESCRIPTION
## Summary

On some platforms (e.g. Linux with Chromium/Electron), `speechSynthesis.getVoices()` returns an empty array on the first call because voices load asynchronously. This causes the "Select a voice" dropdown in Voice Reminder settings to show no options.

**Fix:** Listen for the `voiceschanged` event to populate the voice dropdown when voices become available. The initial synchronous call is kept for platforms where voices are available immediately.

Fixes #6437

## Changes

- `voice-reminder-form.const.ts`: Refactored the `onInit` hook to extract a `populateVoices` helper that is called both synchronously and via the `voiceschanged` event listener

## Test plan

- [x] All 7,348 existing tests pass (both Europe/Berlin and America/Los_Angeles timezones)
- [x] Lint passes (TypeScript + SCSS)
- [x] Manual test on Linux: open Settings > Voice Reminder, verify voice dropdown populates