### PR TITLE
fix(add-task-bar): show web FAB after slide-up animation instead of full entrance duration

### DIFF
--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.html
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.html
@@ -1,6 +1,7 @@
 <nav
   class="mobile-bottom-nav"
   [class.entrance]="isEntrance()"
+  (animationend)="onEntranceAnimationEnd()"
 >
   <button
     mat-button
@@ -25,7 +26,7 @@
     mat-fab
     class="add-task-button"
     [class.smaller]="hasProjectBacklog()"
-    [class.hide-for-native]="isAndroid && isEntrance()"
+    [class.hide-for-native]="isEntranceAnimating()"
     color="primary"
     (click)="showAddTaskBar()"
   >

--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.html
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.html
@@ -1,7 +1,7 @@
 <nav
   class="mobile-bottom-nav"
   [class.entrance]="isEntrance()"
-  (animationend)="onEntranceAnimationEnd()"
+  (animationend)="onEntranceAnimationEnd($event)"
 >
   <button
     mat-button

--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
@@ -105,7 +105,7 @@
       height: 28px;
     }
 
-    // On Android, hide during entrance animation (native add-task button is visible).
+    // On Android, hide during the slide-up entrance animation.
     // var(--transition-standard) on .add-task-button already transitions opacity,
     // so removing the class fades in automatically.
     &.hide-for-native {

--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.ts
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.ts
@@ -64,20 +64,25 @@ export class MobileBottomNavComponent {
   private _entranceAnimationTimeout: ReturnType<typeof setTimeout> | undefined;
 
   constructor() {
-    effect(() => {
+    effect((onCleanup) => {
       if (this.isEntrance() && this.isAndroid) {
         this.isEntranceAnimating.set(true);
-        // Safety fallback: clear if animationend doesn't fire (prefers-reduced-motion)
+        // Safety fallback: clear if animationend doesn't fire
+        // (e.g. prefers-reduced-motion: reduce → animation: none).
+        // Timeout = 250ms delay + 400ms duration + 50ms buffer = 700ms
         this._entranceAnimationTimeout = setTimeout(() => {
           this.isEntranceAnimating.set(false);
         }, 700);
+        onCleanup(() => clearTimeout(this._entranceAnimationTimeout));
       }
     });
   }
 
-  onEntranceAnimationEnd(): void {
-    this.isEntranceAnimating.set(false);
-    clearTimeout(this._entranceAnimationTimeout);
+  onEntranceAnimationEnd(event: AnimationEvent): void {
+    if (event.animationName === 'slide-up-from-bottom') {
+      this.isEntranceAnimating.set(false);
+      clearTimeout(this._entranceAnimationTimeout);
+    }
   }
 
   readonly T = T;

--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.ts
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, inject, input, output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -47,6 +55,30 @@ export class MobileBottomNavComponent {
 
   isEntrance = input(false);
   readonly isAndroid = IS_ANDROID_NATIVE;
+
+  // Tracks whether the slide-up entrance animation is actively running.
+  // On Android, the web FAB is hidden only during this animation (not the full
+  // entrance duration) so that the button appears as soon as the nav settles —
+  // even if the native startup overlay was not shown (e.g. process-death recreation).
+  readonly isEntranceAnimating = signal(false);
+  private _entranceAnimationTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  constructor() {
+    effect(() => {
+      if (this.isEntrance() && this.isAndroid) {
+        this.isEntranceAnimating.set(true);
+        // Safety fallback: clear if animationend doesn't fire (prefers-reduced-motion)
+        this._entranceAnimationTimeout = setTimeout(() => {
+          this.isEntranceAnimating.set(false);
+        }, 700);
+      }
+    });
+  }
+
+  onEntranceAnimationEnd(): void {
+    this.isEntranceAnimating.set(false);
+    clearTimeout(this._entranceAnimationTimeout);
+  }
 
   readonly T = T;
   readonly TODAY_TAG = TODAY_TAG;


### PR DESCRIPTION
On Android process-death recreation, the native startup overlay may not
be shown while the web FAB was hidden for the full 1500ms entrance
duration, leaving no add-task button visible. Decouple the FAB hiding
from isAppEntrance and instead tie it to the actual slide-up animation
(~650ms) using animationend, with a 700ms safety timeout for
prefers-reduced-motion.

https://claude.ai/code/session_01URndXtakxCN5tXWoUqWQQb