### PR TITLE
fix(planner): allow task titles to wrap instead of truncating

### DIFF
--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.scss
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.scss
@@ -57,6 +57,7 @@
   flex-shrink: 1;
   min-width: 0;
   overflow: hidden;
+  word-break: break-word;
   font-size: var(--planner-font-size-mobile);
 
   @include mq(xs) {

--- a/src/app/features/planner/planner-deadline-task/planner-deadline-task.component.scss
+++ b/src/app/features/planner/planner-deadline-task/planner-deadline-task.component.scss
@@ -41,6 +41,7 @@
   flex-shrink: 1;
   min-width: 0;
   overflow: hidden;
+  word-break: break-word;
 
   @include mq(xs) {
     font-size: var(--planner-font-size);

--- a/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.scss
+++ b/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.scss
@@ -41,6 +41,7 @@
   flex-shrink: 1;
   min-width: 0;
   overflow: hidden;
+  word-break: break-word;
 
   @include mq(xs) {
     font-size: var(--planner-font-size);

--- a/src/app/features/planner/planner-task/planner-task.component.scss
+++ b/src/app/features/planner/planner-task/planner-task.component.scss
@@ -106,6 +106,7 @@ done-toggle {
   line-height: 1.5;
   position: relative;
   overflow: hidden;
+  word-break: break-word;
   flex-grow: 1;
   flex-shrink: 1;
 
@@ -120,6 +121,7 @@ done-toggle {
   padding-top: var(--s-half);
   padding-bottom: var(--s-half);
   overflow: hidden;
+  word-break: break-word;
   line-height: 1.1;
   font-size: var(--planner-font-size-smaller-mobile);
 


### PR DESCRIPTION
## Summary

The refactoring in 56d1ff57b replaced manual overflow properties with `@include truncateText()` in planner component `.title` classes. The `truncateText()` mixin adds `white-space: nowrap`, which prevented task titles from wrapping to multiple lines.

This replaces the mixin with `overflow: hidden` in all four planner components to restore wrapping behavior.

Fixes #7095

## Changes

- `planner-task.component.scss` — `.title` and `.parent-title`
- `planner-repeat-projection.component.scss` — `.title`
- `planner-calendar-event.component.scss` — `.title`
- `planner-deadline-task.component.scss` — `.title`

The `text-overflow: ellipsis` property from the mixin is omitted as it has no effect without `white-space: nowrap`.