### PR TITLE
feat(focus): change time under focus icon after a break to turn zero

### DIFF
--- a/src/app/core-ui/main-header/focus-button/focus-button.component.html
+++ b/src/app/core-ui/main-header/focus-button/focus-button.component.html
@@ -25,9 +25,5 @@
     <div class="focus-label focus-running-label">
       {{ runningMs | msToMinuteClockString }}
     </div>
-  } @else {
-    <div class="focus-label">
-      {{ 0 | msToMinuteClockString }}
-    </div>
   }
 </div>


### PR DESCRIPTION
## Problem

After a break auto-completes, it shows total focused time instead of 0:00
This causes confusion

https://github.com/super-productivity/super-productivity/issues/6723


## Solution

changed the time under the focus icon to show zero after a brake instead of the total time

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [V] Existing tests still pass
- [V] My commit messages follow the Angular format (`type(scope): description`)
