### PR TITLE
feat(mobile): handle back button navigation of bottom sheet (project notes)

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -94,4 +94,6 @@ export const HANDLED_ERROR_PROP_STR = 'HANDLED_ERROR_PROP';
 export const HISTORY_STATE = {
   MOBILE_NAVIGATION: 'mobileSideNav',
   TASK_DETAIL_PANEL: 'taskDetailPanel',
+  DIALOG_FULLSCREEN_MARKDOWN: 'dialogFullscreenMarkdown',
+  NOTES: 'notes',
 };

--- a/src/app/features/right-panel/right-panel.component.ts
+++ b/src/app/features/right-panel/right-panel.component.ts
@@ -220,7 +220,7 @@ export class RightPanelComponent implements AfterViewInit, OnDestroy {
 
           this._bottomSheetRef = this._bottomSheet.open(BottomPanelContainerComponent, {
             hasBackdrop: true,
-            closeOnNavigation: true,
+            closeOnNavigation: false,
             panelClass: 'bottom-panel-sheet',
             // Let CSS handle positioning and height
           });

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
@@ -31,6 +31,8 @@ import * as MarkdownToolbar from '../inline-markdown/markdown-toolbar.util';
 import { ClipboardImageService } from '../../core/clipboard-image/clipboard-image.service';
 import { TaskAttachmentService } from '../../features/tasks/task-attachment/task-attachment.service';
 import { ClipboardPasteHandlerService } from '../../core/clipboard-image/clipboard-paste-handler.service';
+import { HISTORY_STATE } from 'src/app/app.constants';
+import { IS_MOBILE } from 'src/app/util/is-mobile';
 
 type ViewMode = 'SPLIT' | 'PARSED' | 'TEXT_ONLY';
 const ALL_VIEW_MODES: ['SPLIT', 'PARSED', 'TEXT_ONLY'] = ['SPLIT', 'PARSED', 'TEXT_ONLY'];
@@ -130,6 +132,16 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
   }
 
   async ngOnInit(): Promise<void> {
+    // Push a fake state for our dialog in the history when it's displayed in fullscreen
+    if (IS_MOBILE) {
+      if (!window.history.state?.[HISTORY_STATE.DIALOG_FULLSCREEN_MARKDOWN]) {
+        window.history.pushState(
+          { [HISTORY_STATE.DIALOG_FULLSCREEN_MARKDOWN]: true },
+          '',
+        );
+      }
+    }
+
     // Update resolved content asynchronously for image processing
     if (this.data.content) {
       await this._updateResolvedContent(this.data.content);


### PR DESCRIPTION
## Problem
When the user opens a project note from the bottom sheet (project notes) on mobile and presses back navigation to close the note, the app minimizes. This can cause frustration to some, where they expect the project note to close and not the app. The same applies for closing the bottom sheet via back button.
<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does
Through the use of the browser history stack, the back navigation can be handled of a fullscreen dialog and the bottom sheet as well.
- Change the `closeOnNavigation` property value from `true` to `false` in `right-panel.component.ts`, to ensure that the bottom sheet doesn't close when navigating back from a project note (`dialog-fullscreen-markdown.component.ts`).
- Modify `dialog-fullscreen-markdown.component.ts`, and `notes.component.ts`, to handle the browser history stack accordingly.


### Before
[Click here to watch](https://gofile.io/d/wh7Cnk)

### After
<!-- Describe your changes in detail -->
[Click here to watch](https://gofile.io/d/ISfKfJ)
