### PR TITLE
fix(focus-mode) : add translate for "T.F.FOCUS_MODE.PAUSE_TRACKING"

### DIFF
--- a/src/app/features/focus-mode/task-tracking-info/task-tracking-info.component.ts
+++ b/src/app/features/focus-mode/task-tracking-info/task-tracking-info.component.ts
@@ -15,17 +15,18 @@ import { selectCurrentTask } from '../../tasks/store/task.selectors';
 import { getTodayStr } from '../../tasks/util/get-today-str';
 import { TaskService } from '../../tasks/task.service';
 import { T } from '../../../t.const';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'task-tracking-info',
   standalone: true,
-  imports: [MatIcon, MatTooltipModule, MsToStringPipe],
+  imports: [MatIcon, MatTooltipModule, MsToStringPipe, TranslateModule],
   template: `
     @if (currentTask() && (showTitle() || currentTaskTimeToday() > 0)) {
       <div
         class="task-tracking-info"
         (click)="onTaskClick()"
-        [matTooltip]="T.F.FOCUS_MODE.PAUSE_TRACKING"
+        [matTooltip]="T.F.FOCUS_MODE.PAUSE_TRACKING | translate"
         role="button"
         tabindex="0"
         [attr.aria-label]="T.F.FOCUS_MODE.PAUSE_TRACKING_FOR_CURRENT_TASK"


### PR DESCRIPTION
Fixed translate for T.F.FOCUS_MODE.PAUSE_TRACKING

## Problem
While hovering the pause, instead of showing translated message it shows **T.F.FOCUS_MODE.PAUSE_TRACKING**
<img width="617" height="668" alt="Screenshot from 2026-03-03 20-14-04" src="https://github.com/user-attachments/assets/4e1e9047-0e42-4f90-95c9-568c3131873a" />

<!-- Describe the problem that these changes should solve (links to issues are welcome). -->

## Solution: What PR does
Resolved it by fixing the translation for the component
<img width="617" height="668" alt="image" src="https://github.com/user-attachments/assets/94bf0712-658b-42ec-ac84-1d4ffe877447" />

> 🚀 My first open-source contribution