### PR TITLE
feat(schedule): show drag timespan preview

### DIFF
--- a/src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.spec.ts
+++ b/src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.spec.ts
@@ -1,0 +1,41 @@
+import { formatScheduleDragPreviewLabel } from './format-schedule-drag-preview-label.util';
+
+describe('formatScheduleDragPreviewLabel', () => {
+  const formatTime = (timestamp: number): string =>
+    new Date(timestamp).toISOString().slice(11, 16);
+
+  it('should return the start time when duration is missing', () => {
+    const startTimestamp = Date.UTC(2026, 2, 20, 9, 0, 0);
+
+    expect(
+      formatScheduleDragPreviewLabel({
+        startTimestamp,
+        formatTime,
+      }),
+    ).toBe('09:00');
+  });
+
+  it('should include the end time and task duration for scheduled drags', () => {
+    const startTimestamp = Date.UTC(2026, 2, 20, 9, 0, 0);
+
+    expect(
+      formatScheduleDragPreviewLabel({
+        startTimestamp,
+        durationInHours: 1.5,
+        formatTime,
+      }),
+    ).toBe('09:00 - 10:30 (1h 30m)');
+  });
+
+  it('should support short durations without adding an hours part', () => {
+    const startTimestamp = Date.UTC(2026, 2, 20, 9, 15, 0);
+
+    expect(
+      formatScheduleDragPreviewLabel({
+        startTimestamp,
+        durationInHours: 0.75,
+        formatTime,
+      }),
+    ).toBe('09:15 - 10:00 (45m)');
+  });
+});

--- a/src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.ts
+++ b/src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.ts
@@ -1,0 +1,33 @@
+import { msToString } from '../../../ui/duration/ms-to-string.pipe';
+
+interface FormatScheduleDragPreviewLabelParams {
+  formatTime: (timestamp: number) => string;
+  startTimestamp: number;
+  durationInHours?: number | null;
+}
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+export const formatScheduleDragPreviewLabel = ({
+  durationInHours,
+  formatTime,
+  startTimestamp,
+}: FormatScheduleDragPreviewLabelParams): string => {
+  const startLabel = formatTime(startTimestamp);
+
+  if (!durationInHours || durationInHours <= 0) {
+    return startLabel;
+  }
+
+  const durationMs = Math.round(durationInHours * MS_PER_HOUR);
+  if (durationMs <= 0) {
+    return startLabel;
+  }
+
+  const endLabel = formatTime(startTimestamp + durationMs);
+  const durationLabel = msToString(durationMs, false, true);
+
+  return durationLabel
+    ? `${startLabel} - ${endLabel} (${durationLabel})`
+    : `${startLabel} - ${endLabel}`;
+};

--- a/src/app/features/schedule/schedule-week/schedule-week.component.ts
+++ b/src/app/features/schedule/schedule-week/schedule-week.component.ts
@@ -32,6 +32,7 @@ import { parseDbDateStr } from '../../../util/parse-db-date-str';
 import { formatMonthDay } from '../../../util/format-month-day.util';
 import { ScheduleWeekDragService } from './schedule-week-drag.service';
 import { calculatePlaceholderForGridMove } from './schedule-week-placeholder.util';
+import { formatScheduleDragPreviewLabel } from './format-schedule-drag-preview-label.util';
 import { truncate } from '../../../util/truncate';
 
 const D_HOURS = 24;
@@ -171,7 +172,11 @@ export class ScheduleWeekComponent implements OnInit, AfterViewInit, OnDestroy {
       return null;
     }
     if (ctx.kind === 'time') {
-      return this._dateTimeFormatService.formatTime(ctx.timestamp);
+      return formatScheduleDragPreviewLabel({
+        startTimestamp: ctx.timestamp,
+        durationInHours: currentDraggedEvent?.timeLeftInHours,
+        formatTime: (timestamp) => this._dateTimeFormatService.formatTime(timestamp),
+      });
     }
     if (ctx.kind === 'shift-column') {
       const dateLabel = this._formatDateLabel(ctx.day);


### PR DESCRIPTION
## Problem

Closes #6883.

Dragging tasks in the timetable currently only shows the start time in the preview badge. That makes it hard to see the full scheduled timespan while moving tasks around.

## Solution

- format the time-mode drag preview as `start - end (duration)`
- keep shift-mode and unschedule preview labels unchanged
- add focused unit tests for the drag preview label formatter

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Validation

- `npm run checkFile src/app/features/schedule/schedule-week/schedule-week.component.ts`
- `npm run checkFile src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.ts`
- `npm run checkFile src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.spec.ts`
- `npx ng lint --lint-file-patterns=src/app/features/schedule/schedule-week/schedule-week.component.ts --lint-file-patterns=src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.ts --lint-file-patterns=src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.spec.ts`
- `CHROME_BIN=<playwright chromium> npm run test:file -- src/app/features/schedule/schedule-week/format-schedule-drag-preview-label.util.spec.ts`

Targeted lint and the new focused test passed on `100.92.89.12`. I did not run the full project test suite.
