### PR TITLE
fix(tasks): don't open time tracking for parent tasks on touchscreen

### DIFF
--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -661,6 +661,10 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   }
 
   estimateTime(): void {
+    if (this.task().subTaskIds?.length > 0) {
+      return;
+    }
+
     this._matDialog
       .open(DialogTimeEstimateComponent, {
         data: { task: this.task() },


### PR DESCRIPTION
Closes #6596

## Problem

On touchscreen devices, it was possible to open the Time Tracking (Time Estimate) modal for parent tasks by clicking/tapping on the time summary.

As established in #4821, time entries for parent tasks are not aggregated in the same way as subtasks. When a user adds time to a parent task via this modal, the entries appear in the Worklog list but are not accumulated in the total time summaries, leading to confusion and inconsistent data representation.

## Solution

I added a guard clause to the estimateTime() method. Now, the function checks if the task has any subtasks (subTaskIds.length > 0) before proceeding. If it is a parent task, the method returns early and the DialogTimeEstimateComponent is not opened.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
