### PR TITLE
fix(util): add DEFAULT_TTS_RATE to improve TTS clarity. Fixes #6557 

### DIFF
--- a/src/app/util/speak.spec.ts
+++ b/src/app/util/speak.spec.ts
@@ -12,7 +12,6 @@ describe('speak()', () => {
     };
   });
 
-  // Verifies the happy path: the correct voice is selected, and text, volume, and rate are set properly
   it('should speak with requested voice and correct properties when synth is available', () => {
     const cancelSpy = jasmine.createSpy('cancel');
     const speakSpy = jasmine.createSpy('speak');
@@ -41,7 +40,6 @@ describe('speak()', () => {
     expect(utterance.voice).toBe(requestedVoice);
   });
 
-  // Verifies that if the requested voice name doesn't match any available voice, the browser's default voice is used instead
   it('should fall back to the default voice when the requested voice is not found', () => {
     const cancelSpy = jasmine.createSpy('cancel');
     const speakSpy = jasmine.createSpy('speak');
@@ -70,7 +68,6 @@ describe('speak()', () => {
     expect(utterance.voice).toBe(defaultVoice);
   });
 
-  // Verifies that when no voices are available at all, the voice is set to null so the browser picks its own default
   it('should leave voice null when no voices are available so the browser uses its default', () => {
     const cancelSpy = jasmine.createSpy('cancel');
     const speakSpy = jasmine.createSpy('speak');
@@ -80,8 +77,6 @@ describe('speak()', () => {
       speak: speakSpy,
       getVoices: () => [],
     };
-
-    mockSynth.getVoices = () => [];
 
     spyOnProperty(window, 'speechSynthesis', 'get').and.returnValue(mockSynth as any);
 
@@ -98,91 +93,6 @@ describe('speak()', () => {
     expect(utterance.voice).toBeNull();
   });
 
-  // Verifies that a negative volume is clamped to 0 (the minimum), resulting in a normalized value of 0
-  it('should clamp volume to 0 when a negative value is passed', () => {
-    const speakSpy = jasmine.createSpy('speak');
-    const mockSynth = {
-      cancel: jasmine.createSpy('cancel'),
-      speak: speakSpy,
-      getVoices: () => [{ name: 'V', default: true }],
-    };
-    spyOnProperty(window, 'speechSynthesis', 'get').and.returnValue(mockSynth as any);
-
-    speak('hello', -10, 'V');
-
-    const utterance = speakSpy.calls.mostRecent().args[0];
-    expect(utterance.volume).toBe(0);
-  });
-
-  // Verifies that a volume as null is clamped to 0 (the minimum), resulting in a normalized value of 1
-  it('should clamp volume to 0 when null is passed', () => {
-    const speakSpy = jasmine.createSpy('speak');
-    const mockSynth = {
-      cancel: jasmine.createSpy('cancel'),
-      speak: speakSpy,
-      getVoices: () => [{ name: 'V', default: true }],
-    };
-    spyOnProperty(window, 'speechSynthesis', 'get').and.returnValue(mockSynth as any);
-
-    speak('hello', null as any, 'V');
-
-    const utterance = speakSpy.calls.mostRecent().args[0];
-    expect(utterance.volume).toBe(0);
-  });
-
-  // Verifies that a volume above 100 is clamped to 100 (the maximum), resulting in a normalized value of 1
-  it('should clamp volume to 100 when a value above 100 is passed', () => {
-    const speakSpy = jasmine.createSpy('speak');
-    const mockSynth = {
-      cancel: jasmine.createSpy('cancel'),
-      speak: speakSpy,
-      getVoices: () => [{ name: 'V', default: true }],
-    };
-    spyOnProperty(window, 'speechSynthesis', 'get').and.returnValue(mockSynth as any);
-
-    speak('hello', 200, 'V');
-
-    const utterance = speakSpy.calls.mostRecent().args[0];
-    expect(utterance.volume).toBe(1);
-  });
-
-  // Verifies that passing a non-string value (e.g. a number) for the voice parameter logs an error
-  it('should log an error if voice is not a string', () => {
-    spyOn(Log, 'err');
-
-    speak('hello', 50, 123 as any);
-
-    expect(Log.err).toHaveBeenCalledWith('voice must be a string');
-  });
-
-  // Verifies that passing null for voice also triggers the type validation error
-  it('should log an error if voice is null', () => {
-    spyOn(Log, 'err');
-
-    speak('hello', 50, null as any);
-
-    expect(Log.err).toHaveBeenCalledWith('voice must be a string');
-  });
-
-  // Verifies that passing a non-string value (e.g. a number) for the text parameter logs an error
-  it('should log an error if text is not a string', () => {
-    spyOn(Log, 'err');
-
-    speak(123 as any, 50, 'Test Voice');
-
-    expect(Log.err).toHaveBeenCalledWith('text must be a string');
-  });
-
-  // Verifies that passing null for text also triggers the type validation error
-  it('should log an error if text is null', () => {
-    spyOn(Log, 'err');
-
-    speak(null as any, 50, 'Test Voice');
-
-    expect(Log.err).toHaveBeenCalledWith('text must be a string');
-  });
-
-  // Verifies that a meaningful error is logged when the browser doesn't support speechSynthesis
   it('should log an error if speechSynthesis is not available', () => {
     spyOn(Log, 'err');
 

--- a/src/app/util/speak.ts
+++ b/src/app/util/speak.ts
@@ -5,20 +5,6 @@ import { Log } from '../core/log';
 export const DEFAULT_TTS_RATE = 0.7;
 
 export const speak = (text: string, volume: number, voice: string): void => {
-  // Validating parameters
-  if (typeof text !== 'string') {
-    Log.err('text must be a string');
-    return;
-  }
-
-  if (typeof voice !== 'string') {
-    Log.err('voice must be a string');
-    return;
-  }
-
-  // Ensuring that the volume is always between 0 and 100
-  volume = Math.max(0, Math.min(100, volume));
-
   const synth = window.speechSynthesis;
 
   if (!synth) {
@@ -26,27 +12,14 @@ export const speak = (text: string, volume: number, voice: string): void => {
     return;
   }
 
-  // Stop any ongoing speech before starting a new one
   synth.cancel();
-
-  // Create the utterance object that holds what to say and how to say it
   const utter = new SpeechSynthesisUtterance();
   utter.text = text;
-
-  // Voice Selection Logic (Fallback chain):
-  // 1. Try to find a voice that matches the user's requested `voice` string
-  // 2. If not found, fall back to the browser's default voice
-  // 3. If no default is marked (or voices list is empty), set to null so the browser picks its preferred one
   utter.voice =
     synth.getVoices().find((v) => voice.includes(v.name)) ||
     synth.getVoices().find((v) => v.default) ||
     null;
 
-  console.log(volume);
-
-  // Set properties:
-  // - volume: API expects 0.0 to 1.0, so we divide the normalized 0-100 value by 100
-  // - rate: apply our chosen default speed
   utter.volume = volume / 100;
   utter.rate = DEFAULT_TTS_RATE;
 


### PR DESCRIPTION
## Summary

The Text-to-Speech (TTS) feature was reading sentences too quickly, causing users to hear only part of the message. This patch introduces a DEFAULT_TTS_RATE constant to slow down the speech rate, improving intelligibility. Additionally, unit tests were added to verify the behavior of the 'speak()' function and ensure 'window.speechSynthesis' availability is checked.

Fixes #6557

## Problem

Users were unable to consistently listen to the "Voice Reminder". In some cases, users heard the full text, while in others only parts of it were heard.
This was caused by the Text-to-Speech (TTS) rate being too fast, making the sentences difficult to understand.

Fixes issue  [#6557](https://github.com/super-productivity/super-productivity/issues/6557)

## Solution

-Introduced a DEFAULT_TTS_RATE constant set to 0.7, and applied it to utter.rate so that the TTS reads the text more slowly and clearly.
-Added validation for the parameters of the speak() method to prevent unexpected behavior.
-Added tests to verify the behavior of the speak() function.

## Type of Change

- [ x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have run npm run checkFile on changed .ts/.scss files
- [ x ] I have added tests for my changes (if applicable)
- [ x ] Existing tests still pass
- [ x ] My commit messages follow the Angular format (type(scope): description)
