### PR TITLE
fix(reminder): restore Android alarms after app update

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -147,6 +147,9 @@
       <intent-filter>
         <action android:name="android.intent.action.BOOT_COMPLETED" />
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+      </intent-filter>
     </receiver>
 
   </application>

--- a/android/app/src/main/java/com/superproductivity/superproductivity/receiver/BootReceiver.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/receiver/BootReceiver.kt
@@ -10,9 +10,11 @@ import com.superproductivity.superproductivity.service.ReminderNotificationHelpe
 import com.superproductivity.superproductivity.service.SyncReminderScheduler
 
 /**
- * Re-registers all saved alarms after device reboot.
- * Android clears all AlarmManager alarms on restart, so this receiver
- * reads persisted alarm data and re-schedules them.
+ * Re-registers all saved alarms after device reboot or app update.
+ * Android clears all AlarmManager alarms on both events, so this receiver
+ * reads persisted alarm data and re-schedules them. Without the app-update
+ * path, reminders would silently stop firing after a Play Store auto-update
+ * until the user next opens the app.
  */
 class BootReceiver : BroadcastReceiver() {
 
@@ -21,9 +23,11 @@ class BootReceiver : BroadcastReceiver() {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        val action = intent.action
+        if (action != Intent.ACTION_BOOT_COMPLETED &&
+            action != Intent.ACTION_MY_PACKAGE_REPLACED) return
 
-        Log.d(TAG, "Boot completed, re-registering alarms")
+        Log.d(TAG, "Received $action, re-registering alarms")
 
         val alarms = ReminderAlarmStore.getAll(context)
         if (alarms.isEmpty()) {


### PR DESCRIPTION
Android clears all AlarmManager alarms (and may cancel WorkManager jobs)
whenever the app's APK is replaced — i.e. on every Play Store auto-update
or manual reinstall. BootReceiver already knows how to re-register
everything from ReminderAlarmStore and re-enqueue SyncReminderWorker, but
its intent-filter only listened for BOOT_COMPLETED, so after an update
reminders stayed silently unregistered until the user next opened the app.

Add MY_PACKAGE_REPLACED to the manifest and broaden the receiver's action
guard so alarm restoration runs on both events. No new permissions or
helpers required — MY_PACKAGE_REPLACED is a protected broadcast delivered
only by the system to the owning app.

Refs #6832