### PR TITLE
Skip onboarding flow in e2e test setup helpers

### DIFF
--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -217,6 +217,15 @@ export const createSimulatedClient = async (
 
   const page = await context.newPage();
 
+  // Skip onboarding, hints, and example tasks before the app boots.
+  // This runs before any page JavaScript, so Angular sees the flags immediately.
+  await page.addInitScript(() => {
+    localStorage.setItem('SUP_ONBOARDING_PRESET_DONE', 'true');
+    localStorage.setItem('SUP_ONBOARDING_HINTS_DONE', 'true');
+    localStorage.setItem('SUP_IS_SHOW_TOUR', 'true');
+    localStorage.setItem('SUP_EXAMPLE_TASKS_CREATED', 'true');
+  });
+
   // Set up error logging
   page.on('pageerror', (error) => {
     console.error(`[Client ${clientName}] Page error:`, error.message);

--- a/e2e/utils/sync-helpers.ts
+++ b/e2e/utils/sync-helpers.ts
@@ -100,6 +100,15 @@ export const setupSyncClient = async (
   const context = await browser.newContext({ baseURL });
   const page = await context.newPage();
 
+  // Skip onboarding, hints, and example tasks before the app boots.
+  // This runs before any page JavaScript, so Angular sees the flags immediately.
+  await page.addInitScript(() => {
+    localStorage.setItem('SUP_ONBOARDING_PRESET_DONE', 'true');
+    localStorage.setItem('SUP_ONBOARDING_HINTS_DONE', 'true');
+    localStorage.setItem('SUP_IS_SHOW_TOUR', 'true');
+    localStorage.setItem('SUP_EXAMPLE_TASKS_CREATED', 'true');
+  });
+
   // Auto-accept confirm dialogs for fresh client sync
   // This handles the window.confirm() call in OperationLogSyncService._showFreshClientSyncConfirmation
   page.on('dialog', async (dialog) => {


### PR DESCRIPTION
## Problem

E2E tests for the sync functionality need to bypass the onboarding flow, hints, and example task creation to reach the actual application state quickly and reliably. Currently, these flows may interfere with test execution.

## Solution

Added `page.addInitScript()` calls in both `createSimulatedClient` and `setupSyncClient` helper functions to set localStorage flags before the Angular application boots. This ensures the app recognizes that onboarding has been completed, hints have been shown, the tour should be hidden, and example tasks have been created—allowing tests to start with a clean, post-onboarding state.

The script runs before any page JavaScript executes, guaranteeing that Angular sees these flags immediately upon initialization.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

https://claude.ai/code/session_01AgeFLhcokw7y2tkTpeQMUz