### PR TITLE
fix(tasks): roll up estimates when adding subtasks

### DIFF
--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -103,6 +103,29 @@ describe('Task Reducer', () => {
       expect(state.entities['task1']!.subTaskIds).toContain('subTask3');
       expect(state.entities['subTask3']).toEqual({ ...newSubTask, parentId: 'task1' });
     });
+
+    it('should roll up the parent time estimate when adding a subtask with an estimate', () => {
+      const parent = createTask('parent');
+      const subTask = createTask('subTask', { timeEstimate: 2.5 * 60 * 60 * 1000 });
+      const state: TaskState = {
+        ...initialTaskState,
+        ids: ['parent'],
+        entities: {
+          parent,
+        },
+      };
+
+      const result = taskReducer(
+        state,
+        fromActions.addSubTask({
+          task: subTask,
+          parentId: 'parent',
+        }),
+      );
+
+      expect(result.entities['parent']!.subTaskIds).toEqual(['subTask']);
+      expect(result.entities['parent']!.timeEstimate).toBe(2.5 * 60 * 60 * 1000);
+    });
   });
 
   describe('moveSubTask (anchor-based)', () => {

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -489,7 +489,7 @@ export const taskReducer = createReducer<TaskState>(
       state,
     );
 
-    return {
+    const stateWithParentTask: TaskState = {
       ...stateCopy,
       // update current task to new sub task if parent was current before
       ...(state.currentTaskId === parentId ? { currentTaskId: task.id } : {}),
@@ -502,6 +502,8 @@ export const taskReducer = createReducer<TaskState>(
         },
       },
     };
+
+    return reCalcTimesForParentIfParent(parentId, stateWithParentTask);
   }),
 
   on(toggleStart, (state) => {


### PR DESCRIPTION
## Problem

Fixes #6958. Parent task estimates were not recalculated when a subtask with an existing estimate was added through the `addSubTask` reducer path, which left markdown-pasted subtasks out of the parent estimate rollup until a later edit triggered recalculation.

## Solution

Recalculate parent time totals after the parent `subTaskIds` list is updated in `addSubTask`, and cover the reducer path with a focused unit test for a subtask that already has an estimate.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Validation:
- `npm run checkFile src/app/features/tasks/store/task.reducer.ts`
- `npm run checkFile src/app/features/tasks/store/task.reducer.spec.ts`
- `CHROME_BIN=/home/sarthak/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome npm run test:file -- src/app/features/tasks/store/task.reducer.spec.ts`