### PR TITLE
Refactor status bar initialization to support both iOS and Android

### DIFF
--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -284,11 +284,11 @@ export class GlobalThemeService {
     // Add native mobile platform classes
     if (this._platformService.isNative) {
       this.document.body.classList.add(BodyClass.isNativeMobile);
+      this._initMobileStatusBar();
 
       if (this._platformService.isIOS()) {
         this.document.body.classList.add(BodyClass.isIOS);
         this._initIOSKeyboardHandling();
-        this._initIOSStatusBar();
 
         // Add iPad-specific class for tablet optimizations
         if (this._platformService.isIPad()) {
@@ -504,16 +504,22 @@ export class GlobalThemeService {
   }
 
   /**
-   * Initialize iOS status bar styling.
-   * Syncs status bar style with app dark/light mode.
+   * Initialize mobile status bar styling.
+   * Syncs status bar style with app dark/light mode on both iOS and Android.
    */
-  private _initIOSStatusBar(): void {
-    // Set initial status bar style based on current theme
+  private _initMobileStatusBar(): void {
     effect(() => {
       const isDark = this.isDarkTheme();
       StatusBar.setStyle({ style: isDark ? Style.Dark : Style.Light }).catch((err) => {
-        Log.warn('Failed to set iOS status bar style', err);
+        Log.warn('Failed to set status bar style', err);
       });
+      if (this._platformService.isAndroid()) {
+        StatusBar.setBackgroundColor({ color: isDark ? '#131314' : '#ffffff' }).catch(
+          (err) => {
+            Log.warn('Failed to set status bar background color', err);
+          },
+        );
+      }
     });
   }
 }


### PR DESCRIPTION
## Problem

The status bar styling was only being initialized for iOS devices, leaving Android devices without proper status bar background color handling. This resulted in inconsistent visual appearance across different mobile platforms.

## Solution: What PR does

- Renamed `_initIOSStatusBar()` to `_initMobileStatusBar()` to reflect that it now handles both iOS and Android platforms
- Moved the status bar initialization call to execute for all native mobile platforms instead of only iOS
- Added Android-specific status bar background color handling that sets the background to dark (`#131314`) or light (`#ffffff`) based on the current theme
- Updated error logging messages to be platform-agnostic
- Ensured the status bar style syncs with the app's dark/light mode on both platforms through the existing reactive effect

This change ensures consistent status bar theming across iOS and Android devices while maintaining the existing iOS keyboard handling logic.

https://claude.ai/code/session_01Wp9Wp9B85ajP7vqc1pEUqC