### PR TITLE
fix(i18n): use locale full month (nominative) in Schedule Month view

### DIFF
--- a/src/app/features/schedule/schedule-month/schedule-month.component.html
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.html
@@ -1,5 +1,5 @@
 <header class="month-header">
-  <div class="month-title">{{ daysToShow()[14] | localeDate: 'MMMM yyyy' }}</div>
+  <div class="month-title">{{ daysToShow()[14] | localeDate: 'LLLL yyyy' }}</div>
 </header>
 
 <div class="month-grid-container">


### PR DESCRIPTION
## Problem

Schedule view (Month) uses declined variant of month (observed in Polish, Czech, Slovak, Russian, and other Slavic languages with declension), e.g. in Polish a correct form for `March 2026` is `marzec 2026. Actual is `marca 2026`

Before:
<img width="1281" height="720" alt="before-month" src="https://github.com/user-attachments/assets/413c5c16-29d1-461f-9247-835c1b45372d" />

## Solution

Replace format from `MMMM` to `LLLL`, so that nominative is used for months.

After:
<img width="1281" height="720" alt="schedule-after" src="https://github.com/user-attachments/assets/609106f5-2224-402c-8198-78fa26b13e26" />

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [X] My commit messages follow the Angular format (`type(scope): description`)
