### PR TITLE
fix(nav): show task count in menu on touch devices #5325

### DIFF
--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -69,8 +69,10 @@
   font-weight: normal;
 }
 
-:host:hover .task-count {
-  display: flex !important;
+@media (hover: hover) {
+  :host:hover .task-count {
+    display: none !important;
+  }
 }
 
 @media (hover: none) {
@@ -79,6 +81,7 @@
     visibility: visible;
   }
   .task-count {
+    right: 48px !important;
     display: flex !important;
   }
 }
@@ -90,7 +93,7 @@
   line-height: 1;
   text-align: center;
   font-size: 10px;
-  right: 48px; // keep space for 3 dots
+  right: 16px; 
   display: flex;
   align-items: center;
   color: var(--text-color-muted);


### PR DESCRIPTION
## Problem

The number of tasks did not appear in the menu on touch devices.
On mobile/tablet screens, the task count was hidden due to hover-only styles.

Fixes #5325


## Solution

Updated the task-count styles to work on devices without hover support.
- Allow task count to be visible on touch devices
- Adjust right spacing to avoid overlap with the additional menu button
- Remove mobile-specific display:none rules that prevented the count from showing


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)


## Checklist

- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)