### PR TITLE
fix: use today tag color as initial Material theme primary color

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ import {
 import { FormlyConfigModule } from './app/ui/formly-config.module';
 import { markedOptionsFactory } from './app/ui/marked-options-factory';
 import { MaterialCssVarsModule } from 'angular-material-css-vars';
+import { DEFAULT_TODAY_TAG_COLOR } from './app/features/work-context/work-context.const';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { ReminderModule } from './app/features/reminder/reminder.module';
@@ -118,7 +119,9 @@ bootstrapApplication(AppComponent, {
         },
         sanitize: { provide: SANITIZE, useValue: SecurityContext.HTML },
       }),
-      MaterialCssVarsModule.forRoot(),
+      MaterialCssVarsModule.forRoot({
+        primary: DEFAULT_TODAY_TAG_COLOR,
+      }),
       MatSidenavModule,
       MatBottomSheetModule,
       ReminderModule,


### PR DESCRIPTION
The angular-material-css-vars library defaults to #03a9f4 (Material Light Blue)
before any data loads. This changes it to use DEFAULT_TODAY_TAG_COLOR (#6495ED)
so the initial flash matches the today list theme.

https://claude.ai/code/session_011YpWAdc7rH3CY9EewWcMfQ