### PR TITLE
fix(add-task-bar): preserve time estimate when typing task title

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -281,9 +281,9 @@ describe('AddTaskBarParserService', () => {
     });
 
     describe('Parsing Integration', () => {
-      it('should call updateEstimate when parsing text', async () => {
+      it('should call updateEstimate when text contains estimate syntax', async () => {
         await service.parseAndUpdateText(
-          'Task with potential time estimate',
+          'Task with estimate 30m',
           mockConfig,
           mockProjects,
           mockTags,
@@ -293,7 +293,7 @@ describe('AddTaskBarParserService', () => {
         expect(mockStateService.updateEstimate).toHaveBeenCalled();
       });
 
-      it('should handle null time estimates', async () => {
+      it('should not call updateEstimate for text without estimate on first parse', async () => {
         await service.parseAndUpdateText(
           'Simple task',
           mockConfig,
@@ -302,7 +302,24 @@ describe('AddTaskBarParserService', () => {
           mockDefaultProject,
         );
 
-        expect(mockStateService.updateEstimate).toHaveBeenCalledWith(null);
+        expect(mockStateService.updateEstimate).not.toHaveBeenCalled();
+      });
+
+      it('should not call updateEstimate when typing text without estimate syntax for the first time', async () => {
+        // Simulates: user sets estimate via dropdown, then types task title.
+        // The parser has no previous result (first parse after empty input).
+        // Since the parsed estimate is null and there's no previous result to
+        // diff against, updateEstimate should NOT be called to avoid wiping
+        // out the dropdown-set value.
+        await service.parseAndUpdateText(
+          'My new task',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+        );
+
+        expect(mockStateService.updateEstimate).not.toHaveBeenCalled();
       });
 
       it('should call updateSpent when parsing text', async () => {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -188,8 +188,9 @@ export class AddTaskBarParserService {
     }
 
     if (
-      !this._previousParseResult ||
-      this._previousParseResult.timeEstimate !== currentResult.timeEstimate
+      (!this._previousParseResult && currentResult.timeEstimate !== null) ||
+      (this._previousParseResult &&
+        this._previousParseResult.timeEstimate !== currentResult.timeEstimate)
     ) {
       this._stateService.updateEstimate(currentResult.timeEstimate);
     }


### PR DESCRIPTION
## Summary

Fixes #7188

When a time estimate was set via the dropdown before typing a task title, the first keystroke would reset the estimate to null. The parser's `updateEstimate` was called unconditionally on the first parse (when `_previousParseResult` was null), overwriting the dropdown value.

The fix skips calling `updateEstimate` on first parse when the text contains no estimate syntax, preserving externally set estimates while still parsing estimates from text input.

## Test plan

- [x] Added test: `should not call updateEstimate when typing text without estimate syntax for the first time`
- [x] Updated existing tests to match corrected behavior
- [x] All 8395 tests pass (Europe/Berlin TZ)
- [x] All 8381 tests pass (America/Los_Angeles TZ)
- [x] Lint passes