### PR TITLE
fix(tracking-reminder): show reminder when tracking is paused

### DIFF
--- a/src/app/features/tracking-reminder/tracking-reminder.service.spec.ts
+++ b/src/app/features/tracking-reminder/tracking-reminder.service.spec.ts
@@ -202,4 +202,42 @@ describe('TrackingReminderService', () => {
     sub.unsubscribe();
     discardPeriodicTasks();
   }));
+
+  it('is not suppressed when work session is paused', fakeAsync(() => {
+    store.overrideSelector(selectIsFocusModeEnabled, true);
+    store.overrideSelector(
+      selectTimer,
+      createMockTimer({ purpose: 'work', isRunning: false }),
+    );
+    store.refreshState();
+
+    const values: number[] = [];
+    const sub = service.remindCounter$.subscribe((v) => values.push(v));
+
+    tick(TRACKING_REMINDER_MIN_TIME + 1000);
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[values.length - 1]).toBeGreaterThan(TRACKING_REMINDER_MIN_TIME);
+
+    sub.unsubscribe();
+    discardPeriodicTasks();
+  }));
+
+  it('is not suppressed when break is paused', fakeAsync(() => {
+    store.overrideSelector(selectIsFocusModeEnabled, true);
+    store.overrideSelector(
+      selectTimer,
+      createMockTimer({ purpose: 'break', isRunning: false }),
+    );
+    store.refreshState();
+
+    const values: number[] = [];
+    const sub = service.remindCounter$.subscribe((v) => values.push(v));
+
+    tick(TRACKING_REMINDER_MIN_TIME + 1000);
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[values.length - 1]).toBeGreaterThan(TRACKING_REMINDER_MIN_TIME);
+
+    sub.unsubscribe();
+    discardPeriodicTasks();
+  }));
 });

--- a/src/app/features/tracking-reminder/tracking-reminder.service.ts
+++ b/src/app/features/tracking-reminder/tracking-reminder.service.ts
@@ -79,7 +79,9 @@ export class TrackingReminderService {
   ]).pipe(
     map(
       ([isEnabled, timer, screen]) =>
-        isEnabled && (timer.purpose !== null || screen === FocusScreen.SessionDone),
+        isEnabled &&
+        ((timer.isRunning && timer.purpose !== null) ||
+          screen === FocusScreen.SessionDone),
     ),
     distinctUntilChanged(),
   );


### PR DESCRIPTION
Fixes #6459

## Summary
The time tracking reminder was incorrectly suppressed when a tracking session was paused. The `_isFocusModeActive$` observable only checked if `timer.purpose` was set (indicating work or break), but didn't verify whether the timer was actually running.

## Changes
- Modified `_isFocusModeActive$` logic in `tracking-reminder.service.ts` to also check `timer.isRunning`
- Reminders now correctly show when tracking is paused (`isRunning: false` but `purpose` is set)
- Added two test cases covering paused work sessions and paused breaks

## Technical Details
The fix changes the condition from:
```typescript
isEnabled && (timer.purpose !== null || screen === FocusScreen.SessionDone)
```

To:
```typescript
isEnabled && ((timer.isRunning && timer.purpose !== null) || screen === FocusScreen.SessionDone)
```

This ensures:
- Reminders are **shown** when tracking is paused (`isRunning: false`)
- Reminders are **suppressed** only when actively tracking (`isRunning: true && purpose !== null`)
- Reminders are **suppressed** on SessionDone screen (session just completed)

## Testing
Added two new unit tests:
- `is not suppressed when work session is paused`
- `is not suppressed when break is paused`

Both tests verify that reminders are emitted when the timer has a purpose but `isRunning` is false.

```
 src/app/features/tracking-reminder/tracking-reminder.service.spec.ts | 38 ++++++++++++++++++++++
 src/app/features/tracking-reminder/tracking-reminder.service.ts      |  4 ++-
 2 files changed, 41 insertions(+), 1 deletion(-)
```