### PR TITLE
feat: allow installation to custom location on windows

### DIFF
--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -31,6 +31,9 @@ win:
     - github
 nsis:
   artifactName: ${productName} Setup-${arch}.${ext}
+  # allow to install to custom location
+  oneClick: false
+  allowToChangeInstallationDirectory: true
 portable:
   artifactName: ${name}-${arch}.${ext}
 appx:


### PR DESCRIPTION
## Problem

Some users (including myself) might have restrictions on PC, allowing to start apps only from specific directories. User directory, which is used for installation by default, is usually not one of them. Related issue #5651

<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does

Change electron builder configuration to allow to install app to custom location

<!-- Describe your changes in detail -->
