### PR TITLE
feat: Shortcut for Making Task Comments Bold and Italic

### DIFF
--- a/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
@@ -93,7 +93,7 @@ describe('InlineMarkdownComponent', () => {
       expect(component.changed.emit).toHaveBeenCalledWith('Hello _world_');
     });
 
-    it('should insert ** at cursor and pace cursor between pairs of ** when pressing Ctrl + B with no selection', () => {
+    it('should insert ** at cursor and place cursor between pairs of ** when pressing Ctrl + B with no selection', () => {
       mockTextareaEl.nativeElement.selectionStart = 5;
       mockTextareaEl.nativeElement.selectionEnd = 5;
       const ev = new KeyboardEvent('keydown', { key: 'b', ctrlKey: true });

--- a/src/app/ui/inline-markdown/inline-markdown.component.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.ts
@@ -472,7 +472,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
     let newValue: string;
     let newCursorPos: number;
 
-    // Case 1: No selection - > Insert markers and place cursor between them
+    // Case 1: No selection -> Insert markers and place cursor between them
     // For example: **<cursor>**
     if (selectedText.length === 0) {
       newValue = value.substring(0, start) + marker + marker + value.substring(end);


### PR DESCRIPTION
## Problem
Currently, there is no support for using shortcuts to make text bold or italic in the Comment section of a Task bold. On has to write `****` for bold and `__` for italic, which takes a bit more time.
<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does
resolves #6606 
When user is in editing mode in the Comment section and they press Ctrl + B or Ctrl + I, insert ** or _. This implementation handles two scenarios: 
  1. User selects a chunk of text -> insert ** or _ before the selection start and after the selection end
  2. User doesn't select text -> insert markers at the cursor, then place cursor between the pairs of markings. For example: `**`Cursor`**`, `_`Cursor`_`

Unit tests are included.

<!-- Describe your changes in detail -->
