### PR TITLE
fix(search): prevent overlapping search results on narrow screens

### DIFF
--- a/src/app/pages/search-page/search-page.component.scss
+++ b/src/app/pages/search-page/search-page.component.scss
@@ -22,6 +22,15 @@
 
     mat-list-item {
       cursor: pointer !important;
+      height: auto !important;
+      min-height: var(--s6);
+
+      &::ng-deep .mdc-list-item {
+        height: auto !important;
+        min-height: var(--s6);
+        padding-top: var(--s);
+        padding-bottom: var(--s);
+      }
 
       &:hover {
         background-color: rgba(0, 0, 0, 0.04) !important;


### PR DESCRIPTION
## Summary

- Override `mat-list-item` fixed height with `height: auto` and `min-height: var(--s6)` so items expand to fit wrapped content on narrow viewports
- Add vertical padding `var(--s)` on the inner `.mdc-list-item` so wrapped content doesn't touch item edges

## Why

Angular Material's `mat-list-item` applies a fixed `height: 48px` via `.mdc-list-item--with-one-line`. On narrow screens (e.g., Android), search result content wraps due to `flex-wrap: wrap` in `.task-info`, but the container stays at 48px, causing results to overlap.

## Verification

- Production build passes
- All 8,406 unit tests pass (including TZ variants)
- Linting (TypeScript + SCSS) passes
- Uses CSS variables per the project's styling guide

Fixes #7223