### PR TITLE
fix(sync): populate Nextcloud in set of file-based provider IDs

### DIFF
--- a/src/app/op-log/sync/operation-sync.util.ts
+++ b/src/app/op-log/sync/operation-sync.util.ts
@@ -6,11 +6,12 @@ import {
 } from '../sync-providers/provider.interface';
 import { SyncProviderId } from '../sync-providers/provider.const';
 
-/** Provider IDs that use file-based operation sync (WebDAV, Dropbox, LocalFile) */
+/** Provider IDs that use file-based operation sync (WebDAV, Dropbox, LocalFile, Nextcloud) */
 const FILE_BASED_PROVIDER_IDS: Set<SyncProviderId> = new Set([
   SyncProviderId.WebDAV,
   SyncProviderId.Dropbox,
   SyncProviderId.LocalFile,
+  SyncProviderId.Nextcloud,
 ]);
 
 /**
@@ -28,7 +29,7 @@ export const isOperationSyncCapable = (
 
 /**
  * Type guard to check if a provider uses file-based operation sync.
- * File-based providers (WebDAV, Dropbox, LocalFile) use file storage for sync.
+ * File-based providers (WebDAV, Dropbox, LocalFile, Nextcloud) use file storage for sync.
  */
 export const isFileBasedProvider = (
   provider: SyncProviderBase<SyncProviderId>,


### PR DESCRIPTION
## Problem
Fixes #7176 - Nextcloud sync was failing with 'Unknown provider type: Nextcloud' error. 

The issue was that Nextcloud was missing from the `FILE_BASED_PROVIDER_IDS` set in `operation-sync.util.ts`, causing the `WrappedProviderService` to not recognize it as a valid file-based sync provider.

### Solution
Added Nextcloud to FILE_BASED_PROVIDER_IDS set so it gets properly recognized as a file-based sync provider.

### Changes
- `src/app/op-log/sync/operation-sync.util.ts`: Added Nextcloud to the file-based provider IDs set


## Solution
Minor changes in the operation-sync.util.ts to populate the Nextcloud into the set of 

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
