### PR TITLE
fix(task-repeat): return null instead of throwing on invalid repeatEvery

### DIFF
--- a/src/app/features/task-repeat-cfg/store/get-newest-possible-due-date.util.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/get-newest-possible-due-date.util.spec.ts
@@ -77,27 +77,21 @@ describe('getNewestPossibleDueDate()', () => {
       expect(result).toBeTruthy();
     });
 
-    it('should throw error if repeatEvery is not a positive integer', () => {
+    it('should return null if repeatEvery is not a positive integer', () => {
       const cfg1 = dummyRepeatable('ID1', {
         repeatEvery: 0,
       });
-      expect(() => getNewestPossibleDueDate(cfg1, new Date())).toThrowError(
-        'Invalid repeatEvery value given',
-      );
+      expect(getNewestPossibleDueDate(cfg1, new Date())).toBeNull();
 
       const cfg2 = dummyRepeatable('ID1', {
         repeatEvery: -1,
       });
-      expect(() => getNewestPossibleDueDate(cfg2, new Date())).toThrowError(
-        'Invalid repeatEvery value given',
-      );
+      expect(getNewestPossibleDueDate(cfg2, new Date())).toBeNull();
 
       const cfg3 = dummyRepeatable('ID1', {
         repeatEvery: 1.5,
       });
-      expect(() => getNewestPossibleDueDate(cfg3, new Date())).toThrowError(
-        'Invalid repeatEvery value given',
-      );
+      expect(getNewestPossibleDueDate(cfg3, new Date())).toBeNull();
     });
   });
 

--- a/src/app/features/task-repeat-cfg/store/get-newest-possible-due-date.util.ts
+++ b/src/app/features/task-repeat-cfg/store/get-newest-possible-due-date.util.ts
@@ -15,7 +15,7 @@ export const getNewestPossibleDueDate = (
   // return new Date();
 
   if (!Number.isInteger(taskRepeatCfg.repeatEvery) || taskRepeatCfg.repeatEvery < 1) {
-    throw new Error('Invalid repeatEvery value given');
+    return null;
   }
 
   const checkDate = new Date(today);

--- a/src/app/features/task-repeat-cfg/store/get-next-repeat-occurrence.util.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/get-next-repeat-occurrence.util.spec.ts
@@ -74,27 +74,21 @@ describe('getNextRepeatOccurrence()', () => {
       expect(result).toBeTruthy();
     });
 
-    it('should throw error if repeatEvery is not a positive integer', () => {
+    it('should return null if repeatEvery is not a positive integer', () => {
       const cfg1 = dummyRepeatable('ID1', {
         repeatEvery: 0,
       });
-      expect(() => getNextRepeatOccurrence(cfg1, new Date())).toThrowError(
-        'Invalid repeatEvery value given',
-      );
+      expect(getNextRepeatOccurrence(cfg1, new Date())).toBeNull();
 
       const cfg2 = dummyRepeatable('ID1', {
         repeatEvery: -1,
       });
-      expect(() => getNextRepeatOccurrence(cfg2, new Date())).toThrowError(
-        'Invalid repeatEvery value given',
-      );
+      expect(getNextRepeatOccurrence(cfg2, new Date())).toBeNull();
 
       const cfg3 = dummyRepeatable('ID1', {
         repeatEvery: 1.5,
       });
-      expect(() => getNextRepeatOccurrence(cfg3, new Date())).toThrowError(
-        'Invalid repeatEvery value given',
-      );
+      expect(getNextRepeatOccurrence(cfg3, new Date())).toBeNull();
     });
   });
 

--- a/src/app/features/task-repeat-cfg/store/get-next-repeat-occurrence.util.ts
+++ b/src/app/features/task-repeat-cfg/store/get-next-repeat-occurrence.util.ts
@@ -12,7 +12,7 @@ export const getNextRepeatOccurrence = (
   fromDate: Date = new Date(),
 ): Date | null => {
   if (!Number.isInteger(taskRepeatCfg.repeatEvery) || taskRepeatCfg.repeatEvery < 1) {
-    throw new Error('Invalid repeatEvery value given');
+    return null;
   }
 
   const checkDate = new Date(fromDate);


### PR DESCRIPTION
When a TaskRepeatCfg has an invalid repeatEvery value (0, negative, or
non-integer), the app crashes with "Invalid repeatEvery value given".
This can happen with corrupted data. Return null gracefully instead of
throwing, consistent with getFirstRepeatOccurrence which already handles
this case. All callers already handle null returns.

Fixes #6985

https://claude.ai/code/session_01V1DxUd5ou7yDYCN6RqjR8U