### PR TITLE
fix(focus-mode): allow long parent task titles to wrap

### DIFF
--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.scss
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.scss
@@ -95,7 +95,6 @@
   line-height: 1.2;
   max-width: 90%;
   overflow-wrap: break-word;
-  word-break: break-word;
 
   @media (max-width: 499px) {
     font-size: 12px;


### PR DESCRIPTION
## Summary

- Remove single-line truncation (`white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis`) from `.parent-title` in focus mode
- Replace with `overflow-wrap: break-word` and `word-break: break-word` so long parent task titles wrap naturally
- Preserves `max-width: 90%` to keep text from touching screen edges

Closes #6651