### PR TITLE
fix(nextcloud-deck): preserve card notes on done transition

### DIFF
--- a/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.ts
+++ b/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.ts
@@ -73,7 +73,12 @@ export class NextcloudDeckApiService {
     boardId: number,
     stackId: number,
     cardId: number,
-    changes: Partial<{ title: string; done: boolean }>,
+    changes: Partial<{
+      title: string;
+      description: string;
+      duedate: string | null;
+      done: boolean;
+    }>,
   ): Observable<DeckCardResponse> {
     this._checkSettings(cfg);
     const url = `${this._getBaseUrl(cfg)}/boards/${boardId}/stacks/${stackId}/cards/${cardId}`;

--- a/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-issue.effects.ts
+++ b/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-issue.effects.ts
@@ -79,6 +79,8 @@ export class NextcloudDeckIssueEffects {
             this._nextcloudDeckApiService
               .updateCard$(cfg, boardId, targetStackId, cardId, {
                 title: issue.title,
+                description: issue.description,
+                duedate: issue.duedate,
                 done: task.isDone,
               })
               .pipe(catchError(() => EMPTY)),


### PR DESCRIPTION
## Summary
- Fixes the `updateCard$` PUT request to include `description` and `duedate` fields in the payload
- Previously only `title` and `done` were sent, causing the Nextcloud Deck API to clear the card's notes/tasks when moving to the done stack

## Test plan
- [ ] Connect SP to a Nextcloud Deck board
- [ ] Create a card with notes and/or tasks in Nextcloud Deck
- [ ] Wait for import in SP, then mark the task as done
- [ ] Verify the card in Nextcloud Deck retains its notes and due date after being moved to the done stack

Closes #6757