### PR TITLE
Fix safe area insets for side navigation on notched devices

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.scss
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.scss
@@ -31,7 +31,7 @@
   align-items: center;
   justify-content: center;
   position: fixed;
-  top: 8px;
+  top: calc(8px + var(--safe-area-top));
   left: 8px;
   background: var(--sidenav-bg);
   border: 1px solid var(--sidenav-border-color);
@@ -200,7 +200,7 @@
   justify-content: flex-start;
 
   @media (max-width: 600px) {
-    padding-top: 0;
+    padding-top: var(--safe-area-top);
   }
 
   :host-context(.isMac.isElectron) & {


### PR DESCRIPTION
## Problem

The magic side navigation component does not account for safe area insets on devices with notches or other screen cutouts (e.g., iPhone with notch, devices with status bars). This causes the navigation to overlap with system UI elements on mobile devices.

## Solution: What PR does

Updated the magic side nav component to respect safe area insets:

1. **Fixed top positioning**: Changed the toggle button's `top` position from a fixed `8px` to `calc(8px + var(--safe-area-top))` to account for the safe area inset at the top of the screen
2. **Fixed mobile padding**: Changed the mobile view's `padding-top` from `0` to `var(--safe-area-top)` to ensure proper spacing below notches or status bars on small screens

These changes ensure the side navigation component properly adapts to devices with notches, status bars, or other screen cutouts by utilizing CSS safe area inset variables.

https://claude.ai/code/session_017LJQGLP44TTkBTyUHa8X6E