### PR TITLE
Prioritize text content in clipboard

### DIFF
--- a/src/app/core/clipboard-image/clipboard-paste-handler.service.ts
+++ b/src/app/core/clipboard-image/clipboard-paste-handler.service.ts
@@ -25,6 +25,14 @@ export class ClipboardPasteHandlerService {
   async handlePaste(ev: ClipboardEvent, context: PasteContext): Promise<boolean> {
     if (!ev.clipboardData) return false;
 
+    // Check for text content first - prioritize text over images (e.g., OneNote copies both)
+    const hasText =
+      ev.clipboardData.types.includes('text/plain') ||
+      ev.clipboardData.types.includes('text/html');
+    if (hasText) {
+      return false; // Let default text paste behavior handle it
+    }
+
     const progress = this._clipboardImageService.handlePasteWithProgress(ev);
     if (!progress) return false;
 


### PR DESCRIPTION
## Problem

Copied text in the software such as Microsoft OneNote will provide multiple clipboard data types.

In our case, we should prioritize text instead of image data.

## Solution: What PR does

Fix #6495

