### PR TITLE
ci/discussion pruning

### DIFF
--- a/.github/workflows/stale-discussions.yml
+++ b/.github/workflows/stale-discussions.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: stalesweeper
-        uses: thenick775/stalesweeper@1970ca7c8eb73680d0be642c0a60a08e28a9692e
+        uses: zenoprax/stalesweeper@init-fork
         env:
           DAYS_BEFORE_CLOSE: ${{ github.event_name == 'schedule' && '180' || github.event.inputs.days-before-close }}
           DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || github.event.inputs.dry-run }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: stalesweeper
-        uses: thenick775/stalesweeper@1970ca7c8eb73680d0be642c0a60a08e28a9692e
+        uses: zenoprax/stalesweeper@init-fork
         env:
           DAYS_BEFORE_CLOSE: ${{ github.event_name == 'schedule' && '90' || github.event.inputs.days-before-close }}
           DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || github.event.inputs.dry-run }}


### PR DESCRIPTION
- **ci(community): initial discussion pruning workflow**
- **ci(community): revised workflow for revised action**
- **ci(community): add first valid workflow**
- **ci(community): switch action to controlled fork**

This workflow is not scheduled to run until next weekend.
The manual mode defaults to dry-run.
The extra commits to help make it easier to trace providence.
Last commit is to make `git revert` easy if it becomes necessary.

Lots of testing done so this is safe to pull in for some dry-runs.
