### PR TITLE
fix(sync): build @sp/shared-schema before running server tests

### DIFF
--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/src/index.js",
     "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
-    "pretest": "prisma generate",
+    "pretest": "npm run build --workspace=@sp/shared-schema && prisma generate",
     "test": "vitest run",
     "docker:build": "./scripts/build-and-push.sh",
     "docker:deploy": "./scripts/deploy.sh",


### PR DESCRIPTION
The super-sync-server pretest script only ran `prisma generate` but
didn't build the @sp/shared-schema workspace dependency. This caused
15 test suites (and 20+ individual tests) to fail with "Failed to
resolve entry for package @sp/shared-schema" because the dist/ output
didn't exist.

https://claude.ai/code/session_01EsRx9RENAEdsNUqMQZqjGN