### PR TITLE
fix(calendar): schedule tasks created from plugin calendar events with start time

### DIFF
--- a/src/app/features/calendar-integration/calendar-integration.model.ts
+++ b/src/app/features/calendar-integration/calendar-integration.model.ts
@@ -25,4 +25,10 @@ export interface CalendarIntegrationEvent {
    * Used to determine if event supports CRUD operations (plugin providers) vs read-only (iCal).
    */
   issueProviderKey: string;
+  /**
+   * Precise due-with-time timestamp (ms). When set, the task created from this event
+   * will be scheduled at this time instead of just being assigned a due day.
+   * For plugin calendar events, this is passed through from PluginSearchResult.dueWithTime.
+   */
+  dueWithTime?: number;
 }

--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -227,6 +227,7 @@ export class CalendarIntegrationService {
         duration: r.duration ?? 0,
         isAllDay: r.isAllDay,
         issueProviderKey: pluginProvider.issueProviderKey,
+        dueWithTime: r.dueWithTime,
       }));
   }
 


### PR DESCRIPTION
When creating a task from a Google Calendar plugin event with a specific
start time, dueWithTime was dropped during the PluginSearchResult to
CalendarIntegrationEvent conversion, causing the task to be added with
dueDay instead of being scheduled via addAndSchedule().

https://claude.ai/code/session_01KRGjzZan7EYsgnXW4Rr1AA