### PR TITLE
fix(mobile): prevent CDK overlays from rendering behind status bar

### DIFF
--- a/src/app/features/tasks/task-context-menu/task-context-menu-touch-fix.scss
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-touch-fix.scss
@@ -82,13 +82,15 @@
   }
 }
 
-// Ensure the overlay container respects screen boundaries
+// Ensure the overlay container respects screen boundaries and safe areas
 .cdk-overlay-container {
   @media (hover: none) and (pointer: coarse) {
     .cdk-overlay-connected-position-bounding-box {
-      // Prevent menus from going off-screen
+      // Prevent menus from going off-screen, accounting for status bar and home indicator
       max-width: calc(100vw - 32px) !important;
-      max-height: calc(100vh - 32px) !important;
+      max-height: calc(
+        100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 32px
+      ) !important;
       margin: 0 16px !important;
     }
   }

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -61,6 +61,18 @@ body.isDarkTheme {
   z-index: 1000;
 }
 
+// Prevent overlays from rendering behind the status bar on native mobile.
+// With overlaysWebView (iOS) and edge-to-edge (Android), the CDK overlay
+// container spans the full viewport including the status bar area.
+// Adding safe area padding to the global overlay wrapper ensures dialogs
+// and other globally-positioned overlays center within the safe area.
+body.isNativeMobile {
+  .cdk-global-overlay-wrapper {
+    padding: var(--safe-area-top) var(--safe-area-right) var(--safe-area-bottom)
+      var(--safe-area-left);
+  }
+}
+
 // DIALOGS
 // ----------
 .mat-mdc-dialog-title.mat-mdc-dialog-title,


### PR DESCRIPTION
Add safe area padding to .cdk-global-overlay-wrapper so dialogs and other globally-positioned overlays center within the safe area instead of the full viewport. Also update the connected position bounding box max-height to account for safe area insets on touch devices.

https://claude.ai/code/session_014JAVLFhyMrZvtvy4WvUWVv

## Problem

<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does

<!-- Describe your changes in detail -->
