### PR TITLE
fix(issue): show board title in Nextcloud Deck provider tooltip

### DIFF
--- a/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.ts
+++ b/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.ts
@@ -42,6 +42,10 @@ export const getIssueProviderTooltip = (issueProvider: IssueProvider): string =>
         return issueProvider.projectId;
       case 'TRELLO':
         return issueProvider.boardName || issueProvider.boardId;
+      case 'NEXTCLOUD_DECK':
+        return issueProvider.selectedBoardTitle
+          ? `Deck: ${issueProvider.selectedBoardTitle}`
+          : undefined;
       case 'AZURE_DEVOPS':
         return issueProvider.project || undefined;
       default:
@@ -117,6 +121,8 @@ export const getIssueProviderInitials = (
       return (issueProvider.boardName || issueProvider.boardId)
         ?.substring(0, 2)
         ?.toUpperCase();
+    case 'NEXTCLOUD_DECK':
+      return issueProvider.selectedBoardTitle?.substring(0, 2)?.toUpperCase();
     case 'AZURE_DEVOPS':
       return issueProvider.project?.substring(0, 2)?.toUpperCase() || 'AD';
   }


### PR DESCRIPTION


## Problem

Nextcloud Deck issue provider, if added multiple times (for different boards) showed up as NEXTCLOUD_DECK for every entity - easy to confuse.

## Solution: What PR does

Add missing NEXTCLOUD_DECK case to tooltip and initials helpers, showing the selected board title prefixed with "Deck:" instead of the raw provider key.
