### PR TITLE
feat(focus-mode): add reset button for pomodoro session counter

### DIFF
--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html
@@ -205,6 +205,18 @@
               <mat-icon>done_all</mat-icon>
             </button>
           }
+
+          <!-- Reset cycles button (In Progress state, Pomodoro only) -->
+          @if (isShowCompleteSessionButton() && isPomodoro()) {
+            <button
+              mat-icon-button
+              [matTooltip]="T.F.FOCUS_MODE.RESET_CYCLES | translate"
+              (click)="resetCycles()"
+              class="reset-cycles-btn"
+            >
+              <mat-icon>restart_alt</mat-icon>
+            </button>
+          }
         </div>
       </div>
 

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
@@ -24,6 +24,7 @@ import {
   completeTask,
   focusModeLoaded,
   pauseFocusSession,
+  resetCycles,
   selectFocusTask,
   setFocusModeMode,
   setFocusSessionDuration,
@@ -181,6 +182,7 @@ export class FocusModeMainComponent {
   isShowTimeAdjustButtons = computed(
     () => this._isInProgress() && this.mode() !== FocusModeMode.Flowtime,
   );
+  isPomodoro = computed(() => this.mode() === FocusModeMode.Pomodoro);
 
   // Play button should be disabled when sync with tracking is enabled but no task is selected
   isPlayButtonDisabled = computed(() => {
@@ -400,6 +402,10 @@ export class FocusModeMainComponent {
 
   resumeSession(): void {
     this._store.dispatch(unPauseFocusSession());
+  }
+
+  resetCycles(): void {
+    this._store.dispatch(resetCycles());
   }
 
   selectMode(mode: FocusModeMode | string | number): void {


### PR DESCRIPTION
Fixes #6709

## Problem

Users had no way to reset the Pomodoro session counter during an active focus session. The reset button was only available during the break screen, forcing users to either wait for a break or skip multiple sessions if they wanted to reset the counter to start fresh with the long break cycle.

## Solution: What PR does

Adds a reset button to the main focus mode UI (next to the complete session button) that allows users to reset the Pomodoro session counter during an active session. The button:
- Is only visible when in Pomodoro mode during the InProgress state
- Uses the same `resetCycles` action already used by the break screen
- Reuses the existing translation key `T.F.FOCUS_MODE.RESET_CYCLES`
- Uses the same `restart_alt` Material icon as the break screen for consistency

## Changes

- `src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts`:
  - Added `resetCycles` action import
  - Added `isPomodoro` computed property
  - Added `resetCycles()` method to dispatch the action

- `src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html`:
  - Added reset cycles button next to the complete session button

## Testing

Verified the translation key already exists and is used consistently across the break component and pomodoro settings dialog.

```bash
git diff --stat HEAD~1
 src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html | 12 ++++++++++++
 src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts  |  6 ++++++
 2 files changed, 18 insertions(+)
```