### PR TITLE
fix(android): match navigation bar color to system theme on startup

### DIFF
--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="statusBar">#131314</color>
+    <color name="navigationBar">#131314</color>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
     <color name="primary">#0B77D2</color>
     <color name="primaryDark">#0D47A1</color>
     <color name="accent">#D81B60</color>
-    <color name="statusBar">#000000</color>
+    <color name="statusBar">#f8f8f7</color>
     <color name="navigationBar">#f8f8f7</color>
 
 </resources>


### PR DESCRIPTION
Add values-night/colors.xml with dark theme colors (#131314) so the
navigation bar and status bar match the system dark theme before the
Angular app boots. Also fix light-mode status bar initial color to
#f8f8f7 to match what the app sets dynamically.

https://claude.ai/code/session_017CVEn9yTUqcPiRzoafP24R