### PR TITLE
fix(planner): keep schedule task calendar at consistent height

### DIFF
--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
@@ -23,6 +23,10 @@
   }
 
   ::ng-deep {
+    mat-calendar {
+      height: 400px;
+    }
+
     .mat-calendar-header {
       padding-top: 0;
     }


### PR DESCRIPTION
 Closes #6556

## Problem

The schedule task dialog can shift vertically when calendar content changes, which creates a jumpy experience while picking dates.

## Solution

Set a fixed height on the embedded mat-calendar in the schedule task dialog to keep layout stable and improve usability. 

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
