### PR TITLE
fix: clear markdown preview when switching to task without notes

### DIFF
--- a/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
@@ -580,8 +580,8 @@ describe('InlineMarkdownComponent', () => {
       resolveDelayed('Task A notes');
       await Promise.resolve();
 
-      // Assert: resolvedModel should remain undefined (not stale Task A content)
-      expect(component.resolvedModel()).toBeUndefined();
+      // Assert: resolvedModel should remain empty (not stale Task A content)
+      expect(component.resolvedModel()).toBe('');
     });
   });
 

--- a/src/app/ui/inline-markdown/inline-markdown.component.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.ts
@@ -120,7 +120,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
     if (v) {
       this._updateResolvedModel(v);
     } else {
-      this.resolvedModel.set(undefined);
+      this.resolvedModel.set('');
     }
 
     if (!this.isShowEdit()) {
@@ -423,7 +423,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
 
   private async _updateResolvedModel(content: string | undefined): Promise<void> {
     if (!content) {
-      this.resolvedModel.set(content);
+      this.resolvedModel.set('');
       this._cd.markForCheck();
       return;
     }


### PR DESCRIPTION
## Summary

Fixes #6490

When switching from a task with notes (item A) to one without notes (item B) in the Boards/Kanban view, the sidebar continued displaying item A's markdown content instead of clearing it.

**Root cause:** The `inline-markdown` component set `resolvedModel` to `undefined` when the model was empty. The ngx-markdown `MarkdownComponent.loadContent()` checks `if (this.data != null)` using loose equality — since `undefined != null` is `false`, `handleData()` was never called, leaving the previously rendered HTML in the DOM.

**Fix:** Set `resolvedModel` to empty string `''` instead of `undefined`. Since `'' != null` is `true`, ngx-markdown properly calls `handleData('')` → `render('')`, which clears the rendered content.

## Changes

- `inline-markdown.component.ts`: Use `''` instead of `undefined` when clearing `resolvedModel` (2 locations)
- `inline-markdown.component.spec.ts`: Update existing race condition test to expect `''` instead of `undefined`

## Test plan

- [x] All 7345 existing tests pass (Europe/Berlin TZ)
- [x] All 7333 existing tests pass (America/Los_Angeles TZ)
- [x] Linting passes
- [x] Manual test: Open Boards → Kanban, click task with notes, then click task without notes — sidebar should clear