### PR TITLE
feat: add StudyForge Leaderboard community plugin

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -36,12 +36,17 @@
   },
   {
     "name": "Dashboard",
-    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
+    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user\u2011defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
     "url": "https://github.com/dougcooper/sp-dashboard"
   },
   {
     "name": "Invoicer",
     "shortDescription": "Generate client invoices from tracked time in Super Productivity, with flexible billing periods, itemization levels, and PDF export.",
     "url": "https://github.com/1jamesthompson1/sp-invoicer"
+  },
+  {
+    "name": "StudyForge Leaderboard",
+    "shortDescription": "Syncs your daily study time from Super Productivity to the StudyForge leaderboard. Compete with friends, track streaks, and join 7-day study war challenges.",
+    "url": "https://github.com/dhananajay-030/studyforge-plugin"
   }
 ]


### PR DESCRIPTION
## StudyForge Leaderboard Plugin

Syncs daily study time from Super Productivity to a live leaderboard. Users can compete with friends, track their streaks via a study calendar, and join 7-day elite study war challenges.

**Repo:** https://github.com/dhananajay-030/studyforge-plugin
**Live Leaderboard:** https://productivity-leaderboard-v2.onrender.com