### PR TITLE
fix: address review findings from 18.0.0 release

### DIFF
--- a/electron/plugin-oauth.ts
+++ b/electron/plugin-oauth.ts
@@ -4,10 +4,16 @@ import { IPC } from './shared-with-frontend/ipc-events.const';
 import { log } from 'electron-log/main';
 
 const LOOPBACK_HOST = '127.0.0.1';
+const OAUTH_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 let loopbackServer: Server | null = null;
+let oauthTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 const cleanupServer = (): void => {
+  if (oauthTimeoutId) {
+    clearTimeout(oauthTimeoutId);
+    oauthTimeoutId = null;
+  }
   if (loopbackServer) {
     loopbackServer.close();
     loopbackServer = null;
@@ -67,6 +73,10 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
         const addr = server.address();
         if (addr && typeof addr !== 'string') {
           loopbackServer = server;
+          oauthTimeoutId = setTimeout(() => {
+            log('Plugin OAuth: Timeout – closing abandoned loopback server');
+            cleanupServer();
+          }, OAUTH_TIMEOUT_MS);
           log(`Plugin OAuth: Loopback server listening on port ${addr.port}`);
           resolve({ port: addr.port });
         } else {
@@ -105,16 +115,12 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
       return;
     }
 
-    // shell.openExternal returns Promise<void> at runtime despite outdated types
-    const result: unknown = shell.openExternal(url);
-    if (result && typeof (result as Record<string, unknown>).catch === 'function') {
-      (result as Promise<void>).catch((err: unknown) => {
-        log('Plugin OAuth: Failed to open system browser:', err);
-        mainWin.webContents.send(IPC.PLUGIN_OAUTH_CB, {
-          error: 'failed_to_open_browser',
-        });
-        cleanupServer();
+    shell.openExternal(url).catch((err: unknown) => {
+      log('Plugin OAuth: Failed to open system browser:', err);
+      mainWin.webContents.send(IPC.PLUGIN_OAUTH_CB, {
+        error: 'failed_to_open_browser',
       });
-    }
+      cleanupServer();
+    });
   });
 };

--- a/src/app/features/issue-panel/issue-provider-setup-overview/issue-provider-setup-overview.component.html
+++ b/src/app/features/issue-panel/issue-provider-setup-overview/issue-provider-setup-overview.component.html
@@ -5,7 +5,7 @@
     (click)="openSetupDialog('ICAL', 'GOOGLE')"
   >
     <mat-icon>calendar_month</mat-icon>
-    <span>Google Calendar Ical</span>
+    <span>Google Calendar (iCal)</span>
   </button>
   <button
     mat-raised-button
@@ -19,7 +19,7 @@
     (click)="openSetupDialog('ICAL', 'OTHER')"
   >
     <mat-icon>calendar_month</mat-icon>
-    <span>iCal Other</span>
+    <span>Other (iCal)</span>
   </button>
   @for (provider of pluginCalendarProviders; track provider.pluginId) {
     <button

--- a/src/app/pages/daily-summary/daily-summary.component.html
+++ b/src/app/pages/daily-summary/daily-summary.component.html
@@ -8,7 +8,10 @@
       <span>{{ T.PDS.SUMMARY_FOR | translate: { dayStr: dayStr } }}</span>
     }
   </h1>
-  <div class="daily-summary-summary">
+  <div
+    class="daily-summary-summary"
+    [class.is-loading-archive]="!isArchiveLoaded()"
+  >
     <div class="summary-point">
       <mat-icon>schedule</mat-icon>
       <div class="summary-text">
@@ -162,8 +165,10 @@
               [isForToday]="isForToday"
               [isShowYesterday]="isForToday && isIncludeYesterday"
             ></task-summary-tables>
-          } @else {
+          } @else if (isArchiveLoaded()) {
             <p>{{ T.PDS.NO_TASKS | translate }}</p>
+          } @else {
+            <mat-spinner style="margin: auto"></mat-spinner>
           }
           @if (tasks?.length) {
             <tasks-by-tag

--- a/src/app/pages/daily-summary/daily-summary.component.scss
+++ b/src/app/pages/daily-summary/daily-summary.component.scss
@@ -74,6 +74,11 @@ $summary-point-inner-margin: var(--s);
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  transition: opacity 0.2s ease;
+
+  &.is-loading-archive {
+    opacity: 0.6;
+  }
 
   p {
     margin: 5px;

--- a/src/app/pages/daily-summary/daily-summary.component.ts
+++ b/src/app/pages/daily-summary/daily-summary.component.ts
@@ -8,6 +8,7 @@ import {
   linkedSignal,
   OnDestroy,
   OnInit,
+  signal,
   Signal,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -29,6 +30,7 @@ import {
   switchMap,
   take,
   takeUntil,
+  tap,
   timeout,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -65,7 +67,6 @@ import { MsToClockStringPipe } from '../../ui/duration/ms-to-clock-string.pipe';
 import { InlineInputComponent } from '../../ui/inline-input/inline-input.component';
 import { InlineMarkdownComponent } from '../../ui/inline-markdown/inline-markdown.component';
 import { MomentFormatPipe } from '../../ui/pipes/moment-format.pipe';
-import { IS_TOUCH_ONLY } from '../../util/is-touch-only';
 import { getPluralKey } from '../../util/get-plural-key';
 import { shareReplayUntil } from '../../util/share-replay-until';
 import { unToggleCheckboxesInMarkdownTxt } from '../../util/untoggle-checkboxes-in-markdown-txt';
@@ -168,6 +169,8 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
     switchMap((dayStr) => this._getDailySummaryTasksFlat$(dayStr)),
     shareReplay(1),
   );
+
+  isArchiveLoaded = signal(false);
 
   hasTasksForToday$: Observable<boolean> = this.tasksWorkedOnOrDoneOrRepeatableFlat$.pipe(
     map((tasks) => tasks && !!tasks.length),
@@ -311,12 +314,16 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
       return;
     }
 
-    this._startCelebrationTimeout = window.setTimeout(
-      () => {
-        this._celebrate();
-      },
-      IS_TOUCH_ONLY ? 1500 : 500,
-    );
+    this.tasksWorkedOnOrDoneOrRepeatableFlat$
+      .pipe(
+        first((tasks) => tasks.length > 0),
+        takeUntil(this._onDestroy$),
+      )
+      .subscribe(() => {
+        this._startCelebrationTimeout = window.setTimeout(() => {
+          this._celebrate();
+        }, 300);
+      });
   }
 
   ngOnDestroy(): void {
@@ -493,7 +500,7 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private _getDailySummaryTasksFlat$(dayStr: string): Observable<Task[]> {
-    // TODO make more performant!!
+    this.isArchiveLoaded.set(false);
     const _isWorkedOnDoneOrDueToday = (() => {
       if (this.isIncludeYesterday) {
         const yesterday = new Date();
@@ -614,6 +621,7 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
       withLatestFrom(this.workContextService.activeWorkContextTypeAndId$),
       map(_mapEntities),
       map(_mapFilterToFlatToday),
+      tap(() => this.isArchiveLoaded.set(true)),
     );
 
     const todayTasks: Observable<TaskWithSubTasks[]> =
@@ -623,9 +631,10 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
         map(_mapFilterToFlatOrRepeatToday),
       );
 
-    return combineLatest([todayTasks, archiveTasks]).pipe(
-      map(([t1, t2]) => t1.concat(t2)),
-    );
+    return combineLatest([
+      todayTasks,
+      archiveTasks.pipe(startWith([] as TaskWithSubTasks[])),
+    ]).pipe(map(([today, archive]) => today.concat(archive)));
   }
 
   private _celebrate(): void {

--- a/src/app/ui/input-color-picker/input-color-picker.component.ts
+++ b/src/app/ui/input-color-picker/input-color-picker.component.ts
@@ -67,11 +67,18 @@ export class InputColorPickerComponent {
     if (!rect) return;
 
     const panelWidth = 196;
+    const panelHeight = 160;
+    const gap = 4;
+
     const spaceRight = window.innerWidth - rect.left;
     const left =
       spaceRight >= panelWidth ? rect.left : window.innerWidth - panelWidth - 8;
 
-    this.panelTop = `${rect.bottom + 4}px`;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const top =
+      spaceBelow >= panelHeight + gap ? rect.bottom + gap : rect.top - panelHeight - gap;
+
+    this.panelTop = `${top}px`;
     this.panelLeft = `${left}px`;
   }
 }


### PR DESCRIPTION
- perf(daily-summary): restore progressive archive loading reverted by cd12556
  Today's tasks render immediately; archive tasks append when ready.
  Show spinner while archive loads, defer confetti until tasks arrive.
- fix(plugins): add 5-minute timeout for abandoned OAuth loopback server
  and simplify shell.openExternal call (already returns Promise)
- fix(color): add vertical overflow check to color picker panel positioning
- fix(issue-panel): fix iCal capitalization in calendar button labels

https://claude.ai/code/session_01SR9JRGdm5wiNw3rKPJdZwY