### PR TITLE
fix: parse time estimation short syntax for bulk-imported subtasks

### DIFF
--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -453,7 +453,7 @@ const parseScheduledDate = async (
   return {};
 };
 
-const parseTimeSpentChanges = (task: Partial<TaskCopy>): Partial<Task> => {
+export const parseTimeSpentChanges = (task: Partial<TaskCopy>): Partial<Task> => {
   if (!task.title) {
     return {};
   }


### PR DESCRIPTION
## Summary

When tasks are bulk-imported via markdown paste (e.g., pasting a markdown checklist), subtasks bypass the short syntax NgRx effect that normally parses time estimation syntax like `t1h` or `t30m`. This is because the `addSubTask` action is not handled by the short syntax effect — only `addTask` and `updateTask` are.

This fix applies `parseTimeSpentChanges` directly to subtask titles before creating them, so time estimates are correctly parsed in both:
- Structured import path (parent tasks with nested sub-tasks)
- Simple list import path (tasks added as sub-tasks of a selected task)

## Changes

- Export `parseTimeSpentChanges` from `short-syntax.ts`
- Import and call it in `markdown-paste.service.ts` for both subtask creation paths
- Destructure the result to cleanly separate the cleaned title from time properties (`timeEstimate`, `timeSpentOnDay`)

Fixes #6520