### PR TITLE
fix(tasks): preserve selected add-task estimate

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -305,6 +305,87 @@ describe('AddTaskBarParserService', () => {
         expect(mockStateService.updateEstimate).toHaveBeenCalledWith(null);
       });
 
+      it('should preserve a manually selected estimate when plain text is typed', async () => {
+        const manualEstimate = 30 * 60 * 1000;
+        mockStateService.state.and.returnValue({
+          projectId: mockDefaultProject.id,
+          tagIds: [],
+          tagIdsFromTxt: [],
+          newTagTitles: [],
+          date: null,
+          time: null,
+          spent: null,
+          estimate: manualEstimate,
+          cleanText: null,
+          remindOption: null,
+          attachments: [],
+          repeatQuickSetting: null,
+        });
+
+        await service.parseAndUpdateText(
+          'Simple task',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+        );
+
+        expect(mockStateService.updateEstimate).toHaveBeenCalledWith(manualEstimate);
+      });
+
+      it('should clear a parsed estimate when its short syntax is removed', async () => {
+        const parsedEstimate = 30 * 60 * 1000;
+        mockStateService.state.and.returnValue({
+          projectId: mockDefaultProject.id,
+          tagIds: [],
+          tagIdsFromTxt: [],
+          newTagTitles: [],
+          date: null,
+          time: null,
+          spent: null,
+          estimate: null,
+          cleanText: null,
+          remindOption: null,
+          attachments: [],
+          repeatQuickSetting: null,
+        });
+
+        await service.parseAndUpdateText(
+          'Simple task 30m',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+        );
+        expect(mockStateService.updateEstimate).toHaveBeenCalledWith(parsedEstimate);
+
+        mockStateService.updateEstimate.calls.reset();
+        mockStateService.state.and.returnValue({
+          projectId: mockDefaultProject.id,
+          tagIds: [],
+          tagIdsFromTxt: [],
+          newTagTitles: [],
+          date: null,
+          time: null,
+          spent: null,
+          estimate: parsedEstimate,
+          cleanText: 'Simple task',
+          remindOption: null,
+          attachments: [],
+          repeatQuickSetting: null,
+        });
+
+        await service.parseAndUpdateText(
+          'Simple task',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+        );
+
+        expect(mockStateService.updateEstimate).toHaveBeenCalledWith(null);
+      });
+
       it('should call updateSpent when parsing text', async () => {
         await service.parseAndUpdateText(
           'Task with potential time spent',

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -73,6 +73,8 @@ export class AddTaskBarParserService {
     if (!parseResult) {
       // No parse result means no short syntax found
       // Preserve current user-selected values instead of falling back to defaults
+      const isClearingParsedEstimate =
+        typeof this._previousParseResult?.timeEstimate === 'number';
 
       currentResult = {
         cleanText: text,
@@ -82,7 +84,7 @@ export class AddTaskBarParserService {
         tagIds: currentState.tagIdsFromTxt, // Preserve pre-selected tags
         newTagTitles: [],
         timeSpentOnDay: null,
-        timeEstimate: null,
+        timeEstimate: isClearingParsedEstimate ? null : currentState.estimate,
         // Preserve current date/time if user has selected them, otherwise use defaults
         dueDate: currentState.date || (defaultDate ? defaultDate : null),
         dueTime: currentState.time || defaultTime || null,


### PR DESCRIPTION
## Problem

Fixes #7188. Selecting a time estimate in the add-task bar before entering a title could be overwritten when the plain title text was parsed without short-syntax estimate data.

## Solution

Keep the current state estimate when parsing plain text unless the previous parser result provided an estimate that now needs to be cleared. Added parser specs for preserving a manually selected estimate and for clearing an estimate after removing short syntax.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Validation:
- `npm run checkFile src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts`
- `npm run checkFile src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts`
- `CHROME_BIN=/home/sarthak/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome npm run test:file -- src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts`