### PR TITLE
Fix project syntax parsing to reject spaces after + delimiter

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1067,6 +1067,42 @@ describe('shortSyntax', () => {
       expect(r).toEqual(undefined);
     });
 
+    it('should not parse when there is a space after +', async () => {
+      const t = {
+        ...TASK,
+        title: 'Fun title + ProjectEasyShort',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual(undefined);
+    });
+
+    it('should not parse when there is a space after + with other syntax', async () => {
+      const t = {
+        ...TASK,
+        title: 'Fun title + ProjectEasyShort 10m',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: undefined,
+        attachments: [],
+        taskChanges: {
+          title: 'Fun title + ProjectEasyShort',
+          timeEstimate: 600000,
+        },
+      });
+    });
+
+    it('should not parse when + is followed by multiple spaces', async () => {
+      const t = {
+        ...TASK,
+        title: 'Fun title +  ProjectEasyShort',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual(undefined);
+    });
+
     it('should prefer shortest prefix full project title match', async () => {
       const t = {
         ...TASK,

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -89,7 +89,7 @@ const loadCustomDateParser = (): Promise<Chrono> => {
 // previous version by not immediately terminating upon encountering a short
 // syntax delimiting character and looks ahead to consider usage context
 const SHORT_SYNTAX_PROJECT_REG_EX = new RegExp(
-  `\\${CH_PRO}((?:(?!\\s+(?:\\${CH_TAG}|\\${CH_DUE}|t?\\d+[mh]\\b)).)+)`,
+  `\\${CH_PRO}(?!\\s)((?:(?!\\s+(?:\\${CH_TAG}|\\${CH_DUE}|t?\\d+[mh]\\b)).)+)`,
   'i',
 );
 const SHORT_SYNTAX_TAGS_REG_EX = new RegExp(`\\${CH_TAG}[^${ALL_SPECIAL}|\\s]+`, 'gi');


### PR DESCRIPTION
## Problem

The short syntax parser was incorrectly matching project names when a space immediately followed the `+` delimiter (e.g., `+ ProjectName`). This caused unintended parsing behavior where spaces after the delimiter should invalidate the project syntax match.

## Solution: What PR does

Updated the `SHORT_SYNTAX_PROJECT_REG_EX` regular expression to include a negative lookahead `(?!\s)` after the `+` delimiter. This ensures that the project syntax is only recognized when the `+` is immediately followed by a non-whitespace character, rejecting cases where there are one or more spaces between the delimiter and the project name.

**Changes:**
- Modified regex pattern in `src/app/features/tasks/short-syntax.ts` to add negative lookahead for whitespace after `+`
- Added three test cases in `src/app/features/tasks/short-syntax.spec.ts` to verify:
  - Single space after `+` is rejected
  - Single space after `+` with additional syntax (time estimate) is handled correctly
  - Multiple spaces after `+` are rejected

The fix ensures stricter parsing rules that align with the intended short syntax behavior.

https://claude.ai/code/session_01VdA4njY8Jax9FdUPbpzLGX