### PR TITLE
fix(store): suppress persistence warning on Electron/Microsoft Store

### DIFF
--- a/src/app/core/startup/startup.service.ts
+++ b/src/app/core/startup/startup.service.ts
@@ -307,10 +307,12 @@ export class StartupService {
               if (granted) {
                 Log.log('Persistent store granted');
               }
-              // NOTE: we never show this warning for native mobile apps, because persistence is always granted
-              // Also suppress during active onboarding to avoid confusing first-time users
+              // NOTE: we never show this warning for native mobile apps or Electron,
+              // because persistence is managed by the OS and not subject to browser eviction.
+              // Also suppress during active onboarding to avoid confusing first-time users.
               else if (
                 !this._platformService.isNative &&
+                !IS_ELECTRON &&
                 !OnboardingHintService.isOnboardingInProgress()
               ) {
                 const msg = T.GLOBAL_SNACK.PERSISTENCE_DISALLOWED;


### PR DESCRIPTION
The "data will not be persisted permanently" snack was showing for
Electron apps (including Microsoft Store release) because the
IS_ELECTRON guard was missing. Electron stores IndexedDB in a
dedicated app data directory not subject to browser eviction,
so the warning is meaningless there.

https://claude.ai/code/session_01TLW8VHoV1FX84UMBfqUE19