### PR TITLE
fix(oauth): use platform-specific client ID for mobile OAuth flows

### DIFF
--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -334,6 +334,14 @@ export interface OAuthFlowConfig {
    * non-confidential (e.g., Google installed-app credentials per RFC 8252).
    */
   clientSecret?: string;
+  /**
+   * Client ID for native mobile platforms (Android/iOS).
+   * Mobile OAuth client types authenticate via app signing (package name + SHA-1
+   * on Android, bundle ID on iOS) and have no client secret. When set, this
+   * overrides `clientId` on native platforms and `clientSecret` is omitted.
+   * PKCE is used as the sole proof mechanism.
+   */
+  mobileClientId?: string;
   scopes: string[];
   /** Additional query parameters to append to the authorization URL (e.g. access_type, prompt). */
   extraAuthParams?: Record<string, string>;

--- a/packages/plugin-dev/google-calendar-provider/src/plugin.ts
+++ b/packages/plugin-dev/google-calendar-provider/src/plugin.ts
@@ -32,6 +32,10 @@ const CLIENT_ID =
 // redirect URI restrictions are the actual security mechanisms.
 // Do not rotate or revoke — this value is intentionally committed.
 const CLIENT_SECRET = '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';
+// Android OAuth client ID — authenticates via package name + SHA-1 signing key.
+// No client secret needed; PKCE is the sole proof mechanism.
+// TODO: Replace with real Android client ID from Google Cloud Console.
+const MOBILE_CLIENT_ID = '';
 
 interface GoogleCalendarConfig {
   calendarId?: string;
@@ -72,8 +76,7 @@ const formatYMD = (d: Date): string =>
 const asCfg = (config: Record<string, unknown>): GoogleCalendarConfig =>
   config as unknown as GoogleCalendarConfig;
 
-const getCalendarId = (cfg: GoogleCalendarConfig): string =>
-  cfg.calendarId || 'primary';
+const getCalendarId = (cfg: GoogleCalendarConfig): string => cfg.calendarId || 'primary';
 
 const eventUrl = (calendarId: string, eventId?: string): string => {
   const base = `${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events`;
@@ -113,19 +116,16 @@ const fetchEvents = async (
     now.getTime() + syncRangeWeeks * 7 * 24 * 60 * 60 * 1000,
   ).toISOString();
 
-  const response = await http.get<GoogleCalendarListResponse>(
-    eventUrl(calendarId),
-    {
-      params: {
-        ...(opts?.query ? { q: opts.query } : {}),
-        timeMin,
-        timeMax,
-        singleEvents: 'true',
-        orderBy: 'startTime',
-        maxResults: opts?.maxResults ?? '50',
-      },
+  const response = await http.get<GoogleCalendarListResponse>(eventUrl(calendarId), {
+    params: {
+      ...(opts?.query ? { q: opts.query } : {}),
+      timeMin,
+      timeMax,
+      singleEvents: 'true',
+      orderBy: 'startTime',
+      maxResults: opts?.maxResults ?? '50',
     },
-  );
+  });
 
   return (response.items || [])
     .filter((e) => e.status !== 'cancelled')
@@ -143,6 +143,7 @@ PluginAPI.registerIssueProvider({
         tokenUrl: GOOGLE_TOKEN_URL,
         clientId: CLIENT_ID,
         clientSecret: CLIENT_SECRET,
+        mobileClientId: MOBILE_CLIENT_ID || undefined,
         scopes: [CALENDAR_EVENTS_SCOPE, CALENDAR_READONLY_SCOPE],
         extraAuthParams: { access_type: 'offline', prompt: 'consent' },
       },
@@ -200,9 +201,7 @@ PluginAPI.registerIssueProvider({
     http: PluginHttp,
   ): Promise<PluginIssue> {
     const calendarId = getCalendarId(asCfg(config));
-    const event = await http.get<GoogleCalendarEvent>(
-      eventUrl(calendarId, issueId),
-    );
+    const event = await http.get<GoogleCalendarEvent>(eventUrl(calendarId, issueId));
 
     return {
       id: event.id,
@@ -235,7 +234,9 @@ PluginAPI.registerIssueProvider({
   ): Promise<boolean> {
     const calendarId = getCalendarId(asCfg(config));
     try {
-      await http.get(`${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}`);
+      await http.get(
+        `${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}`,
+      );
       return true;
     } catch {
       return false;
@@ -425,14 +426,11 @@ PluginAPI.registerIssueProvider({
     const tmrw = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
     const tomorrow = formatYMD(tmrw);
 
-    const event = await http.post<GoogleCalendarEvent>(
-      eventUrl(calendarId),
-      {
-        summary: title,
-        start: { date: today },
-        end: { date: tomorrow },
-      },
-    );
+    const event = await http.post<GoogleCalendarEvent>(eventUrl(calendarId), {
+      summary: title,
+      start: { date: today },
+      end: { date: tomorrow },
+    });
 
     return {
       issueId: event.id,

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
@@ -40,9 +40,25 @@ export class PluginOAuthBridgeService {
     // getRedirectUri() starts a server — avoid leaking it if config is invalid.
     this._pluginOAuthService.validateOAuthConfig(config);
 
+    // On native mobile platforms, use the mobile-specific client ID (which
+    // authenticates via app signing, not a client secret). This keeps the
+    // solution generic for any OAuth provider requiring platform-specific IDs.
+    const effectiveClientId =
+      IS_NATIVE_PLATFORM && config.mobileClientId
+        ? config.mobileClientId
+        : config.clientId;
+    const effectiveClientSecret =
+      IS_NATIVE_PLATFORM && config.mobileClientId ? undefined : config.clientSecret;
+
+    const effectiveConfig: OAuthFlowConfig = {
+      ...config,
+      clientId: effectiveClientId,
+      clientSecret: effectiveClientSecret,
+    };
+
     const redirectUri = await this._pluginOAuthService.getRedirectUri();
     const { url, codeVerifier, state } = await this._pluginOAuthService.buildAuthUrl(
-      config,
+      effectiveConfig,
       redirectUri,
     );
 
@@ -51,19 +67,19 @@ export class PluginOAuthBridgeService {
     const code = await this._pluginOAuthService.waitForRedirectCode(pluginId, state);
 
     const tokens = await this._pluginOAuthService.exchangeCodeForTokens({
-      tokenUrl: config.tokenUrl,
-      clientId: config.clientId,
+      tokenUrl: effectiveConfig.tokenUrl,
+      clientId: effectiveClientId,
       code,
       codeVerifier,
       redirectUri,
-      clientSecret: config.clientSecret,
+      clientSecret: effectiveClientSecret,
     });
 
     this._pluginOAuthService.storeTokens(pluginId, {
       ...tokens,
-      tokenUrl: config.tokenUrl,
-      clientId: config.clientId,
-      clientSecret: config.clientSecret,
+      tokenUrl: effectiveConfig.tokenUrl,
+      clientId: effectiveClientId,
+      clientSecret: effectiveClientSecret,
     });
 
     await this._persistOAuthTokens(pluginId);


### PR DESCRIPTION
Google rejects Desktop OAuth client IDs when the redirect URI is a
custom scheme (as used on mobile via Capacitor), returning a 400 error.

Add `mobileClientId` to `OAuthFlowConfig` so plugins can specify a
separate Android/iOS client ID that authenticates via app signing
instead of a client secret. On native platforms, the bridge service
automatically uses the mobile client ID with PKCE only.

https://claude.ai/code/session_01EddVMfVeoV8zvVqjj4x7w1